### PR TITLE
feat: error-only mode

### DIFF
--- a/assets/ui/FuzzPanelMain.js
+++ b/assets/ui/FuzzPanelMain.js
@@ -1069,12 +1069,21 @@ function handleFuzzStart(e) {
   const disableArr = [e.currentTarget]; // List of controls to disable while fuzzer is busy
   const fuzzBase = "fuzz"; // Base html id name
 
-  // Process fuzzer options
-  ["suiteTimeout", "maxTests", "fnTimeout"].forEach((e) => {
+  // Process integer fuzzer options
+  ["suiteTimeout", "maxTests", "fnTimeout", "maxFailures"].forEach((e) => {
     const item = document.getElementById(fuzzBase + "-" + e);
     if (item !== null) {
       disableArr.push(item);
       overrides.fuzzer[e] = parseInt(item.getAttribute("current-value"));
+    }
+  });
+
+  // Process boolean fuzzer options
+  ["onlyFailures"].forEach((e) => {
+    const item = document.getElementById(fuzzBase + "-" + e);
+    if (item !== null) {
+      disableArr.push(item);
+      overrides.fuzzer[e] = item.getAttribute("value") === "true";
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -84,6 +84,13 @@
           "minimum": 1,
           "description": "Maximum number of tests the fuzzer should run before stopping."
         },
+        "nanofuzz.fuzzer.maxFailures": {
+          "title": "Maximum number of failures (0=no limit)",
+          "type": "integer",
+          "default": 0,
+          "minimum": 0,
+          "description": "Maximum number of failed tests the fuzzer should run before stopping."
+        },
         "nanofuzz.fuzzer.suiteTimeout": {
           "title": "Maximum time to run the fuzzer (ms)",
           "type": "integer",
@@ -97,6 +104,12 @@
           "default": 100,
           "minimum": 0,
           "description": "Maximum time (in ms) to allow a test function to run before making it as a timeout."
+        },
+        "nanofuzz.fuzzer.onlyFailures": {
+          "title": "Report only test failures?",
+          "type": "boolean",
+          "default": false,
+          "description": "Report only failing tests?"
         },
         "nanofuzz.argdef.strCharset": {
           "title": "String character set",

--- a/src/fuzzer/Fuzzer.test.ts
+++ b/src/fuzzer/Fuzzer.test.ts
@@ -10,6 +10,8 @@ const intOptions: FuzzOptions = {
   fnTimeout: 100,
   suiteTimeout: 3000,
   seed: "qwertyuiop",
+  maxFailures: 0,
+  onlyFailures: false,
 };
 
 /**
@@ -18,6 +20,15 @@ const intOptions: FuzzOptions = {
 const floatOptions: FuzzOptions = {
   ...intOptions,
   argDefaults: ArgDef.getDefaultFloatOptions(),
+};
+
+/**
+ * Fuzzer options for counter-example mode
+ */
+const counterExampleOptions: FuzzOptions = {
+  ...intOptions,
+  maxFailures: 1,
+  onlyFailures: true,
 };
 
 /**
@@ -297,5 +308,15 @@ describe("Fuzzer", () => {
       await fuzz(setup(intOptions, "nanofuzz-study/examples/14.ts", "modInv"))
     ).results;
     expect(results.length).not.toStrictEqual(0);
+  });
+
+  test("Counter-example mode 01", async () => {
+    const results = (
+      await fuzz(
+        setup(counterExampleOptions, "nanofuzz-study/examples/14.ts", "modInv")
+      )
+    ).results;
+    expect(results.length).toStrictEqual(1);
+    expect(results[0].category).not.toStrictEqual("ok");
   });
 });

--- a/src/fuzzer/Types.ts
+++ b/src/fuzzer/Types.ts
@@ -79,6 +79,8 @@ export type FuzzOptions = {
   argDefaults: ArgOptions; // default options for arguments
   seed?: string; // optional seed for pseudo-random number generator
   maxTests: number; // number of fuzzing tests to execute (>= 0)
+  maxFailures: number; // maximum number of failures to report (>=0)
+  onlyFailures: boolean; // only report tests that do not pass
   fnTimeout: number; // timeout threshold in ms per test
   suiteTimeout: number; // timeout for the entire test suite
 };


### PR DESCRIPTION
This PR adds a new "error only" mode to NaNofuzz, which only reports failed tests. Passed tests are not reported.

This mode may be turned on using the `more options` panel, and you may tell the fuzzer to stop after a specific number of failed tests. This mode allows NaNofuzz to approximate the behavior of some other property-based testing tools that may only report a single failing counter-example. 