### PR TITLE
fix: resolve #111

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "sourceMap": true,
     "allowJs": true,
     "moduleResolution": "node",
-    "rootDirs": ["src", "packages/runtime/src"],
+    "rootDirs": ["src"],
     "forceConsistentCasingInFileNames": true,
     "noImplicitThis": true,
     "noImplicitAny": true,
@@ -53,11 +53,7 @@
     "placeOpenBraceOnNewLineForFunctions": false,
     "placeOpenBraceOnNewLineForControlBlocks": false
   },
-  "include": [
-    "src",
-    "assets/FuzzPanelMain.js",
-    "packages/runtime/src/index.ts"
-  ],
+  "include": ["src", "assets/FuzzPanelMain.js"],
   "exclude": [
     "node_modules",
     "build",
@@ -77,8 +73,7 @@
       "**/*.test.ts",
       "**/*.test.tsx",
       "**/*__*/**",
-      "**/node_modules/**",
-      "packages/runtime/src"
+      "**/node_modules/**"
     ]
   }
 }


### PR DESCRIPTION
Eliminates the need to build the `runtime` npm package prior to building the extension.