### PR TITLE
feat: explain stop reason

### DIFF
--- a/assets/ui/FuzzPanelMain.css
+++ b/assets/ui/FuzzPanelMain.css
@@ -127,7 +127,7 @@ tr.classErrorExpectedOutputRow td div.slightFade {
 }
 .tooltip-top .tooltiptext {
   visibility: hidden;
-  width: 160px;
+  width: 190px;
   background-color: var(--vscode-panel-background);
   text-align: center;
   border-width: 1px;
@@ -139,7 +139,7 @@ tr.classErrorExpectedOutputRow td div.slightFade {
   z-index: 1;
   bottom: 100%;
   left: 50%;
-  margin-left: -85px;
+  margin-left: -100px;
   margin-bottom: 6px;
 }
 .tooltiptext-small {
@@ -181,4 +181,9 @@ tr.classErrorExpectedOutputRow td div.slightFade {
 /* Stop conditions */
 .fuzzStopReason {
   opacity: 50%;
+}
+
+/* Narrow tab strip column gaps */
+div.fuzzResults > vscode-panels::part(tablist) {
+  column-gap: calc(var(--design-unit) * 4px);
 }

--- a/assets/ui/FuzzPanelMain.css
+++ b/assets/ui/FuzzPanelMain.css
@@ -177,3 +177,8 @@ tr.classErrorExpectedOutputRow td div.slightFade {
   padding-left: 0.25ch;
   position: absolute;
 }
+
+/* Stop conditions */
+.fuzzStopReason {
+  opacity: 50%;
+}

--- a/src/fuzzer/Types.ts
+++ b/src/fuzzer/Types.ts
@@ -70,6 +70,7 @@ export enum FuzzResultCategory {
   DISAGREE = "disagree",
   FAILURE = "failure", // Validator failure (e.g., threw an exception)
 }
+
 /**
  * Fuzzer Options that specify the fuzzing behavior
  */
@@ -120,3 +121,14 @@ export type FuzzArgOverride = {
     dimLength: { min: number; max: number }[];
   };
 };
+
+/**
+ * Reason the fuzzer stopped
+ */
+export enum FuzzStopReason {
+  CRASH = "crash",
+  MAXTESTS = "maxTests",
+  MAXFAILURES = "maxFailures",
+  MAXTIME = "maxTime",
+  MAXDUPES = "maxDupes",
+}

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -916,12 +916,12 @@ export function ${validatorPrefix}${
               </vscode-radio-group>
             </div>
 
-            <p>Choose to return all test results or only the failed ones.</p>
+            <p>Choose to report all test results or only the failed ones.</p>
             <vscode-radio-group id="fuzz-onlyFailures">
               <vscode-radio ${disabledFlag} id="onlyFailures.false" name="onlyFailures.false" value="false" ${
-                !this._fuzzEnv.options.onlyFailures ? "checked" : ""}>Return all test results</vscode-radio>
+                !this._fuzzEnv.options.onlyFailures ? "checked" : ""}>Report all test results</vscode-radio>
               <vscode-radio ${disabledFlag} id="onlyFailures.true" name="onlyFailures.true" value="true" ${
-                this._fuzzEnv.options.onlyFailures ? "checked" : ""}>Return only failed test results</vscode-radio>
+                this._fuzzEnv.options.onlyFailures ? "checked" : ""}>Report only failed test results</vscode-radio>
             </vscode-radio-group>
           
             <p>These settings control how long testing runs. Testing stops when any limit is reached.  Pinned tests count against the maximum runtime and failures but do not count against the maximum number of tests.</p>
@@ -945,10 +945,10 @@ export function ${validatorPrefix}${
 
           <!-- Button Bar -->
           <div style="padding-top: .25em;">
-            <vscode-button ${disabledFlag} id="fuzz.start">
+            <vscode-button ${disabledFlag} id="fuzz.start" appearance="primary">
               ${this._state === FuzzPanelState.busy ? "Testing..." : "Test"}
             </vscode-button>
-            <vscode-button ${disabledFlag} id="fuzz.options" appearance="secondary">
+            <vscode-button ${disabledFlag} id="fuzz.options" appearance="secondary" aria-label="Fuzzer Options">
               More options
             </vscode-button>
           </div>
@@ -969,7 +969,7 @@ export function ${validatorPrefix}${
               ? ""
               : /*html*/ `style="display:none;"`
           }>
-            <vscode-panels>`;
+            <vscode-panels class="fuzzTabStrip">`;
 
     // If we have results, render the output tabs to display the results.
     const tabs = [
@@ -979,84 +979,121 @@ export function ${validatorPrefix}${
         description: `For these inputs, the custom validator function (${
           this._fuzzEnv.validator ?? ""
         }) threw an exception. You should fix the bug in the validator and start the fuzzer again.`,
+        hasGrid: true,
       },
       {
         id: "disagree",
         name: "Disagree",
         description: `For these inputs, the validator function (<span class="codicon codicon-hubot"></span>) and the manual validation (<span class="codicon codicon-person"></span>) disagree about whether the output passes. Either correct the validation function or correct the manual validation.`,
+        hasGrid: true,
       },
       {
         id: "timeout",
         name: "Timeouts",
         description: `These inputs did not terminate within ${this._fuzzEnv.options.fnTimeout}ms, and no validator categorized them as passed.`,
+        hasGrid: true,
       },
       {
         id: "exception",
         name: "Exceptions",
         description: `These inputs resulted in a runtime exception, and no validator categorized them as passed.`,
+        hasGrid: true,
       },
       {
         id: "badValue",
         name: "Failed",
         description: `These inputs were categorized by a validator as failed. NaNofuzz by default categorizes outputs as incorrect that contain null, NaN, Infinity, or undefined if no other validator categorizes them as passed.`,
+        hasGrid: true,
       },
       {
         id: "ok",
         name: "Passed",
         description: `No validator categorized these outputs as failed, or a validator categorized them as passed.`,
+        hasGrid: true,
       },
     ];
+    if (this._results) {
+      const textReason = {
+        [fuzzer.FuzzStopReason.CRASH]: `because it crashed`,
+        [fuzzer.FuzzStopReason
+          .MAXTIME]: `when it exceeded the maximum time you configured (${this._results.env.options.suiteTimeout} ms) for it to run`,
+        [fuzzer.FuzzStopReason
+          .MAXFAILURES]: `when it found ${this._results.env.options.maxFailures} failing test(s), which is the maximum you configured`,
+        [fuzzer.FuzzStopReason
+          .MAXTESTS]: `when it ran ${this._results.env.options.maxTests} new test(s) (plus ${this._results.inputsSaved} saved test(s)), the maximum you configured`,
+        [fuzzer.FuzzStopReason
+          .MAXDUPES]: `because it was unlikely to generate more unique test inputs. Often this means the function's input space is small`,
+        "": `of an unknown reason`,
+      };
+      tabs.push({
+        id: "runInfo",
+        name: `<div class="codicon codicon-info"></div>`,
+        description: `NaNofuzz stopped testing ${
+          this._results.stopReason in textReason
+            ? textReason[this._results.stopReason]
+            : textReason[""]
+        }.<p>NaNofuzz ran for ${this._results.elapsedTime} ms, re-tested ${
+          this._results.inputsSaved
+        } saved input(s), generated ${
+          this._results.inputsGenerated
+        } new input(s) (${
+          this._results.dupesGenerated
+        } of which were duplicates NaNofuzz previously tested), and reported ${
+          this._results.results.length
+        } test result(s) before stopping.</p><p>NaNofuzz is configured to return ${
+          this._results.env.options.onlyFailures ? "only failed" : "all"
+        } test results.</p>`,
+        hasGrid: false,
+      });
+    }
     tabs.forEach((e) => {
-      if (resultSummary[e.id] > 0) {
+      if (!e.hasGrid || resultSummary[e.id] > 0) {
         // prettier-ignore
         html += /*html*/ `
               <vscode-panel-tab id="tab-${e.id}">
-                ${e.name}<vscode-badge appearance="secondary">${
+                ${e.name}`;
+        if (e.hasGrid) {
+          // prettier-ignore
+          html += /*html*/ `
+                <vscode-badge appearance="secondary">${
                   resultSummary[e.id]
-                }</vscode-badge>
+                }</vscode-badge>`;
+        }
+        // prettier-ignore
+        html += /*html*/ `
               </vscode-panel-tab>`;
       }
     });
 
     tabs.forEach((e) => {
-      if (resultSummary[e.id] > 0)
+      if (!e.hasGrid || resultSummary[e.id] > 0) {
         html += /*html*/ `
               <vscode-panel-view class="fuzzGridPanel" id="view-${e.id}">
                 <section>
-                <div style="margin-bottom:.25em;margin-top:.25em;">${e.description}</div>
-                <div id="fuzzResultsGrid-${e.id}">
+                  <div style="margin-bottom:.25em;margin-top:.25em;">${e.description}</div>`;
+        if (e.hasGrid) {
+          // prettier-ignore
+          html += /*html*/ `
+                  <div id="fuzzResultsGrid-${e.id}">
                     <table class="fuzzGrid">
                       <thead class="columnSortOrder" id="fuzzResultsGrid-${e.id}-thead" /> 
                       <tbody id="fuzzResultsGrid-${e.id}-tbody" />
                     </table>
-                  </div>
+                  </div>`;
+        }
+        // prettier-ignore
+        html += /*html*/ `
                 </section>
               </vscode-panel-view>`;
+      }
     });
+
+    // prettier-ignore
     html += /*html*/ `
             </vscode-panels>
           </div>`;
 
-    if (this._results) {
-      const textReason = {
-        [fuzzer.FuzzStopReason.CRASH]: `because it crashed`,
-        [fuzzer.FuzzStopReason
-          .MAXTIME]: `when it ran for the maximum time you configured (${this._results.env.options.suiteTimeout} ms)`,
-        [fuzzer.FuzzStopReason
-          .MAXFAILURES]: `when it found ${this._results.env.options.maxFailures} failing test(s), the maximum you configured`,
-        [fuzzer.FuzzStopReason
-          .MAXTESTS]: `when it ran ${this._results.env.options.maxTests} test(s), the maximum you configured`,
-        [fuzzer.FuzzStopReason
-          .MAXDUPES]: `because it was unlikely to generate more unique test inputs. Often this means the function's input space is small`,
-        "": `of an unknown reason`,
-      };
-      // prettier-ignore
-      html += /*html*/ `
-          <!-- Fuzzer Stop Criteria -->
-          <vscode-divider></vscode-divider>
-          <div class="fuzzStopReason">NaNofuzz stopped ${this._results.stopReason in textReason ? textReason[this._results.stopReason] : textReason[""]}.</span>`;
-    }
-
+    // Hidden data for the client script to process
     html += /*html*/ `
           <!-- Fuzzer Result Payload: for the client script to process -->
           <div id="fuzzResultsData" style="display:none">

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -926,7 +926,7 @@ export function ${validatorPrefix}${
           
             <p>These settings control how long testing runs. Testing stops when any limit is reached.  Pinned tests count against the maximum runtime and failures but do not count against the maximum number of tests.</p>
             <vscode-text-field ${disabledFlag} size="3" id="fuzz-suiteTimeout" name="fuzz-suiteTimeout" value="${this._fuzzEnv.options.suiteTimeout}">
-              Max total runtime (ms)
+              Max runtime (ms)
             </vscode-text-field>
             <vscode-text-field ${disabledFlag} size="3" id="fuzz-maxTests" name="fuzz-maxTests" value="${this._fuzzEnv.options.maxTests}">
               Max number of tests
@@ -1035,8 +1035,29 @@ export function ${validatorPrefix}${
     });
     html += /*html*/ `
             </vscode-panels>
-          </div>
+          </div>`;
 
+    if (this._results) {
+      const textReason = {
+        [fuzzer.FuzzStopReason.CRASH]: `because it crashed`,
+        [fuzzer.FuzzStopReason
+          .MAXTIME]: `when it ran for the maximum time you configured (${this._results.env.options.suiteTimeout} ms)`,
+        [fuzzer.FuzzStopReason
+          .MAXFAILURES]: `when it found ${this._results.env.options.maxFailures} failing test(s), the maximum you configured`,
+        [fuzzer.FuzzStopReason
+          .MAXTESTS]: `when it ran ${this._results.env.options.maxTests} test(s), the maximum you configured`,
+        [fuzzer.FuzzStopReason
+          .MAXDUPES]: `because it was unlikely to generate more unique test inputs. Often this means the function's input space is small`,
+        "": `of an unknown reason`,
+      };
+      // prettier-ignore
+      html += /*html*/ `
+          <!-- Fuzzer Stop Criteria -->
+          <vscode-divider></vscode-divider>
+          <div class="fuzzStopReason">NaNofuzz stopped ${this._results.stopReason in textReason ? textReason[this._results.stopReason] : textReason[""]}.</span>`;
+    }
+
+    html += /*html*/ `
           <!-- Fuzzer Result Payload: for the client script to process -->
           <div id="fuzzResultsData" style="display:none">
             ${


### PR DESCRIPTION
This PR adds a new informational tab to the results grid that explains why NaNofuzz stopped testing and provides some basic information about the tests it ran.