### PR TITLE
fix: heuristic oracle should expect `undefined` for `void` functions

### DIFF
--- a/assets/ui/FuzzPanelMain.js
+++ b/assets/ui/FuzzPanelMain.js
@@ -270,11 +270,14 @@ function main() {
             // noop (hidden)
           } else if (k === implicitLabel) {
             if (resultsData.env.options.useImplicit) {
+              const heuristicValidatorDescription =
+                document.getElementById("fuzz-useImplicit").children[0]
+                  .ariaLabel;
               const cell = hRow.appendChild(document.createElement("th"));
               cell.id = type + "-" + implicitLabel;
               cell.classList.add("colorColumn", "clickable");
               cell.innerHTML = /* html */ `
-              <span class="tooltipped tooltipped-nw" aria-label="Heuristic validator. Fails: timeout, exception, null, undefined, Infinity, NaN">
+              <span class="tooltipped tooltipped-nw" aria-label="${heuristicValidatorDescription}">
                 <span class="codicon codicon-debug"></span>
               </span>`;
               cell.addEventListener("click", () => {

--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -231,21 +231,19 @@ export const fuzz = async (
 
     // IMPLICIT ORACLE --------------------------------------------
     // How can it fail ... let us count the ways...
-    // TODO Add suppport for multiple validators !!!
-    if (
-      // Check for exceptions and timeouts
-      env.options.useImplicit &&
-      (result.exception || result.timeout)
-    ) {
-      result.passedImplicit = false;
-    }
-    if (
-      // Check implicit oracle if function is not void
-      env.options.useImplicit &&
-      !env.function.isVoid() &&
-      result.output.some((e) => !implicitOracle(e))
-    ) {
-      result.passedImplicit = false;
+    if (env.options.useImplicit) {
+      if (result.exception || result.timeout) {
+        // Exceptions and timeouts fail the implicit oracle
+        result.passedImplicit = false;
+      } else if (env.function.isVoid()) {
+        // Functions with a void return type should only return undefined
+        result.passedImplicit = !result.output.some(
+          (e) => e.value !== undefined
+        );
+      } else {
+        // Non-void functions should not contain disallowed values
+        result.passedImplicit = !result.output.some((e) => !implicitOracle(e));
+      }
     }
 
     // HUMAN ORACLE -----------------------------------------------

--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -232,10 +232,17 @@ export const fuzz = async (
     // How can it fail ... let us count the ways...
     // TODO Add suppport for multiple validators !!!
     if (
+      // Check for exceptions and timeouts
       env.options.useImplicit &&
-      (result.exception ||
-        result.timeout ||
-        result.output.some((e) => !implicitOracle(e)))
+      (result.exception || result.timeout)
+    ) {
+      result.passedImplicit = false;
+    }
+    if (
+      // Check implicit oracle if function is not void
+      env.options.useImplicit &&
+      !env.function.isVoid() &&
+      result.output.some((e) => !implicitOracle(e))
     ) {
       result.passedImplicit = false;
     }

--- a/src/fuzzer/Types.ts
+++ b/src/fuzzer/Types.ts
@@ -47,6 +47,7 @@ export type FuzzTestsFunction = {
   sortColumns?: FuzzSortColumns; // column sort order
   validators: string[]; // validator functions
   tests: Record<string, FuzzPinnedTest>; // pinned tests
+  isVoid: boolean; // is the function return type void?
 };
 
 /**

--- a/src/fuzzer/analysis/typescript/FunctionDef.test.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.test.ts
@@ -307,33 +307,45 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
     });
   });
 
-  // Checking whether functions are void
-  const srcVoid = `export function noReturnF3() {return () => {return 1;}}
-  export const noReturnA3 = () => {return () => {return 1;}}
-  export function noReturnF1() {const z2 = [1,2,3].map((z) => {return z*z;});}
-  export function f1() {return 1;}`;
-  const thisProgramVoid = dummyProgram.setSrc(() => srcVoid);
-
-  test("findFnInSource: check void", () => {
+  test("findFnInSource: void, standard fn def", () => {
+    const src = `
+    export function returnF1() {return;}
+    export function returnF2() {return 1;}
+    export function returnF3() {return () => {return 1;}}
+    export function noReturnF1() {const x = 2;}
+    export function noReturnF2() {const z2 = [1,2,3].map((z) => {return z*z;});}
+    export function noReturnF3() {const x = () => {return 1;}}
+    `;
+    const thisProgram = dummyProgram.setSrc(() => src);
     expect(
-      Object.values(thisProgramVoid.getFunctions()).map((e) => e.getRef())
+      Object.values(thisProgram.getFunctions()).map((e) => e.getRef())
     ).toStrictEqual([
       {
-        name: "noReturnF3",
+        name: "returnF1",
         module: "dummy.ts",
-        src: "function noReturnF3() {return () => {return 1;}}",
-        startOffset: 7,
-        endOffset: 55,
+        src: "function returnF1() {return;}",
+        startOffset: 12,
+        endOffset: 41,
         isExported: true,
         isVoid: false,
         args: [],
       },
       {
-        name: "noReturnA3",
+        name: "returnF2",
         module: "dummy.ts",
-        src: "const noReturnA3 = () => {return () => {return 1;}}",
-        startOffset: 71,
-        endOffset: 116,
+        src: "function returnF2() {return 1;}",
+        startOffset: 53,
+        endOffset: 84,
+        isExported: true,
+        isVoid: false,
+        args: [],
+      },
+      {
+        name: "returnF3",
+        module: "dummy.ts",
+        src: "function returnF3() {return () => {return 1;}}",
+        startOffset: 96,
+        endOffset: 142,
         isExported: true,
         isVoid: false,
         args: [],
@@ -341,21 +353,107 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
       {
         name: "noReturnF1",
         module: "dummy.ts",
-        src: "function noReturnF1() {const z2 = [1,2,3].map((z) => {return z*z;});}",
-        startOffset: 126,
-        endOffset: 195,
+        src: "function noReturnF1() {const x = 2;}",
+        startOffset: 154,
+        endOffset: 190,
         isExported: true,
         isVoid: true,
         args: [],
       },
       {
-        name: "f1",
+        name: "noReturnF2",
         module: "dummy.ts",
-        src: "function f1() {return 1;}",
-        startOffset: 205,
-        endOffset: 230,
+        src: "function noReturnF2() {const z2 = [1,2,3].map((z) => {return z*z;});}",
+        startOffset: 202,
+        endOffset: 271,
+        isExported: true,
+        isVoid: true,
+        args: [],
+      },
+      {
+        name: "noReturnF3",
+        module: "dummy.ts",
+        src: "function noReturnF3() {const x = () => {return 1;}}",
+        startOffset: 283,
+        endOffset: 334,
+        isExported: true,
+        isVoid: true,
+        args: [],
+      },
+    ]);
+  });
+
+  test("findFnInSource: void, arrow fn", () => {
+    const src = `
+    export const returnA1 = () => {return;}
+    export const returnA2 = () => {return 1;}
+    export const returnA3 = () => {return () => {return 1;}}
+    export const noReturnA1 = () => {const x = 2;}
+    export const noReturnA2 = () => {const z2 = [1,2,3].map((z) => {return z*z;});}
+    export const noReturnA3 = () => {const x = () => {return 1;}}
+    `;
+    const thisProgram = dummyProgram.setSrc(() => src);
+    expect(
+      Object.values(thisProgram.getFunctions()).map((e) => e.getRef())
+    ).toStrictEqual([
+      {
+        name: "returnA1",
+        module: "dummy.ts",
+        src: "const returnA1 = () => {return;}",
+        startOffset: 18,
+        endOffset: 44,
         isExported: true,
         isVoid: false,
+        args: [],
+      },
+      {
+        name: "returnA2",
+        module: "dummy.ts",
+        src: "const returnA2 = () => {return 1;}",
+        startOffset: 62,
+        endOffset: 90,
+        isExported: true,
+        isVoid: false,
+        args: [],
+      },
+      {
+        name: "returnA3",
+        module: "dummy.ts",
+        src: "const returnA3 = () => {return () => {return 1;}}",
+        startOffset: 108,
+        endOffset: 151,
+        isExported: true,
+        isVoid: false,
+        args: [],
+      },
+      {
+        name: "noReturnA1",
+        module: "dummy.ts",
+        src: "const noReturnA1 = () => {const x = 2;}",
+        startOffset: 169,
+        endOffset: 202,
+        isExported: true,
+        isVoid: true,
+        args: [],
+      },
+      {
+        name: "noReturnA2",
+        module: "dummy.ts",
+        src: "const noReturnA2 = () => {const z2 = [1,2,3].map((z) => {return z*z;});}",
+        startOffset: 220,
+        endOffset: 286,
+        isExported: true,
+        isVoid: true,
+        args: [],
+      },
+      {
+        name: "noReturnA3",
+        module: "dummy.ts",
+        src: "const noReturnA3 = () => {const x = () => {return 1;}}",
+        startOffset: 304,
+        endOffset: 352,
+        isExported: true,
+        isVoid: true,
         args: [],
       },
     ]);

--- a/src/fuzzer/analysis/typescript/FunctionDef.test.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.test.ts
@@ -236,7 +236,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         startOffset: 99,
         endOffset: 170,
         isExported: true,
-        isVoid: true,
+        isVoid: false,
         args: [],
         returnType: undefined,
       },
@@ -346,9 +346,9 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
     export function returnF1() {return;}
     export function returnF2() {return 1;}
     export function returnF3() {return () => {return 1;}}
-    export function noReturnF1() {const x = 2;}
-    export function noReturnF2() {const z2 = [1,2,3].map((z) => {return z*z;});}
-    export function noReturnF3() {const x = () => {return 1;}}
+    export function noReturnF1():void {const x = 2;}
+    export function noReturnF2():void {const z2 = [1,2,3].map((z) => {return z*z;});}
+    export function noReturnF3():void {const x = () => {return 1;}}
     `;
     const thisProgram = dummyProgram.setSrc(() => src);
     expect(
@@ -363,6 +363,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         isExported: true,
         isVoid: false,
         args: [],
+        returnType: undefined,
       },
       {
         name: "returnF2",
@@ -373,6 +374,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         isExported: true,
         isVoid: false,
         args: [],
+        returnType: undefined,
       },
       {
         name: "returnF3",
@@ -383,36 +385,40 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         isExported: true,
         isVoid: false,
         args: [],
+        returnType: undefined,
       },
       {
         name: "noReturnF1",
         module: "dummy.ts",
-        src: "function noReturnF1() {const x = 2;}",
+        src: "function noReturnF1():void {const x = 2;}",
         startOffset: 154,
-        endOffset: 190,
+        endOffset: 195,
         isExported: true,
         isVoid: true,
         args: [],
+        returnType: undefined,
       },
       {
         name: "noReturnF2",
         module: "dummy.ts",
-        src: "function noReturnF2() {const z2 = [1,2,3].map((z) => {return z*z;});}",
-        startOffset: 202,
-        endOffset: 271,
+        src: "function noReturnF2():void {const z2 = [1,2,3].map((z) => {return z*z;});}",
+        startOffset: 207,
+        endOffset: 281,
         isExported: true,
         isVoid: true,
         args: [],
+        returnType: undefined,
       },
       {
         name: "noReturnF3",
         module: "dummy.ts",
-        src: "function noReturnF3() {const x = () => {return 1;}}",
-        startOffset: 283,
-        endOffset: 334,
+        src: "function noReturnF3():void {const x = () => {return 1;}}",
+        startOffset: 293,
+        endOffset: 349,
         isExported: true,
         isVoid: true,
         args: [],
+        returnType: undefined,
       },
     ]);
   });
@@ -422,9 +428,9 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
     export const returnA1 = () => {return;}
     export const returnA2 = () => {return 1;}
     export const returnA3 = () => {return () => {return 1;}}
-    export const noReturnA1 = () => {const x = 2;}
-    export const noReturnA2 = () => {const z2 = [1,2,3].map((z) => {return z*z;});}
-    export const noReturnA3 = () => {const x = () => {return 1;}}
+    export const noReturnA1 = ():void => {const x = 2;}
+    export const noReturnA2 = ():void => {const z2 = [1,2,3].map((z) => {return z*z;});}
+    export const noReturnA3 = ():void => {const x = () => {return 1;}}
     `;
     const thisProgram = dummyProgram.setSrc(() => src);
     expect(
@@ -439,6 +445,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         isExported: true,
         isVoid: false,
         args: [],
+        returnType: undefined,
       },
       {
         name: "returnA2",
@@ -449,6 +456,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         isExported: true,
         isVoid: false,
         args: [],
+        returnType: undefined,
       },
       {
         name: "returnA3",
@@ -459,36 +467,40 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         isExported: true,
         isVoid: false,
         args: [],
+        returnType: undefined,
       },
       {
         name: "noReturnA1",
         module: "dummy.ts",
-        src: "const noReturnA1 = () => {const x = 2;}",
+        src: "const noReturnA1 = ():void => {const x = 2;}",
         startOffset: 169,
-        endOffset: 202,
+        endOffset: 207,
         isExported: true,
         isVoid: true,
         args: [],
+        returnType: undefined,
       },
       {
         name: "noReturnA2",
         module: "dummy.ts",
-        src: "const noReturnA2 = () => {const z2 = [1,2,3].map((z) => {return z*z;});}",
-        startOffset: 220,
-        endOffset: 286,
+        src: "const noReturnA2 = ():void => {const z2 = [1,2,3].map((z) => {return z*z;});}",
+        startOffset: 225,
+        endOffset: 296,
         isExported: true,
         isVoid: true,
         args: [],
+        returnType: undefined,
       },
       {
         name: "noReturnA3",
         module: "dummy.ts",
-        src: "const noReturnA3 = () => {const x = () => {return 1;}}",
-        startOffset: 304,
-        endOffset: 352,
+        src: "const noReturnA3 = ():void => {const x = () => {return 1;}}",
+        startOffset: 314,
+        endOffset: 367,
         isExported: true,
         isVoid: true,
         args: [],
+        returnType: undefined,
       },
     ]);
   });
@@ -514,6 +526,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         isExported: true,
         isVoid: false,
         args: [],
+        returnType: undefined,
       },
       {
         name: "returnForIn",
@@ -524,6 +537,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         isExported: true,
         isVoid: false,
         args: [],
+        returnType: undefined,
       },
       {
         name: "returnFor",
@@ -534,6 +548,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         isExported: true,
         isVoid: false,
         args: [],
+        returnType: undefined,
       },
       {
         name: "returnForOf",
@@ -544,6 +559,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         isExported: true,
         isVoid: false,
         args: [],
+        returnType: undefined,
       },
       {
         name: "returnDoWhile",
@@ -554,6 +570,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         isExported: true,
         isVoid: false,
         args: [],
+        returnType: undefined,
       },
     ]);
   });
@@ -579,6 +596,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         isExported: true,
         isVoid: false,
         args: [],
+        returnType: undefined,
       },
       {
         name: "returnSwitch",
@@ -589,6 +607,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         isExported: true,
         isVoid: false,
         args: [],
+        returnType: undefined,
       },
       {
         name: "returnTry",
@@ -599,6 +618,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         isExported: true,
         isVoid: false,
         args: [],
+        returnType: undefined,
       },
       {
         name: "returnThrow",
@@ -609,6 +629,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         isExported: true,
         isVoid: false,
         args: [],
+        returnType: undefined,
       },
       {
         name: "returnLabeled",
@@ -619,6 +640,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         isExported: true,
         isVoid: false,
         args: [],
+        returnType: undefined,
       },
     ]);
   });

--- a/src/fuzzer/analysis/typescript/FunctionDef.test.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.test.ts
@@ -344,7 +344,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
   test("findFnInSource: void, standard fn def", () => {
     const src = `
     export function returnF1() {return;}
-    export function returnF2() {return 1;}
+    export function returnF2():number {return 1;}
     export function returnF3() {return () => {return 1;}}
     export function noReturnF1():void {const x = 2;}
     export function noReturnF2():void {const z2 = [1,2,3].map((z) => {return z*z;});}
@@ -368,20 +368,30 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
       {
         name: "returnF2",
         module: "dummy.ts",
-        src: "function returnF2() {return 1;}",
+        src: "function returnF2():number {return 1;}",
         startOffset: 53,
-        endOffset: 84,
+        endOffset: 91,
         isExported: true,
         isVoid: false,
         args: [],
-        returnType: undefined,
+        returnType: {
+          dims: 0,
+          isExported: false,
+          module: "dummy.ts",
+          optional: false,
+          type: {
+            children: [],
+            resolved: true,
+            type: "number",
+          },
+        },
       },
       {
         name: "returnF3",
         module: "dummy.ts",
         src: "function returnF3() {return () => {return 1;}}",
-        startOffset: 96,
-        endOffset: 142,
+        startOffset: 103,
+        endOffset: 149,
         isExported: true,
         isVoid: false,
         args: [],
@@ -391,8 +401,8 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         name: "noReturnF1",
         module: "dummy.ts",
         src: "function noReturnF1():void {const x = 2;}",
-        startOffset: 154,
-        endOffset: 195,
+        startOffset: 161,
+        endOffset: 202,
         isExported: true,
         isVoid: true,
         args: [],
@@ -402,8 +412,8 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         name: "noReturnF2",
         module: "dummy.ts",
         src: "function noReturnF2():void {const z2 = [1,2,3].map((z) => {return z*z;});}",
-        startOffset: 207,
-        endOffset: 281,
+        startOffset: 214,
+        endOffset: 288,
         isExported: true,
         isVoid: true,
         args: [],
@@ -413,8 +423,8 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         name: "noReturnF3",
         module: "dummy.ts",
         src: "function noReturnF3():void {const x = () => {return 1;}}",
-        startOffset: 293,
-        endOffset: 349,
+        startOffset: 300,
+        endOffset: 356,
         isExported: true,
         isVoid: true,
         args: [],
@@ -426,7 +436,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
   test("findFnInSource: void, arrow fn", () => {
     const src = `
     export const returnA1 = () => {return;}
-    export const returnA2 = () => {return 1;}
+    export const returnA2 = ():number => {return 1;}
     export const returnA3 = () => {return () => {return 1;}}
     export const noReturnA1 = ():void => {const x = 2;}
     export const noReturnA2 = ():void => {const z2 = [1,2,3].map((z) => {return z*z;});}
@@ -450,20 +460,30 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
       {
         name: "returnA2",
         module: "dummy.ts",
-        src: "const returnA2 = () => {return 1;}",
+        src: "const returnA2 = ():number => {return 1;}",
         startOffset: 62,
-        endOffset: 90,
+        endOffset: 97,
         isExported: true,
         isVoid: false,
         args: [],
-        returnType: undefined,
+        returnType: {
+          dims: 0,
+          isExported: false,
+          module: "dummy.ts",
+          optional: false,
+          type: {
+            children: [],
+            resolved: true,
+            type: "number",
+          },
+        },
       },
       {
         name: "returnA3",
         module: "dummy.ts",
         src: "const returnA3 = () => {return () => {return 1;}}",
-        startOffset: 108,
-        endOffset: 151,
+        startOffset: 115,
+        endOffset: 158,
         isExported: true,
         isVoid: false,
         args: [],
@@ -473,8 +493,8 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         name: "noReturnA1",
         module: "dummy.ts",
         src: "const noReturnA1 = ():void => {const x = 2;}",
-        startOffset: 169,
-        endOffset: 207,
+        startOffset: 176,
+        endOffset: 214,
         isExported: true,
         isVoid: true,
         args: [],
@@ -484,8 +504,8 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         name: "noReturnA2",
         module: "dummy.ts",
         src: "const noReturnA2 = ():void => {const z2 = [1,2,3].map((z) => {return z*z;});}",
-        startOffset: 225,
-        endOffset: 296,
+        startOffset: 232,
+        endOffset: 303,
         isExported: true,
         isVoid: true,
         args: [],
@@ -495,8 +515,8 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         name: "noReturnA3",
         module: "dummy.ts",
         src: "const noReturnA3 = ():void => {const x = () => {return 1;}}",
-        startOffset: 314,
-        endOffset: 367,
+        startOffset: 321,
+        endOffset: 374,
         isExported: true,
         isVoid: true,
         args: [],

--- a/src/fuzzer/analysis/typescript/FunctionDef.test.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.test.ts
@@ -11,6 +11,7 @@ const dummyRef: FunctionRef = {
   startOffset: 0,
   endOffset: 999,
   isExported: true,
+  isVoid: false,
 };
 const dummyProgram: ProgramDef = ProgramDef.fromSource(
   () => "",

--- a/src/fuzzer/analysis/typescript/FunctionDef.test.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.test.ts
@@ -458,4 +458,134 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
       },
     ]);
   });
+
+  test("findFnInSource: void, loops", () => {
+    const src = `
+    export const returnWhile = () => {let x: number = 0; while (x < 10) {return Infinity;}}
+    export const returnForIn = () => {const arr: number[] = [1,2,3]; for (var idx in arr) {if (arr[idx] === 2) {return undefined;}} return 0;}
+    export const returnFor = () => {const z = undefined; for (let x =0; x<10; ++x) {if (x === 9) {return z;}} return 0;}
+    export const returnForOf = () => {const arr: number[] = [1,2,3]; for (const x of arr) {return NaN;}}
+    export const returnDoWhile = () => {const x = undefined; do {const y = 1; return x;} while (1 == 1)}
+    `;
+    const thisProgram = dummyProgram.setSrc(() => src);
+    expect(
+      Object.values(thisProgram.getFunctions()).map((e) => e.getRef())
+    ).toStrictEqual([
+      {
+        name: "returnWhile",
+        module: "dummy.ts",
+        src: "const returnWhile = () => {let x: number = 0; while (x < 10) {return Infinity;}}",
+        startOffset: 18,
+        endOffset: 92,
+        isExported: true,
+        isVoid: false,
+        args: [],
+      },
+      {
+        name: "returnForIn",
+        module: "dummy.ts",
+        src: "const returnForIn = () => {const arr: number[] = [1,2,3]; for (var idx in arr) {if (arr[idx] === 2) {return undefined;}} return 0;}",
+        startOffset: 110,
+        endOffset: 235,
+        isExported: true,
+        isVoid: false,
+        args: [],
+      },
+      {
+        name: "returnFor",
+        module: "dummy.ts",
+        src: "const returnFor = () => {const z = undefined; for (let x =0; x<10; ++x) {if (x === 9) {return z;}} return 0;}",
+        startOffset: 253,
+        endOffset: 356,
+        isExported: true,
+        isVoid: false,
+        args: [],
+      },
+      {
+        name: "returnForOf",
+        module: "dummy.ts",
+        src: "const returnForOf = () => {const arr: number[] = [1,2,3]; for (const x of arr) {return NaN;}}",
+        startOffset: 374,
+        endOffset: 461,
+        isExported: true,
+        isVoid: false,
+        args: [],
+      },
+      {
+        name: "returnDoWhile",
+        module: "dummy.ts",
+        src: "const returnDoWhile = () => {const x = undefined; do {const y = 1; return x;} while (1 == 1)}",
+        startOffset: 479,
+        endOffset: 566,
+        isExported: true,
+        isVoid: false,
+        args: [],
+      },
+    ]);
+  });
+
+  test("findFnInSource: void, other cases", () => {
+    const src = `
+    export const returnIf = () => {const x = undefined; if (x) {return x} else {return Infinity;}}
+    export const returnSwitch = () => {switch(1) {case 1: {return undefined;} default: {return undefined;}}}
+    export const returnTry = () => {try {return Infinity;} catch {return NaN;}}
+    export const returnThrow = () => {const x = undefined; if (!x) {throw Error();} else {throw Error();}}
+    export const returnLabeled = () => {const arr: number[] = []; loop1: for (let x=0; x<5; ++x) {if (x === 1) {continue loop1;} arr.push(x); if (x === 4) {return undefined;}} return 0;}
+    `;
+    const thisProgram = dummyProgram.setSrc(() => src);
+    expect(
+      Object.values(thisProgram.getFunctions()).map((e) => e.getRef())
+    ).toStrictEqual([
+      {
+        name: "returnIf",
+        module: "dummy.ts",
+        src: "const returnIf = () => {const x = undefined; if (x) {return x} else {return Infinity;}}",
+        startOffset: 18,
+        endOffset: 99,
+        isExported: true,
+        isVoid: false,
+        args: [],
+      },
+      {
+        name: "returnSwitch",
+        module: "dummy.ts",
+        src: "const returnSwitch = () => {switch(1) {case 1: {return undefined;} default: {return undefined;}}}",
+        startOffset: 117,
+        endOffset: 208,
+        isExported: true,
+        isVoid: false,
+        args: [],
+      },
+      {
+        name: "returnTry",
+        module: "dummy.ts",
+        src: "const returnTry = () => {try {return Infinity;} catch {return NaN;}}",
+        startOffset: 226,
+        endOffset: 288,
+        isExported: true,
+        isVoid: false,
+        args: [],
+      },
+      {
+        name: "returnThrow",
+        module: "dummy.ts",
+        src: "const returnThrow = () => {const x = undefined; if (!x) {throw Error();} else {throw Error();}}",
+        startOffset: 306,
+        endOffset: 395,
+        isExported: true,
+        isVoid: false,
+        args: [],
+      },
+      {
+        name: "returnLabeled",
+        module: "dummy.ts",
+        src: "const returnLabeled = () => {const arr: number[] = []; loop1: for (let x=0; x<5; ++x) {if (x === 1) {continue loop1;} arr.push(x); if (x === 4) {return undefined;}} return 0;}",
+        startOffset: 413,
+        endOffset: 582,
+        isExported: true,
+        isVoid: false,
+        args: [],
+      },
+    ]);
+  });
 });

--- a/src/fuzzer/analysis/typescript/FunctionDef.test.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.test.ts
@@ -202,6 +202,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         startOffset: 7,
         endOffset: 58,
         isExported: true,
+        isVoid: false,
         args: [
           {
             dims: 1,
@@ -224,6 +225,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         startOffset: 99,
         endOffset: 170,
         isExported: true,
+        isVoid: true,
         args: [],
       },
       /*
@@ -261,6 +263,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
       startOffset: 7,
       endOffset: 58,
       isExported: true,
+      isVoid: false,
       args: [
         {
           dims: 1,
@@ -286,6 +289,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
       startOffset: 7,
       endOffset: 58,
       isExported: true,
+      isVoid: false,
       args: [
         {
           dims: 1,
@@ -301,5 +305,59 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         },
       ],
     });
+  });
+
+  // Checking whether functions are void
+  const srcVoid = `export function noReturnF3() {return () => {return 1;}}
+  export const noReturnA3 = () => {return () => {return 1;}}
+  export function noReturnF1() {const z2 = [1,2,3].map((z) => {return z*z;});}
+  export function f1() {return 1;}`;
+  const thisProgramVoid = dummyProgram.setSrc(() => srcVoid);
+
+  test("findFnInSource: check void", () => {
+    expect(
+      Object.values(thisProgramVoid.getFunctions()).map((e) => e.getRef())
+    ).toStrictEqual([
+      {
+        name: "noReturnF3",
+        module: "dummy.ts",
+        src: "function noReturnF3() {return () => {return 1;}}",
+        startOffset: 7,
+        endOffset: 55,
+        isExported: true,
+        isVoid: false,
+        args: [],
+      },
+      {
+        name: "noReturnA3",
+        module: "dummy.ts",
+        src: "const noReturnA3 = () => {return () => {return 1;}}",
+        startOffset: 71,
+        endOffset: 116,
+        isExported: true,
+        isVoid: false,
+        args: [],
+      },
+      {
+        name: "noReturnF1",
+        module: "dummy.ts",
+        src: "function noReturnF1() {const z2 = [1,2,3].map((z) => {return z*z;});}",
+        startOffset: 126,
+        endOffset: 195,
+        isExported: true,
+        isVoid: true,
+        args: [],
+      },
+      {
+        name: "f1",
+        module: "dummy.ts",
+        src: "function f1() {return 1;}",
+        startOffset: 205,
+        endOffset: 230,
+        isExported: true,
+        isVoid: false,
+        args: [],
+      },
+    ]);
   });
 });

--- a/src/fuzzer/analysis/typescript/FunctionDef.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.ts
@@ -129,6 +129,15 @@ export class FunctionDef {
   } // fn: isExported()
 
   /**
+   * Returns true if the function is void; false, otherwise.
+   *
+   * @returns true if the function is void; false, otherwise.
+   */
+  public isVoid(): boolean {
+    return this._ref.isVoid;
+  } // fn: isVoid()
+
+  /**
    * Returns true if the function is a validator; false, otherwise.
    *
    * @returns true if the function is a validator; false, otherwise.

--- a/src/fuzzer/analysis/typescript/ProgramDef.ts
+++ b/src/fuzzer/analysis/typescript/ProgramDef.ts
@@ -28,7 +28,6 @@ import {
   ArgOptions,
   ProgramImport,
 } from "./Types";
-import { Breakpoint } from "vscode";
 
 /**
  * The ProgramDef class represents a program definition in a TypeScript source

--- a/src/fuzzer/analysis/typescript/ProgramDef.ts
+++ b/src/fuzzer/analysis/typescript/ProgramDef.ts
@@ -1139,7 +1139,7 @@ export class ProgramDef {
       case AST_NODE_TYPES.LabeledStatement:
         return this._findReturns(node.body);
       case AST_NODE_TYPES.ThrowStatement:
-        return false;
+        return true;
       case AST_NODE_TYPES.TryStatement:
         return (
           this._findReturns(node.block) ||

--- a/src/fuzzer/analysis/typescript/ProgramDef.ts
+++ b/src/fuzzer/analysis/typescript/ProgramDef.ts
@@ -11,6 +11,7 @@ import {
 import {
   TSTypeAliasDeclaration,
   TSTypeAnnotation,
+  TSVoidKeyword,
   Identifier,
   TSPropertySignature,
   TypeNode,
@@ -1135,10 +1136,16 @@ export class ProgramDef {
       // ReturnType is not as important for fuzzing, so we don't throw an error
       // if we encounter something we don't support.
       let returnType;
+      let isVoid = false;
       try {
+        isVoid =
+          node.init.returnType?.typeAnnotation.type ===
+          AST_NODE_TYPES.TSVoidKeyword;
         returnType = this._getTypeRefFromAstNode(node.id);
       } catch {
-        console.debug('Unsupported return type for function "' + name + '".');
+        if (!isVoid) {
+          console.debug('Unsupported return type for function "' + name + '".');
+        }
         returnType = undefined;
       }
       return {
@@ -1155,7 +1162,7 @@ export class ProgramDef {
           .filter((arg) => arg.type === AST_NODE_TYPES.Identifier)
           .map((arg) => this._getTypeRefFromAstNode(arg as Identifier)),
         returnType,
-        isVoid: false, // !!!!! TODO
+        isVoid,
       };
     } else if (
       // Standard Function Definition: function xyz(): void => { ... }
@@ -1165,11 +1172,16 @@ export class ProgramDef {
       // ReturnType is not as important for fuzzing, so we don't throw an error
       // if we encounter something we don't support.
       let returnType;
+      let isVoid = false;
       try {
+        isVoid =
+          node.returnType?.typeAnnotation.type === AST_NODE_TYPES.TSVoidKeyword;
         returnType =
           node.returnType && this._getTypeRefFromAstNode(node.returnType);
       } catch {
-        console.debug('Unsupported return type for function "' + name + '".');
+        if (!isVoid) {
+          console.debug('Unsupported return type for function "' + name + '".');
+        }
         returnType = undefined;
       }
       return {
@@ -1185,7 +1197,7 @@ export class ProgramDef {
           .filter((arg) => arg.type === AST_NODE_TYPES.Identifier)
           .map((arg) => this._getTypeRefFromAstNode(arg as Identifier)),
         returnType,
-        isVoid: false, // !!!!! TODO
+        isVoid,
       };
     }
   } // fn: _getFunctionFromNode()

--- a/src/fuzzer/analysis/typescript/ProgramDef.ts
+++ b/src/fuzzer/analysis/typescript/ProgramDef.ts
@@ -1135,18 +1135,18 @@ export class ProgramDef {
     ) {
       // ReturnType is not as important for fuzzing, so we don't throw an error
       // if we encounter something we don't support.
-      let returnType;
+      let returnType = undefined;
       let isVoid = false;
+      const typeNode = node.init.returnType;
       try {
-        isVoid =
-          node.init.returnType?.typeAnnotation.type ===
-          AST_NODE_TYPES.TSVoidKeyword;
-        returnType = this._getTypeRefFromAstNode(node.id);
+        isVoid = typeNode?.typeAnnotation.type === AST_NODE_TYPES.TSVoidKeyword;
+        returnType = typeNode
+          ? this._getTypeRefFromAstNode(typeNode)
+          : undefined;
       } catch {
         if (!isVoid) {
           console.debug('Unsupported return type for function "' + name + '".');
         }
-        returnType = undefined;
       }
       return {
         name,
@@ -1171,18 +1171,18 @@ export class ProgramDef {
     ) {
       // ReturnType is not as important for fuzzing, so we don't throw an error
       // if we encounter something we don't support.
-      let returnType;
+      let returnType = undefined;
       let isVoid = false;
+      const typeNode = node.returnType;
       try {
-        isVoid =
-          node.returnType?.typeAnnotation.type === AST_NODE_TYPES.TSVoidKeyword;
-        returnType =
-          node.returnType && this._getTypeRefFromAstNode(node.returnType);
+        isVoid = typeNode?.typeAnnotation.type === AST_NODE_TYPES.TSVoidKeyword;
+        returnType = typeNode
+          ? this._getTypeRefFromAstNode(typeNode)
+          : undefined;
       } catch {
         if (!isVoid) {
           console.debug('Unsupported return type for function "' + name + '".');
         }
-        returnType = undefined;
       }
       return {
         name,

--- a/src/fuzzer/analysis/typescript/ProgramDef.ts
+++ b/src/fuzzer/analysis/typescript/ProgramDef.ts
@@ -1156,6 +1156,7 @@ export class ProgramDef {
           .filter((arg) => arg.type === AST_NODE_TYPES.Identifier)
           .map((arg) => this._getTypeRefFromAstNode(arg as Identifier)),
         returnType,
+        isVoid: false, // !!!!! TODO
       };
     } else if (
       // Standard Function Definition: function xyz(): void => { ... }
@@ -1185,6 +1186,7 @@ export class ProgramDef {
           .filter((arg) => arg.type === AST_NODE_TYPES.Identifier)
           .map((arg) => this._getTypeRefFromAstNode(arg as Identifier)),
         returnType,
+        isVoid: false, // !!!!! TODO
       };
     }
   } // fn: _getFunctionFromNode()

--- a/src/fuzzer/analysis/typescript/ProgramDef.ts
+++ b/src/fuzzer/analysis/typescript/ProgramDef.ts
@@ -1097,11 +1097,15 @@ export class ProgramDef {
   } // fn: findFunctions()
 
   /**
-   * Returns true if any return statements are defined in block statement
+   * Returns true if any return statements are defined in a given block statement
    */
   private _findReturns(node: any, returns: boolean): boolean {
     if (returns) return true;
     if (node.body) {
+      // Implicit return for arrow function
+      if (node.body.type === AST_NODE_TYPES.Identifier) return true;
+
+      // Inner block statements and nested controls
       for (const n of node.body) {
         switch (n.type) {
           case AST_NODE_TYPES.ReturnStatement:

--- a/src/fuzzer/analysis/typescript/Types.ts
+++ b/src/fuzzer/analysis/typescript/Types.ts
@@ -37,6 +37,7 @@ export type FunctionRef = {
   startOffset: number; // Starting offset of the function in the source file
   endOffset: number; // Ending offset of the function in the source file
   isExported: boolean; // True if the function is exported; false, otherwise
+  isVoid: boolean; // True if the function is void; false, otherwise
   args?: TypeRef[]; // Array of argument types
 };
 

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -963,6 +963,9 @@ ${inArgConsts}
     const fn = env.function; // Function under test
     const counter = { id: 0 }; // Unique counter for argument ids
     let argDefHtml = ""; // HTML representing argument definitions
+    const heuristicValidatorDescription = fn.isVoid()
+      ? "Heuristic validator (for void functions). Fails: timeout, exception, values !==undefined"
+      : "Heuristic validator. Fails: timeout, exception, null, undefined, Infinity, NaN";
 
     // If fuzzer results are available, calculate how many tests passed, failed, etc.
     if (this._state === FuzzPanelState.done && this._results !== undefined) {
@@ -1007,7 +1010,7 @@ ${inArgConsts}
             <!-- Checkboxes -->
             <div class="fuzzInputControlGroup">
               <vscode-checkbox ${disabledFlag} id="fuzz-useImplicit" ${this._fuzzEnv.options.useImplicit ? "checked" : ""}>
-                <span class="tooltipped tooltipped-ne" aria-label="Heuristic validator. Fails: timeout, exception, null, undefined, Infinity, NaN"> 
+                <span class="tooltipped tooltipped-ne" aria-label="${heuristicValidatorDescription}">
                 Heuristic validator 
                 </span>
               </vscode-checkbox>

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -442,6 +442,7 @@ export class FuzzPanel {
           argOverrides: this._argOverrides,
           validators: this._fuzzEnv.validators.map((ref) => ref.name),
           tests: {},
+          isVoid: this._fuzzEnv.function.isVoid(),
         },
       },
     };
@@ -874,6 +875,7 @@ ${inArgConsts}
         testSet.validators = this._fuzzEnv.validators.map((ref) => ref.name);
         testSet.argOverrides = this._argOverrides;
         testSet.sortColumns = this._sortColumns;
+        testSet.isVoid = this._fuzzEnv.function.isVoid();
         this._putFuzzTestsForThisFn(testSet);
       } catch (e: any) {
         this._state = FuzzPanelState.error;


### PR DESCRIPTION
This PR resolves #73 by turning off the implicit oracle's `undefined` check in the case where the function has a declared return type of `void`. For simplicity, we do not attempt to determine if the function's return type should or should not be `void`; rather, we simply observe the declared return type and act accordingly. #194 is also resolved by this PR.

Feedback regarding the `void`/non-`void` mode of the implicit oracle is conveyed via `FuzzPanel` tooltips. Jest test cases now also respect this mode.