### PR TITLE
fix: add missing copy of PUT input

### DIFF
--- a/src/fuzzer/Fuzzer.test.ts
+++ b/src/fuzzer/Fuzzer.test.ts
@@ -34,6 +34,14 @@ const counterExampleOptions: FuzzOptions = {
 };
 
 /**
+ * Fuzz target that alters its input - used to verify
+ * that recorded fuzzer input is not altered by the target
+ */
+export function testChangeInput(obj: { a: number }) {
+  obj["b"] = "hi";
+}
+
+/**
  * These tests currently just ensure that the fuzzer runs and produces output
  * for each example. TODO: Add tests that check the fuzzer output.
  */
@@ -320,5 +328,17 @@ describe("Fuzzer", () => {
     ).results;
     expect(results.length).toStrictEqual(1);
     expect(results[0].category).not.toStrictEqual("ok");
+  });
+
+  /**
+   * Ensure fuzz targets that mutate their inputs cannot alter
+   * the input the fuzzer recorded for the function.
+   */
+  test("Fuzz target cannot change fuzzer input record", async () => {
+    const results = (
+      await fuzz(setup(intOptions, "./Fuzzer.test.ts", "testChangeInput"))
+    ).results;
+    expect(results.length).not.toStrictEqual(0);
+    expect(results[0].input[0].value.b).toBeUndefined();
   });
 });

--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -214,7 +214,7 @@ export const fuzz = async (
       result.output.push({
         name: "0",
         offset: 0,
-        value: fnWrapper(result.input), // <-- Wrapper
+        value: fnWrapper(JSON5.parse(JSON.stringify(result.input))), // <-- Wrapper (protect the input)
       });
       result.elapsedTime = performance.now() - startElapsedTime; // stop timer
     } catch (e: any) {


### PR DESCRIPTION
This PR:

1. Passes the PUT a copy of its input rather than the fuzzer's record of the input
2. Adds a new test to verify that PUTs cannot modify the fuzzer's input record