### PR TITLE
NaNofuzz+

### DIFF
--- a/assets/ui/FuzzPanelMain.css
+++ b/assets/ui/FuzzPanelMain.css
@@ -42,6 +42,12 @@ td.fuzzGridCellPinned,
 td.fuzzGridCellPin:hover {
   opacity: 100%;
 }
+/* Expand or collapse twistie column (›) */
+th.expandCollapseColumn {
+  padding-left: 0px;
+  padding-right: 0px;
+  padding-bottom: 0px;
+}
 
 /* Validator icons */
 td.classCheckOff,

--- a/assets/ui/FuzzPanelMain.css
+++ b/assets/ui/FuzzPanelMain.css
@@ -36,7 +36,7 @@ th.fuzzGridCellPin {
   text-align: center;
 }
 td.fuzzGridCellPin {
-  opacity: 20%;
+  opacity: 0%;
 }
 td.fuzzGridCellPinned,
 td.fuzzGridCellPin:hover {

--- a/assets/ui/FuzzPanelMain.css
+++ b/assets/ui/FuzzPanelMain.css
@@ -36,7 +36,7 @@ th.fuzzGridCellPin {
   text-align: center;
 }
 td.fuzzGridCellPin {
-  opacity: 35%;
+  opacity: 0%;
 }
 td.fuzzGridCellPinned,
 td.fuzzGridCellPin:hover {

--- a/assets/ui/FuzzPanelMain.css
+++ b/assets/ui/FuzzPanelMain.css
@@ -87,6 +87,10 @@ td.classErrorOn {
   opacity: 100%;
 }
 
+.classAddRefreshValidator:active {
+  background-color: var(--vscode-list-inactiveSelectionBackground);
+}
+
 /* Expected output panel */
 td.classErrorCell {
   text-decoration: red underline wavy;

--- a/assets/ui/FuzzPanelMain.css
+++ b/assets/ui/FuzzPanelMain.css
@@ -74,13 +74,8 @@ td.classErrorOn.colGroupEnd {
 }
 td.classCheckOff,
 td.classErrorOff {
-  opacity: 25%;
-  /* border-width: 1px;
-  border-style: solid;
-  border-color: var(--vscode-focus-border);
-  border-radius: 6px; */
-  /* background-color: var(--vscode-list-inactiveSelectionBackground); */
-} /* THISISME!!!!! used to be: opacity 35% */
+  opacity: 35%;
+}
 
 td.classCheckOff:hover,
 td.classErrorOff:hover {

--- a/assets/ui/FuzzPanelMain.css
+++ b/assets/ui/FuzzPanelMain.css
@@ -36,7 +36,7 @@ th.fuzzGridCellPin {
   text-align: center;
 }
 td.fuzzGridCellPin {
-  opacity: 0%;
+  opacity: 35%;
 }
 td.fuzzGridCellPinned,
 td.fuzzGridCellPin:hover {

--- a/assets/ui/FuzzPanelMain.css
+++ b/assets/ui/FuzzPanelMain.css
@@ -74,11 +74,18 @@ td.classErrorOn.colGroupEnd {
 }
 td.classCheckOff,
 td.classErrorOff {
-  opacity: 35%;
-}
+  opacity: 25%;
+  /* border-width: 1px;
+  border-style: solid;
+  border-color: var(--vscode-focus-border);
+  border-radius: 6px; */
+  /* background-color: var(--vscode-list-inactiveSelectionBackground); */
+} /* THISISME!!!!! used to be: opacity 35% */
+
 td.classCheckOff:hover,
 td.classErrorOff:hover {
   opacity: 100%;
+  /* background-color: var(--vscode-list-inactiveSelectionBackground); */
 }
 td.classCheckOn,
 td.classErrorOn {
@@ -267,14 +274,31 @@ tr.classErrorExpectedOutputRow td div.slightFade {
 /* Sorting */
 .columnSortDesc::after {
   content: "▼";
+  font-size: 0.9em;
   display: inline-block;
   padding-left: 0.25ch;
   position: absolute;
 }
 .columnSortAsc::after {
   content: "▲";
+  font-size: 0.9em;
   display: inline-block;
   padding-left: 0.25ch;
+  position: absolute;
+}
+.columnSortDescSmall::after {
+  content: "▼";
+  font-size: 0.75em;
+  display: inline-block;
+  padding-left: 0.2ch;
+  padding-bottom: 0em;
+  position: absolute;
+}
+.columnSortAscSmall::after {
+  content: "▲";
+  font-size: 0.75em;
+  display: inline-block;
+  padding-left: 0.2ch;
   position: absolute;
 }
 

--- a/assets/ui/FuzzPanelMain.css
+++ b/assets/ui/FuzzPanelMain.css
@@ -36,7 +36,7 @@ th.fuzzGridCellPin {
   text-align: center;
 }
 td.fuzzGridCellPin {
-  opacity: 0%;
+  opacity: 20%;
 }
 td.fuzzGridCellPinned,
 td.fuzzGridCellPin:hover {
@@ -335,4 +335,21 @@ div.fuzzInputControlGroup {
 .fuzzInfo > p {
   margin-top: 0.5em;
   margin-bottom: 0.25em;
+}
+
+.dropdown-container {
+  box-sizing: border-box;
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: flex-start;
+  justify-content: flex-start;
+}
+
+.dropdown-container label {
+  display: block;
+  color: var(--vscode-foreground);
+  cursor: pointer;
+  font-size: var(--vscode-font-size);
+  line-height: normal;
+  margin-bottom: 2px;
 }

--- a/assets/ui/FuzzPanelMain.css
+++ b/assets/ui/FuzzPanelMain.css
@@ -82,13 +82,22 @@ td.classErrorOff:hover {
   opacity: 100%;
   /* background-color: var(--vscode-list-inactiveSelectionBackground); */
 }
+td.classCheckOff:active,
+td.classErrorOff:active {
+  opacity: 80%;
+}
 td.classCheckOn,
 td.classErrorOn {
   opacity: 100%;
 }
+td.classCheckOn:active,
+td.classErrorOn:active {
+  opacity: 80%;
+}
 
 .classAddRefreshValidator:active {
-  background-color: var(--vscode-list-inactiveSelectionBackground);
+  /* background-color: var(--vscode-list-inactiveSelectionBackground); */
+  opacity: 50%;
 }
 
 /* Expected output panel */

--- a/assets/ui/FuzzPanelMain.css
+++ b/assets/ui/FuzzPanelMain.css
@@ -76,6 +76,10 @@ td.classCheckOff,
 td.classErrorOff {
   opacity: 35%;
 }
+td.classCheckOff:hover,
+td.classErrorOff:hover {
+  opacity: 100%;
+}
 td.classCheckOn,
 td.classErrorOn {
   opacity: 100%;

--- a/assets/ui/FuzzPanelMain.js
+++ b/assets/ui/FuzzPanelMain.js
@@ -332,7 +332,10 @@ function main() {
           } else if (hiddenColumns.indexOf(k) !== -1) {
             // noop (hidden)
           } else if (k === implicitLabel) {
-            if (mode === fuzzLabel) {
+            // THISISME
+            // checkboxes
+            if (resultsData.env.options.useImplicit) {
+              // if mode === fuzz
               const cell = hRow.appendChild(document.createElement("th"));
               cell.style = "text-align: center";
               cell.classList.add("colorColumn");
@@ -345,7 +348,8 @@ function main() {
               });
             }
           } else if (validators.validators.indexOf(k) !== -1) {
-            if (mode === propertyLabel) {
+            if (resultsData.env.options.useProperty) {
+              // if mode === property
               const cell = hRow.appendChild(document.createElement("th"));
               cell.style = "text-align: center";
               cell.classList.add("colorColumn");
@@ -397,14 +401,16 @@ function main() {
             // hidden column (id, expected, allValidators)
             continue;
           }
+          // THISISME checkboxes
           if (
             // hidden depending on mode
-            (col === implicitLabel && mode !== fuzzLabel) ||
+            (col === implicitLabel && !resultsData.env.options.useImplicit) ||
             (validators.validators.indexOf(col) !== -1 &&
-              mode !== propertyLabel) ||
+              !resultsData.env.options.useProperty) ||
             (col === correctLabel &&
               mode !== (fuzzLabel || exampleLabel || propertyLabel))
           ) {
+            // if mode === fuzz, or mode === property
             continue;
           }
           handleColumnSort(cell, hRow, type, col, data, tbody, false);
@@ -844,6 +850,7 @@ function updateColumnArrow(cell, type, col, isClicking) {
  * @param isClicking bool true if the function is being called because the user is clicking
  */
 function drawTableBody(data, type, tbody, isClicking, button) {
+  // console.log("resultsData.env.options:", resultsData.env.options);
   // Clear table
   while (tbody.rows.length > 0) tbody.deleteRow(0);
 
@@ -872,7 +879,10 @@ function drawTableBody(data, type, tbody, isClicking, button) {
       } else if (hiddenColumns.indexOf(k) !== -1) {
         // noop (hidden)
       } else if (k === implicitLabel) {
-        if (mode === "Fuzz") {
+        // THISISME
+        // checkboxes instead of mode
+        if (resultsData.env.options.useImplicit) {
+          // if mode === fuzz
           const cell = row.appendChild(document.createElement("td"));
           // Fade the indicator if overridden by another validator
           if (
@@ -894,7 +904,9 @@ function drawTableBody(data, type, tbody, isClicking, button) {
           }
         }
       } else if (validators.validators.indexOf(k) !== -1) {
-        if (mode === propertyLabel) {
+        // THISISME checkboxes
+        if (resultsData.env.options.useProperty) {
+          // if mode === property
           const cell = row.appendChild(document.createElement("td"));
           if (e[k] === undefined) {
             cell.innerHTML = "";
@@ -906,7 +918,8 @@ function drawTableBody(data, type, tbody, isClicking, button) {
 
             if (!e[validatorLabel]) {
               // if check mark and not on passed tab (passed everything)
-              cell.style.opacity = "35%";
+              span.classList.add("codicon", "codicon-pass-filled");
+              cell.style.opacity = "25%";
             }
           } else {
             cell.classList.add("classErrorOn", "colGroupStart", "colGroupEnd");
@@ -1377,7 +1390,7 @@ function handleFuzzStart(eCurrTarget) {
 
   // Process boolean fuzzer options
   // THISISME - where they're using the checkboxes
-  ["onlyFailures", "useHuman", "useImplicit"].forEach((e) => {
+  ["onlyFailures", "useHuman", "useImplicit", "useProperty"].forEach((e) => {
     const item = document.getElementById(fuzzBase + "-" + e);
     if (item !== null) {
       disableArr.push(item);
@@ -1485,12 +1498,28 @@ function handleFuzzStart(eCurrTarget) {
     e.style.disabled = true;
   }
 
+  console.log("fuzzpanelmain.js overrides:", overrides);
+
   // Send the fuzzer start command to the extension
   vscode.postMessage({
     command: "fuzz.start",
     json: JSON5.stringify(overrides),
   });
 } // fn: handleFuzzStart
+
+function listForValidatorFnTooltip() {
+  let list = "";
+  if ([...validators.validators].length === 0) {
+    list += "(none)";
+  }
+  for (const idx in validators.validators) {
+    list += validators.validators[idx];
+    if (idx !== validators.validators.length) {
+      list += "\n";
+    }
+  }
+  return list;
+}
 
 /**
  * Refreshes the displayed list of validtors based on a list of
@@ -1502,6 +1531,7 @@ function handleFuzzStart(eCurrTarget) {
  * }
  */
 function refreshValidators(validatorList) {
+  console.log("validatorLIst:", validatorList);
   // If no default validator is selected or the selected validator does not
   // exist, then select the implicit validator
   if (
@@ -1513,6 +1543,24 @@ function refreshValidators(validatorList) {
   } else {
     validatorList.validator = implicitOracleValidatorName;
   }
+
+  // THISISME
+  const validatorFnListWithTooltipOther = document.getElementById(
+    "validator-functionList-icon"
+  );
+  validatorFnListWithTooltipOther.setAttribute(
+    "aria-label",
+    listForValidatorFnTooltip()
+  );
+  const validatorFnListWithTooltip = document.getElementById(
+    "validator-functionList"
+  );
+  validatorFnListWithTooltip.setAttribute(
+    "aria-label",
+    listForValidatorFnTooltip()
+  );
+
+  // THISISME
 
   // Get the current list of validator controls
   const validatorFnGrp = document.getElementById("validatorFunctions-radios");

--- a/assets/ui/FuzzPanelMain.js
+++ b/assets/ui/FuzzPanelMain.js
@@ -175,17 +175,17 @@ function main() {
         ? { [expectedLabel]: e.expectedOutput }
         : {};
 
-      // Custom validator (bool, true if passed all custom validators)
+      // Property validator summary (true if passed all validator functions)
       const passedValidator = resultsData.env.options.useProperty
         ? { [validatorLabel]: e.passedValidator }
         : {};
 
-      // Custom validator (array of bools for all custom validators, true if passed)
-      const allValidators = resultsData.env.options.useProperty
-        ? { [allValidatorsLabel]: e.passedValidators }
-        : {};
+      // Array of all property validator results (array of bools, each is true if passed)
+      // const allValidators = resultsData.env.options.useProperty
+      //   ? { [allValidatorsLabel]: e.passedValidators }
+      //   : {};
 
-      // Custom validator result
+      // Result for each property validator (true if passed)
       const validatorFns = {};
       for (const v in e.passedValidators) {
         validatorFns[validators.validators[v]] = e.passedValidators[v];
@@ -238,7 +238,7 @@ function main() {
           //...elapsedTimes,
           ...passedImplicit,
           ...passedValidator,
-          ...allValidators,
+          // ...allValidators,
           ...validatorFns,
           ...passedHuman,
           ...pinned,
@@ -246,7 +246,7 @@ function main() {
         });
       }
     } // for: each result
-
+    console.log("data:", data);
     // Fill the grids with data
     gridTypes.forEach((type) => {
       if (data[type].length) {
@@ -275,7 +275,7 @@ function main() {
               cell.style = "text-align: center";
               cell.classList.add("colorColumn");
               cell.innerHTML = /* html */ `
-              <span class="tooltipped tooltipped-nw" aria-label="Heuristic validator. Fails: timeout, exception, null, undefined, Infinity, &amp; NaN">
+              <span class="tooltipped tooltipped-nw" aria-label="Heuristic validator. Fails: timeout, exception, null, undefined, Infinity, NaN">
                 <span class="codicon codicon-debug"></span>
               </span>`;
               cell.addEventListener("click", () => {
@@ -287,7 +287,7 @@ function main() {
               const cell = hRow.appendChild(document.createElement("th"));
               cell.classList.add("colorColumn");
               cell.innerHTML = /* html */ `
-                <span class="tooltipped tooltipped-nw" aria-label="Custom validators (summary)">
+                <span class="tooltipped tooltipped-nw" aria-label="Property validators summary">
                   <span class="codicon codicon-hubot" style="font-size:1.4em;"></span>
                 </span>`;
               cell.id = k;
@@ -295,7 +295,7 @@ function main() {
               cell.addEventListener("click", () => {
                 handleColumnSort(cell, hRow, type, k, tbody, true);
               });
-              // Twistie column with right arrow (to expand columns)
+              // Twistie column with right arrow (to expand validator columns)
               const expandCell = hRow.appendChild(document.createElement("th"));
               expandCell.innerHTML = /* html */ `
                 <span class="tooltipped tooltipped-nw" aria-label="Expand">
@@ -330,7 +330,7 @@ function main() {
                 validators.validators.indexOf(k) ===
                 validators.validators.length - 1
               ) {
-                // Twistie column with left arrow (to collapse columns)
+                // Twistie column with left arrow (to collapse validator columns)
                 const collapseCell = hRow.appendChild(
                   document.createElement("th")
                 );
@@ -341,8 +341,6 @@ function main() {
                 // asc = columns currently hidden; desc = columns currently expanded
                 if (columnSortOrders[type][expandLabel] === "asc") {
                   collapseCell.classList.add("hidden");
-                } else {
-                  // collapseCell.classList.remove("hidden");
                 }
                 collapseCell.id = type + "-" + collapseLabel;
                 collapseCell.style =
@@ -352,7 +350,7 @@ function main() {
                 });
               } // if last custom validator col
               if (columnSortOrders[type][expandLabel] === "asc") {
-                cell.classList.add("hidden"); // Make hidden (collapsible columns)
+                cell.classList.add("hidden");
               }
               cell.addEventListener("click", () => {
                 handleColumnSort(cell, hRow, type, k, tbody, true);
@@ -363,7 +361,7 @@ function main() {
             cell.style = "text-align: center";
             cell.classList.add("colorColumn");
             cell.innerHTML = /* html */ `
-              <span class="tooltipped tooltipped-nw" aria-label="Human (manual) validation">
+              <span class="tooltipped tooltipped-nw" aria-label="Human validator">
                 <span class="codicon codicon-person" id="humanIndicator" style="font-size:1.4em;"></span>
               </span>`;
             cell.colSpan = 2;
@@ -1383,22 +1381,8 @@ function handleFuzzStart(eCurrTarget) {
   });
 } // fn: handleFuzzStart
 
-function listForValidatorFnTooltip(validatorList) {
-  let list = "Custom functions:\n";
-  if (validatorList.validators.length === 0) {
-    list += "(none)";
-  }
-  for (const idx in validatorList.validators) {
-    list += validatorList.validators[idx];
-    if (idx !== validatorList.validators.length) {
-      list += "\n";
-    }
-  }
-  return list;
-}
-
 /**
- * Refreshes the displayed list of validtors based on a list of
+ * Refreshes the displayed list of validators based on a list of
  * validators provided from the back-end.
  *
  * @param {*} object of type: {
@@ -1589,6 +1573,26 @@ function getIdxInTableHeader(id, hRow) {
     ++idx;
   }
   return idx;
+}
+
+/**
+ * Returns string of validator function names
+ *
+ * @param {*} validatorList list of validator fn names
+ * @returns
+ */
+function listForValidatorFnTooltip(validatorList) {
+  let list = "Property validators:\n";
+  if (validatorList.validators.length === 0) {
+    list += "(none)";
+  }
+  for (const idx in validatorList.validators) {
+    list += validatorList.validators[idx];
+    if (idx !== validatorList.validators.length) {
+      list += "\n";
+    }
+  }
+  return list;
 }
 
 /**

--- a/assets/ui/FuzzPanelMain.js
+++ b/assets/ui/FuzzPanelMain.js
@@ -357,13 +357,13 @@ function main() {
           } else if (k === validatorLabel) {
             if (resultsData.env.options.useProperty) {
               const cell = hRow.appendChild(document.createElement("th"));
-              cell.style = "text-align: center;";
               cell.classList.add("colorColumn");
               cell.innerHTML = /* html */ `
                 <span class="tooltipped tooltipped-nw" aria-label="Custom validators (summary)">
                   <span class="codicon codicon-hubot" style="font-size:1.4em;"></span>
                 </span>`;
-              cell.setAttribute("id", k);
+              cell.id = k;
+              cell.style = "padding-left:3px; padding-right:0px;";
               cell.addEventListener("click", () => {
                 handleColumnSort(cell, hRow, type, k, tbody, true);
               });
@@ -373,7 +373,9 @@ function main() {
                   ? expandColumnState.htmlHidden
                   : expandColumnState.htmlOpen;
 
-              expandCell.setAttribute("id", type + "-" + expandColumnLabel);
+              expandCell.id = type + "-" + expandColumnLabel;
+              expandCell.style =
+                "padding-left:0px; padding-right:0px; padding-bottom:0px;";
               expandCell.addEventListener("click", () => {
                 toggleExpandColumn(cell, expandCell, type);
               });
@@ -382,13 +384,20 @@ function main() {
             if (resultsData.env.options.useProperty) {
               // if mode === property
               const cell = hRow.appendChild(document.createElement("th"));
-              cell.style = "text-align: center";
               cell.classList.add("colorColumn");
               cell.innerHTML = /* html */ `
                 <span class="tooltipped tooltipped-nw" aria-label="${k}">
                   <span class="codicon codicon-hubot" style="font-size: 1em;"></span> <!-- small -->
                 </span>`;
-              cell.setAttribute("id", type + "-" + k);
+              cell.id = type + "-" + k;
+              cell.style = "padding-left:0px; padding-right:0px;";
+              if (
+                validators.validators.indexOf(k) ===
+                validators.validators.length - 1
+              ) {
+                // Add padding to last custom validator header cell
+                cell.style = "padding-left:6px; padding-right:15px;";
+              }
               // if (columnSortOrders[type][expandColumnLabel] === "asc") {
               const expandCell = document.getElementById(
                 type + "-" + expandColumnLabel
@@ -411,7 +420,7 @@ function main() {
               cell.classList.add("colorColumn");
               cell.innerHTML = /* html */ `
               <span class="tooltipped tooltipped-nw" aria-label="Human (manual) validation">
-                <span class="codicon codicon-person" id="humanIndicator"></span>
+                <span class="codicon codicon-person" id="humanIndicator" style="font-size:1.4em;"></span>
               </span>`;
               cell.colSpan = 2;
               cell.addEventListener("click", () => {
@@ -957,6 +966,7 @@ function drawTableBody(type, tbody, isClicking, button) {
       } else if (k === validatorLabel) {
         if (resultsData.env.options.useProperty) {
           const cell = row.appendChild(document.createElement("td"));
+          cell.setAttribute("style", "padding-right:0px;");
           if (e[k] === undefined) {
             cell.innerHTML = "";
           } else if (e[k]) {
@@ -974,6 +984,7 @@ function drawTableBody(type, tbody, isClicking, button) {
         if (resultsData.env.options.useProperty) {
           // if mode === property
           const cell = row.appendChild(document.createElement("td"));
+          cell.style = "text-align: left;";
           if (e[k] === undefined) {
             cell.innerHTML = "";
           } else if (e[k]) {

--- a/assets/ui/FuzzPanelMain.js
+++ b/assets/ui/FuzzPanelMain.js
@@ -27,8 +27,8 @@ const elapsedTimeLabel = "running time (ms)";
 const hiddenColumns = [
   idLabel,
   expectedLabel,
-  allValidatorsLabel,
   validatorLabel,
+  allValidatorsLabel,
 ];
 
 // Mode labels
@@ -235,16 +235,14 @@ function main() {
         : {};
 
       // Custom validator (bool, true if passed all custom validators)
-      const passedValidator =
-        validators.validator !== implicitOracleValidatorName
-          ? { [validatorLabel]: e.passedValidator }
-          : {};
+      const passedValidator = resultsData.env.options.useProperty
+        ? { [validatorLabel]: e.passedValidator }
+        : {};
 
       // Custom validator (array of bools for all custom validators, true if passed)
-      const allValidators =
-        validators.validator !== implicitOracleValidatorName
-          ? { [allValidatorsLabel]: e.passedValidators }
-          : {};
+      const allValidators = resultsData.env.options.useProperty
+        ? { [allValidatorsLabel]: e.passedValidators }
+        : {};
 
       // Custom validator result
       const validatorFns = {};
@@ -307,7 +305,6 @@ function main() {
         });
       }
     } // for: each result
-    console.log("data:", data);
 
     // Fill the grids with data
     gridTypes.forEach((type) => {
@@ -332,8 +329,6 @@ function main() {
           } else if (hiddenColumns.indexOf(k) !== -1) {
             // noop (hidden)
           } else if (k === implicitLabel) {
-            // THISISME
-            // checkboxes
             if (resultsData.env.options.useImplicit) {
               // if mode === fuzz
               const cell = hRow.appendChild(document.createElement("th"));
@@ -351,6 +346,7 @@ function main() {
             if (resultsData.env.options.useProperty) {
               // if mode === property
               const cell = hRow.appendChild(document.createElement("th"));
+              // cell.classList.add("hidden"); // Make hidden (collapsible columns)
               cell.style = "text-align: center";
               cell.classList.add("colorColumn");
               cell.innerHTML = /* html */ `
@@ -904,7 +900,6 @@ function drawTableBody(data, type, tbody, isClicking, button) {
           }
         }
       } else if (validators.validators.indexOf(k) !== -1) {
-        // THISISME checkboxes
         if (resultsData.env.options.useProperty) {
           // if mode === property
           const cell = row.appendChild(document.createElement("td"));
@@ -1507,14 +1502,14 @@ function handleFuzzStart(eCurrTarget) {
   });
 } // fn: handleFuzzStart
 
-function listForValidatorFnTooltip() {
+function listForValidatorFnTooltip(validatorList) {
   let list = "";
-  if ([...validators.validators].length === 0) {
+  if (validatorList.validators.length === 0) {
     list += "(none)";
   }
-  for (const idx in validators.validators) {
-    list += validators.validators[idx];
-    if (idx !== validators.validators.length) {
+  for (const idx in validatorList.validators) {
+    list += validatorList.validators[idx];
+    if (idx !== validatorList.validators.length) {
       list += "\n";
     }
   }
@@ -1531,7 +1526,6 @@ function listForValidatorFnTooltip() {
  * }
  */
 function refreshValidators(validatorList) {
-  console.log("validatorLIst:", validatorList);
   // If no default validator is selected or the selected validator does not
   // exist, then select the implicit validator
   if (
@@ -1545,19 +1539,12 @@ function refreshValidators(validatorList) {
   }
 
   // THISISME
-  const validatorFnListWithTooltipOther = document.getElementById(
-    "validator-functionList-icon"
-  );
-  validatorFnListWithTooltipOther.setAttribute(
-    "aria-label",
-    listForValidatorFnTooltip()
-  );
   const validatorFnListWithTooltip = document.getElementById(
     "validator-functionList"
   );
   validatorFnListWithTooltip.setAttribute(
     "aria-label",
-    listForValidatorFnTooltip()
+    listForValidatorFnTooltip(validatorList)
   );
 
   // THISISME

--- a/assets/ui/FuzzPanelMain.js
+++ b/assets/ui/FuzzPanelMain.js
@@ -246,7 +246,6 @@ function main() {
         });
       }
     } // for: each result
-    console.log("data:", data);
     // Fill the grids with data
     gridTypes.forEach((type) => {
       if (data[type].length) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nanofuzz",
   "displayName": "NaNofuzz",
   "publisher": "penrose",
-  "version": "0.2.1",
+  "version": "0.2.5",
   "description": "NaNofuzz is a fast and easy-to-use automatic test suite generator for TypeScript that runs inside VS Code",
   "repository": "https://github.com/nanofuzz/nanofuzz.git",
   "author": "The NaNofuzz Team @ Carnegie Mellon University",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -2,7 +2,7 @@
   "name": "@nanofuzz/runtime",
   "displayName": "NaNofuzz runtime support",
   "publisher": "penrose",
-  "version": "0.2.1",
+  "version": "0.2.5",
   "description": "Runtime support and types for NaNofuzz",
   "repository": {
     "type": "git",

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -7,6 +7,11 @@ import * as build from "./build.json";
 export const versions = build.versions;
 
 /**
+ * Simplified single Fuzzer Test Result
+ */
+export type Result = fuzzer.Result;
+
+/**
  * Single Fuzzer Test Result
  */
 export type FuzzTestResult = fuzzer.FuzzTestResult;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -9,12 +9,7 @@ export const versions = build.versions;
 /**
  * Simplified single Fuzzer Test Result
  */
-export type Result = fuzzer.Result;
-
-/**
- * Single Fuzzer Test Result
- */
-export type FuzzTestResult = fuzzer.FuzzTestResult;
+export type FuzzTestResult = fuzzer.Result;
 
 /**
  * Fuzzer Input/Output Element; i.e., a concrete input or output value

--- a/src/fuzzer/Fuzzer.test.ts
+++ b/src/fuzzer/Fuzzer.test.ts
@@ -15,7 +15,6 @@ const intOptions: FuzzOptions = {
   useImplicit: true,
   useHuman: true,
   useProperty: false,
-  mode: "Fuzz",
 };
 
 /**

--- a/src/fuzzer/Fuzzer.test.ts
+++ b/src/fuzzer/Fuzzer.test.ts
@@ -14,6 +14,7 @@ const intOptions: FuzzOptions = {
   onlyFailures: false,
   useImplicit: true,
   useHuman: true,
+  mode: "Fuzz",
 };
 
 /**

--- a/src/fuzzer/Fuzzer.test.ts
+++ b/src/fuzzer/Fuzzer.test.ts
@@ -14,6 +14,7 @@ const intOptions: FuzzOptions = {
   onlyFailures: false,
   useImplicit: true,
   useHuman: true,
+  useProperty: false,
   mode: "Fuzz",
 };
 

--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -252,8 +252,6 @@ export const fuzz = async (
 
     // CUSTOM VALIDATOR ------------------------------------------
     // If a custom validator is selected, call it to evaluate the result
-    // THISISME
-    // checkboxes
     if (
       "validator" in env &&
       env.validators.length &&

--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -252,10 +252,12 @@ export const fuzz = async (
 
     // CUSTOM VALIDATOR ------------------------------------------
     // If a custom validator is selected, call it to evaluate the result
+    // THISISME
+    // checkboxes
     if (
       "validator" in env &&
       env.validators.length &&
-      env.options.mode === "Property Test"
+      env.options.useProperty
     ) {
       // const fnName = env.validator;
       result.passedValidators = [];

--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -302,7 +302,6 @@ export const fuzz = async (
         const validatorResult = validatorFnWrapper(result);
 
         // Store the validator results
-        // result.passedValidator = validatorResult.passedValidator;
         result.passedValidators.push(validatorResult.passedValidator);
         result.validatorException = validatorResult.validatorException;
         result.validatorExceptionMessage =
@@ -316,40 +315,6 @@ export const fuzz = async (
         result.passedValidator =
           result.passedValidator && result.passedValidators[i];
       }
-
-      //   // Build the validator function wrapper
-      //   const validatorFnWrapper = functionTimeout(
-      //     (input: FuzzTestResult): FuzzTestResult => {
-      //       try {
-      //         const result: FuzzTestResult = mod[fnName]({ ...input });
-      //         return {
-      //           ...input,
-      //           passedValidator: result.passedValidator,
-      //         };
-      //       } catch (e: any) {
-      //         return {
-      //           ...input,
-      //           validatorException: true,
-      //           validatorExceptionMessage: e.message,
-      //           validatorExceptionStack: e.stack,
-      //         };
-      //       }
-      //     },
-      //     env.options.fnTimeout
-      //   );
-
-      //   // Categorize the results (so it's not stale)
-      //   result.category = categorizeResult(result);
-
-      //   // Call the validator function wrapper
-      //   const validatorResult = validatorFnWrapper(result);
-
-      //   // Store the validator results
-      //   result.passedValidator = validatorResult.passedValidator;
-      //   result.validatorException = validatorResult.validatorException;
-      //   result.validatorExceptionMessage =
-      //     validatorResult.validatorExceptionMessage;
-      //   result.validatorExceptionStack = validatorResult.validatorExceptionStack;
     } // if validator
 
     // (Re-)categorize the result
@@ -556,17 +521,10 @@ export function categorizeResult(
     return FuzzResultCategory.FAILURE; // Validator failed
   }
 
-  // // Only pass/fail for validator functions?
-  // if (result.passedValidators && result.passedValidators.length !== 0) {
-  //   return result.passedValidator
-  //     ? FuzzResultCategory.OK
-  //     : FuzzResultCategory.BADVALUE;
-  // }
-
   const implicit = result.passedImplicit ? true : false;
   const human =
     "passedHuman" in result ? (result.passedHuman ? true : false) : undefined;
-  const validator =
+  const property =
     "passedValidator" in result ? result.passedValidator : undefined;
 
   // Returns the type of bad value: execption, timeout, or badvalue
@@ -579,7 +537,7 @@ export function categorizeResult(
       return FuzzResultCategory.BADVALUE; // PUT returned bad value
     }
   };
-  const getBadValueTypeValidator = (
+  const getBadValueTypeProperty = (
     result: FuzzTestResult
   ): FuzzResultCategory => {
     return result.passedValidator
@@ -593,22 +551,22 @@ export function categorizeResult(
   // agree. If the human and validator are present yet disagree,
   // then the disagreement is another error.
   if (human === true) {
-    if (validator === false) {
+    if (property === false) {
       return FuzzResultCategory.DISAGREE;
     } else {
       return FuzzResultCategory.OK;
     }
   } else if (human === false) {
-    if (validator === true) {
+    if (property === true) {
       return FuzzResultCategory.DISAGREE;
     } else {
-      return getBadValueTypeValidator(result);
+      return getBadValueType(result);
     }
   } else {
-    if (validator === true) {
+    if (property === true) {
       return FuzzResultCategory.OK;
-    } else if (validator === false) {
-      return getBadValueTypeValidator(result);
+    } else if (property === false) {
+      return getBadValueTypeProperty(result);
     } else {
       if (implicit) {
         return FuzzResultCategory.OK;

--- a/src/fuzzer/Types.ts
+++ b/src/fuzzer/Types.ts
@@ -97,7 +97,7 @@ export type FuzzOptions = {
   suiteTimeout: number; // timeout for the entire test suite
   useImplicit: boolean; // use implicit oracle
   useHuman: boolean; // use human oracle
-  useProperty: boolean; // use custom validator function oracle
+  useProperty: boolean; // use property validator oracle
 };
 
 /**

--- a/src/fuzzer/Types.ts
+++ b/src/fuzzer/Types.ts
@@ -13,13 +13,24 @@ export type FuzzTestResult = {
   timeout: boolean; // true if the fn call timed out
   passedImplicit: boolean; // true if output matches implicit oracle; false, otherwise
   passedHuman?: boolean; // true if actual output matches human-expected output
-  passedValidator?: boolean; // true if passed custom validator; false, otherwise
+  passedValidator?: boolean; // true if passed all custom validators; false, otherwise
+  passedValidators?: boolean[]; // for each custom validator, true if passed; false, otherwise
   validatorException: boolean; // true if validator threw an exception
   validatorExceptionMessage?: string; // validator exception message
   validatorExceptionStack?: string; // validator stack trace if exception was thrown
   elapsedTime: number; // elapsed time of test
   expectedOutput?: FuzzIoElement[]; // the expected output, if any
   category: string; // the ResultCategory of the test result
+};
+
+/**
+ * Simplified single test result for writing custom validator
+ */
+export type Result = {
+  in: any[]; // function input
+  out: any; // function output
+  exception: boolean; // true if an exception was thrown
+  timeout: boolean; // true if the fn call timed out
 };
 
 /**
@@ -86,6 +97,7 @@ export type FuzzOptions = {
   suiteTimeout: number; // timeout for the entire test suite
   useImplicit: boolean; // use implicit oracle
   useHuman: boolean; // use human oracle
+  mode: string; // current mode of NaNoguide
 };
 
 /**

--- a/src/fuzzer/Types.ts
+++ b/src/fuzzer/Types.ts
@@ -97,6 +97,7 @@ export type FuzzOptions = {
   suiteTimeout: number; // timeout for the entire test suite
   useImplicit: boolean; // use implicit oracle
   useHuman: boolean; // use human oracle
+  useProperty: boolean; // use custom validator function oracle
   mode: string; // current mode of NaNoguide
 };
 

--- a/src/fuzzer/Types.ts
+++ b/src/fuzzer/Types.ts
@@ -98,7 +98,6 @@ export type FuzzOptions = {
   useImplicit: boolean; // use implicit oracle
   useHuman: boolean; // use human oracle
   useProperty: boolean; // use custom validator function oracle
-  mode: string; // current mode of NaNoguide
 };
 
 /**

--- a/src/fuzzer/analysis/typescript/ArgDef.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.ts
@@ -290,6 +290,25 @@ export class ArgDef<T extends ArgType> {
   } // fn: setIntervals()
 
   /**
+   * Sets the input intervals for the argument.
+   *
+   * @param intervals The input intervals to set
+   *
+   * Throws an exception if any interval's min>max.
+   */
+  public setDefaultIntervals(options: ArgOptions): void {
+    const intervals = ArgDef.getDefaultIntervals(
+      this.type,
+      options
+    ) as Interval<T>[];
+    if (intervals.some((e) => e.min > e.max))
+      throw new Error(
+        `Invalid interval provided (max>min): ${JSON5.stringify(intervals)}`
+      );
+    this.intervals = intervals;
+  } // fn: setIntervals()
+
+  /**
    * Indicates whether the argument has a constant input interval.
    *
    * @returns true if the input interval represents a constant input; false otherwise

--- a/src/fuzzer/analysis/typescript/ArgDef.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.ts
@@ -394,6 +394,14 @@ export class ArgDef<T extends ArgType> {
   } // fn: setOptions()
 
   /**
+   * Sets the argument's strcharset (alphabet of chars for strings).
+   * @param strcharset
+   */
+  public setStrCharSet(strcharset: string) {
+    this.options.strCharset = strcharset;
+  }
+
+  /**
    * Returns the argument's children.
    *
    * @returns the argument's children (if it is an object)

--- a/src/fuzzer/analysis/typescript/FunctionDef.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.ts
@@ -158,6 +158,20 @@ export class FunctionDef {
   } // fn: applyOverrides()
 
   /**
+   * Applies options to the argument definitions for the function
+   * definition that influence how the function analysis is
+   * interpreted.
+   *
+   * @param options
+   */
+  public applyOptions(options: ArgOptions): void {
+    this._argDefs.forEach((argdef) => {
+      argdef.setOptions(options);
+      argdef.setDefaultIntervals(options);
+    });
+  } // fn: applyOverrides()
+
+  /**
    * Returns a flat array of all function arguments, including
    * the children of arguments.  The selection is depth-first.
    *

--- a/src/fuzzer/analysis/typescript/FunctionDef.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.ts
@@ -135,9 +135,10 @@ export class FunctionDef {
    */
   public isValidator(): boolean {
     return (
-      this.isExported() &&
-      this._argDefs.length === 1 &&
-      this._argDefs[0].getTypeRef() === "FuzzTestResult"
+      (this.isExported() &&
+        this._argDefs.length === 1 &&
+        this._argDefs[0].getTypeRef() === "FuzzTestResult") ||
+      this._argDefs[0].getTypeRef() === "Result"
     );
   } // fn: isValidator()
 

--- a/src/fuzzer/analysis/typescript/FunctionDef.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.ts
@@ -137,8 +137,7 @@ export class FunctionDef {
     return (
       this.isExported() &&
       this._argDefs.length === 1 &&
-      (this._argDefs[0].getTypeRef() === "FuzzTestResult" ||
-        this._argDefs[0].getTypeRef() === "Result")
+      this._argDefs[0].getTypeRef() === "FuzzTestResult"
     );
   } // fn: isValidator()
 

--- a/src/fuzzer/analysis/typescript/FunctionDef.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.ts
@@ -166,7 +166,7 @@ export class FunctionDef {
    */
   public applyOptions(options: ArgOptions): void {
     this._argDefs.forEach((argdef) => {
-      argdef.setOptions(options);
+      argdef.setStrCharSet(options.strCharset);
       argdef.setDefaultIntervals(options);
     });
   } // fn: applyOverrides()

--- a/src/fuzzer/analysis/typescript/FunctionDef.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.ts
@@ -135,10 +135,10 @@ export class FunctionDef {
    */
   public isValidator(): boolean {
     return (
-      (this.isExported() &&
-        this._argDefs.length === 1 &&
-        this._argDefs[0].getTypeRef() === "FuzzTestResult") ||
-      this._argDefs[0].getTypeRef() === "Result"
+      this.isExported() &&
+      this._argDefs.length === 1 &&
+      (this._argDefs[0].getTypeRef() === "FuzzTestResult" ||
+        this._argDefs[0].getTypeRef() === "Result")
     );
   } // fn: isValidator()
 

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -726,7 +726,6 @@ export function ${validatorPrefix}${
     const panelInput: {
       fuzzer: Record<string, number>; // !!! Improve typing
       args: fuzzer.FuzzArgOverride[]; // !!! Improve typing
-      // changeMode: boolean; // THISISME is this totally useless?
     } = JSON5.parse(json);
     const fn = this._fuzzEnv.function;
 

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -899,66 +899,6 @@ export function ${validatorPrefix}${
       (arg) => (argDefHtml += this._argDefToHtmlForm(arg, counter))
     );
 
-    console.log("updateHTML() MODE:", this._fuzzEnv.options.mode);
-
-    /*
-    // HTML for radio button version of changeMode:
-                <vscode-radio-group id="mode-radios" orientation="vertical">
-                  <vscode-radio ${disabledFlag} id="mode.explore" name="mode.explore" value="false" ${
-                    (!this._fuzzEnv.options.useImplicit && !this._fuzzEnv.options.useHuman) ? "checked" : ""}>Show me lots of example outputs</vscode-radio>
-                  <vscode-radio ${disabledFlag} id="mode.fuzz" name="mode.fuzz" value="false" ${
-                    (this._fuzzEnv.options.useImplicit && !this._fuzzEnv.options.useHuman)  ? "checked" : ""}>Quickly check for likely bugs</vscode-radio>
-                  <vscode-radio ${disabledFlag} id="mode.example" name="mode.example" value="false" ${
-                    (!this._fuzzEnv.options.useImplicit && this._fuzzEnv.options.useHuman)  ? "checked" : ""}>Manually classify outputs as correct or incorrect</vscode-radio>
-                  <vscode-radio ${disabledFlag} id="mode.validator" name="mode.validator" value="false" ${
-                    (this._fuzzEnv.options.useImplicit && this._fuzzEnv.options.useHuman)  ? "checked" : ""}>Use a function to classify outputs as correct or incorrect</vscode-radio>
-                </vscode-radio-group>
-
-
-    // The 'Testing' fuzz.start button:
-
-    <vscode-button ${disabledFlag} id="fuzz.start" appearance="primary">
-              ${this._state === FuzzPanelState.busy ? "Testing..." : "Test"}
-            </vscode-button>
-
-
-    Previous title:
-
-    <h2> Test ${htmlEscape(
-            fn.getName()
-          )}() w/inputs:</h2>
-
-          <h2 style="font-size:1.9em; padding-top: .25em;"> 
-
-    <h2 style="font-size:1.75em;"> ${this._state === FuzzPanelState.busy ? "Testing..." : "Test: "+htmlEscape(
-            fn.getName())+"()"} </h2>
-
-
-    <!-- THIS IS ME!!!!!!!!!! -->
-          <!-- Change validators options -->
-          <p style="font-size:1.2em; margin-top: 0.1em; margin-bottom: 0.1em;"> <strong> Change validators: </strong> </p>
-          <vscode-radio-group orientation="vertical" style="padding-left: .75em;"> 
-            <vscode-radio ${disabledFlag} id="" name="onlyFailures.false" value="value-1" ${
-              !this._fuzzEnv.options.onlyFailures ? "checked" : ""}>
-              <strong> Fuzz: </strong> quickly check for likely bugs &nbsp;
-              <span class="codicon codicon-debug" style="font-size:1em"></span>
-              <span class="codicon codicon-person" style="font-size:1.15em"></span>
-            </vscode-radio>
-            <vscode-radio ${disabledFlag} id="" name="onlyFailures.true" value="value-2" ${
-              this._fuzzEnv.options.onlyFailures ? "checked" : ""}><strong> Example Test: </strong> classify outputs manually
-              <span class="codicon codicon-person" style="font-size:1.15em"></span>
-            </vscode-radio>
-            <vscode-radio ${disabledFlag} id="" name="onlyFailures.false" value="value-3" ${
-              !this._fuzzEnv.options.onlyFailures ? "checked" : ""}><strong> Property Test: </strong> classify outputs using a function
-              <span class="codicon codicon-hubot" style="font-size:1.15em"></span>
-              <span class="codicon codicon-person" style="font-size:1.15em"></span>
-            </vscode-radio>
-            <vscode-radio ${disabledFlag} id="" name="onlyFailures.true" value="value-4" ${
-              this._fuzzEnv.options.onlyFailures ? "checked" : ""}><strong> Custom... </strong> </vscode-radio>
-          </vscode-radio-group>
-          <vscode-divider></vscode-divider>
-    */
-
     // Note: the stuff in the NaNofuzz pane should technically all be indented
     console.log("env:", env);
 
@@ -1020,7 +960,7 @@ export function ${validatorPrefix}${
 
         <!-- NaNofuzz pane -->
         <div id="pane-nanofuzz" class=${this._state === FuzzPanelState.init ? "hidden" : ""}> 
-          <h2 style="font-size:1.75em; padding-top:.2em;"> ${this._state === FuzzPanelState.busy ? "Testing..." : "Test: "+htmlEscape(
+          <h2 style="font-size:1.75em; padding-top:.2em; margin-bottom:.2em;"> ${this._state === FuzzPanelState.busy ? "Testing..." : "Test: "+htmlEscape(
             fn.getName())+"()"} </h2>
 
           <!-- Function Arguments -->
@@ -1077,12 +1017,12 @@ export function ${validatorPrefix}${
             
             <!-- Checkboxes to select validator -->
             <div class="fuzzInputControlGroup">
-              <vscode-checkbox id="fuzz-useImplicit" ${this._fuzzEnv.options.useImplicit ? "checked" : ""}>
+              <vscode-checkbox ${disabledFlag} id="fuzz-useImplicit" ${this._fuzzEnv.options.useImplicit ? "checked" : ""}>
                 Use heuristic validator
               </vscode-checkbox>
               <span style="padding-left:1.3em;"> </span>
               <span style="display:inline-block;">
-                <vscode-checkbox id="fuzz-useProperty" ${this._fuzzEnv.options.useProperty ? "checked" : ""}>
+                <vscode-checkbox ${disabledFlag} id="fuzz-useProperty" ${this._fuzzEnv.options.useProperty ? "checked" : ""}>
                   Use custom functions <span id="validator-functionList" class="tooltipped tooltipped-n" aria-label=""> (see list) </span>
                 </vscode-checkbox>
                 <span id="validator.add" class="tooltipped tooltipped-nw" aria-label="Add new custom function">

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1538,7 +1538,7 @@ export async function handleFuzzCommand(match?: FunctionMatch): Promise<void> {
     fuzzSetup = fuzzer.setup(fuzzOptions, srcFile, fnName);
   } catch (e: any) {
     vscode.window.showErrorMessage(
-      `NaNofuzz could not find or does not support this function. Messge: "${e.message}"`
+      `NaNofuzz could not find or does not support this function. Message: "${e.message}"`
     );
     return;
   }

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -211,6 +211,10 @@ export class FuzzPanel {
     this._argOverrides = testSet.argOverrides ?? [];
     this._sortColumns = testSet.sortColumns;
     _applyArgOverrides(this._fuzzEnv.function, this._argOverrides);
+    // TODO: There is likely a bug somewhere related to initializing the arg options !!!
+    // Options configured in the json file are correct in `this._fuzzEnv.options`, but are not carried over
+    // in `this._fuzzEnv.function._argDefs`
+    this._fuzzEnv.function.applyOptions(testSet.options.argDefaults);
 
     // Set the webview's initial html content
     this._updateHtml();

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1068,8 +1068,8 @@ export function ${validatorPrefix}${
       {
         id: "ok",
         name: "Passed",
-        description: `Passed. No validator categorized these outputs as failed.`,
-        // description: `A validator categorized these outputs as passed, or no validator categorized them as failed.`,
+        description: `Passed. A validator categorized these outputs as passed, or no validator categorized them as failed.`,
+        // description: `Passed. No validator categorized these outputs as failed.`,
         // description: `No validator categorized these outputs as failed, or a validator categorized them as passed.`,
         hasGrid: true,
       },

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -210,6 +210,7 @@ export class FuzzPanel {
     this._fuzzEnv.options = testSet.options;
     this._argOverrides = testSet.argOverrides ?? [];
     this._sortColumns = testSet.sortColumns;
+    console.log("this._sortColumns:", this._sortColumns);
     _applyArgOverrides(this._fuzzEnv.function, this._argOverrides);
 
     // Set the webview's initial html content
@@ -689,7 +690,7 @@ export function ${validatorPrefix}${
         this._fuzzEnv.options.useHuman = true;
         this._fuzzEnv.options.mode = "Example Test";
         break;
-      case "mode.validator":
+      case "mode.property":
         this._fuzzEnv.options.useImplicit = false;
         this._fuzzEnv.options.useHuman = true;
         this._fuzzEnv.options.mode = "Property Test";
@@ -967,6 +968,7 @@ export function ${validatorPrefix}${
     */
 
     // Note: the stuff in the NaNofuzz pane should technically all be indented
+    console.log("env:", env);
 
     // Prettier abhorrently butchers this HTML, so disable prettier here
     // prettier-ignore
@@ -1012,8 +1014,8 @@ export function ${validatorPrefix}${
                 </vscode-button>
               </div>
               <div style="padding-top: 1.5em;">
-                <vscode-button ${disabledFlag} id="mode.validator" appearance="primary" style="width: 95%;">
-                  <p id="mode.validator"> <strong> Property Test: </strong> ${this._state === FuzzPanelState.busy ? "Testing..." : " Use a function to classify outputs as correct or incorrect"} </p>
+                <vscode-button ${disabledFlag} id="mode.property" appearance="primary" style="width: 95%;">
+                  <p id="mode.property"> <strong> Property Test: </strong> ${this._state === FuzzPanelState.busy ? "Testing..." : " Use a function to classify outputs as correct or incorrect"} </p>
                 </vscode-button>
               </div>
                 <p style="padding-top: .5em; text-align: center;">
@@ -1026,11 +1028,68 @@ export function ${validatorPrefix}${
 
         <!-- NaNofuzz pane -->
         <div id="pane-nanofuzz" class=${this._state === FuzzPanelState.init ? "hidden" : ""}> 
-          <h2 style="font-size:1.9em; padding-top: .25em;"> ${this._state === FuzzPanelState.busy ? "Testing..." : this._fuzzEnv.options.mode+": "+htmlEscape(
+          <h2 style="font-size:1.75em; padding-top:.2em;"> ${this._state === FuzzPanelState.busy ? "Testing..." : "Test: "+htmlEscape(
             fn.getName())+"()"} </h2>
 
           <!-- Function Arguments -->
           <div id="argDefs">${argDefHtml}</div>
+
+          <!-- THIS IS ME!!!!!!!!!! -->
+          <!-- Change validators options -->
+          <!-- radios (probably not) -->
+          <div class="hidden">
+          <p style="font-size:1.2em; margin-top: 0.1em; margin-bottom: 0.1em;"> <strong> Change validators: </strong> </p>
+          <vscode-radio-group orientation="vertical" style="padding-left: .75em;"> 
+            <vscode-radio ${disabledFlag} id="" name="onlyFailures.false" value="value-1" ${
+              !this._fuzzEnv.options.onlyFailures ? "checked" : ""}>
+              <strong> Fuzz: </strong> quickly check for likely bugs &nbsp;
+              <span class="codicon codicon-debug" style="font-size:1em"></span>
+              <span class="codicon codicon-person" style="font-size:1.15em"></span>
+            </vscode-radio>
+            <vscode-radio ${disabledFlag} id="" name="onlyFailures.true" value="value-2" ${
+              this._fuzzEnv.options.onlyFailures ? "checked" : ""}><strong> Example Test: </strong> classify outputs manually
+              <span class="codicon codicon-person" style="font-size:1.15em"></span>
+            </vscode-radio>
+            <vscode-radio ${disabledFlag} id="" name="onlyFailures.false" value="value-3" ${
+              !this._fuzzEnv.options.onlyFailures ? "checked" : ""}><strong> Property Test: </strong> classify outputs using a function
+              <span class="codicon codicon-hubot" style="font-size:1.15em"></span>
+              <span class="codicon codicon-person" style="font-size:1.15em"></span>
+            </vscode-radio>
+            <vscode-radio ${disabledFlag} id="" name="onlyFailures.true" value="value-4" ${
+              this._fuzzEnv.options.onlyFailures ? "checked" : ""}><strong> Custom... </strong> </vscode-radio>
+          </vscode-radio-group>
+          </div>
+
+          <!-- THISISME -->
+          <!-- Basic dropdown -->
+          <p style="font-size:1.2em; margin-top: 0.1em; margin-bottom: 0.3em;"> <strong> Select validators</strong>:</p>
+          <div style="padding-left: .76em; padding-bottom: .5em;">
+            <vscode-dropdown id="validator-dropdown" style="width: 26em;">
+              <vscode-option id="dropdown.fuzz" ${env.options.mode === "Fuzz" ? "selected" : ""}> <!--  style="font-size:1.1em;" -->
+                Fuzz: quickly check for likely bugs &nbsp;
+                <span class="codicon codicon-debug" style="font-size:1.1em; align-content: center;"></span>
+                <span class="codicon codicon-person" style="font-size:; align-self: baseline;"></span>
+              </vscode-option>
+              <vscode-option id="dropdown.example" ${env.options.mode === "Example Test" ? "selected" : ""}>
+                Example test: classify outputs manually
+                <span class="codicon codicon-person" style="font-size:; align-content: end;"></span>
+              </vscode-option>
+              <vscode-option id="dropdown.property" ${env.options.mode === "Property Test" ? "selected" : ""}>
+                Property test: classify outputs using a function
+                <span class="codicon codicon-hubot" style="font-size:; align-self: end;"></span>
+                <span class="codicon codicon-person" style="font-size:; align-self: self-end;"></span>
+              </vscode-option>
+              <!-- <vscode-option id="dropdown.custom"> Custom...</vscode-option> -->
+            </vscode-dropdown>
+            
+            <!-- checkboxes Currently not functional... -->
+            <!--
+            <div class="fuzzInputControlGroup">
+                  <vscode-checkbox id="fuzz-useImplicit" ${this._fuzzEnv.options.useImplicit ? "checked" : ""}>Use heuristic validator</vscode-checkbox>
+                  <vscode-checkbox id="fuzz-useHuman" ${this._fuzzEnv.options.useHuman ? "checked" : ""}>Use human validation</vscode-checkbox>
+                </div>
+                -->
+          </div>
 
           <vscode-divider></vscode-divider>
 
@@ -1047,6 +1106,7 @@ export function ${validatorPrefix}${
               <vscode-panel-tab aria-label="Stopping options tab">Stopping</vscode-panel-tab>
 
               <vscode-panel-view>
+              <!--
                 <p>
                   Validators categorize outputs as passed (✔︎) or failed (X). 
                   The <strong>heuristic validator</strong> automatically categorizes these outputs as failed: 
@@ -1057,8 +1117,9 @@ export function ${validatorPrefix}${
                   <vscode-checkbox id="fuzz-useImplicit" ${this._fuzzEnv.options.useImplicit ? "checked" : ""}>Use heuristic validator</vscode-checkbox>
                   <vscode-checkbox id="fuzz-useHuman" ${this._fuzzEnv.options.useHuman ? "checked" : ""}>Use human validation</vscode-checkbox>
                 </div>
+                -->
 
-                <div class=${this._fuzzEnv.options.mode === "Property Test" ? "" : ""}>
+                <!-- <div class=${this._fuzzEnv.options.mode === "Property Test" ? "" : ""}> -->
                   <p>
                     Use a <strong>custom validator function</strong> to automatically categorize outputs as passed (✔︎) or failed (X). 
                     Click the (+) button to create a new custom validator function.
@@ -1080,20 +1141,23 @@ export function ${validatorPrefix}${
                     </div> <!-- hiding validator function radios -->
 
                     <!-- THISISME -->
-                    <ul id="validatorFunctions-bullets"> 
-                    <vscode-button ${disabledFlag} id="validator.add" appearance="icon" aria-label="Add">
+                    <ul id="validatorFunctions-bullets" style="margin-top:.1em;"> 
+                    </ul>
+                    <div style="padding-left:1em;">
+                      <vscode-button ${disabledFlag} id="validator.add" appearance="icon" aria-label="Add">
                         <span class="tooltipped tooltipped-ne" aria-label="New validator function">
-                          <span class="codicon codicon-add"></span>
+                          <span class="codicon codicon-add" style="font-size:1.5em;"></span>
                         </span>
                       </vscode-button>
-                      <vscode-button ${disabledFlag} id="validator.getList" appearance="icon" aria-label="Refresh">
+                      <vscode-button ${disabledFlag} id="validator.getList" appearance="icon" aria-label="Refresh" style="margin-left:1.5em;">
                         <span class="tooltipped tooltipped-ne" aria-label="Refresh list">
-                          <span class="codicon codicon-refresh"></span>
+                          <span class="codicon codicon-refresh" style="font-size:1.5em;"></span>
                         </span>
-                    </ul>
+                      </vscode-button>
+                    </div>
                     <!-- THISISME -->
                   </div>
-                </div>
+                <!-- </div> -->
               </vscode-panel-view>
 
               <!-- HIDDENFORNOW -->
@@ -1156,7 +1220,7 @@ export function ${validatorPrefix}${
                   </vscode-text-field>
                 </div>
               </vscode-panel-view>
-            </vscode-panels>
+              </vscode-panels>
 
             <vscode-divider></vscode-divider>
           </div>
@@ -1164,7 +1228,7 @@ export function ${validatorPrefix}${
           <!-- Button Bar -->
           <div style="padding-top: .25em;">
             <vscode-button ${disabledFlag} id="fuzz.start" appearance="primary">
-              ${this._state === FuzzPanelState.busy ? "Testing..." : "Test"}
+              ${this._state === FuzzPanelState.busy ? "Testing..." : "Retest"}
             </vscode-button>
             <vscode-button  ${disabledFlag} id="fuzz.changeMode" appearance="secondary" aria-label="Change Mode">
               Change Mode
@@ -1209,7 +1273,28 @@ export function ${validatorPrefix}${
             <p>All tests passed.</p>
           </div>
           
-          
+          <!-- THISISME -->
+          <!--
+          <vscode-panels aria-label="Mode tabs" class="fuzzTabStrip">
+            <vscode-panel-tab aria-label="Fuzz tab" style="font-size:1.15em;">Fuzz &nbsp;
+              <span class="codicon codicon-debug" style="font-size:1em"></span>
+              <span class="codicon codicon-person" style="font-size:1.15em"></span>
+            </vscode-panel-tab>
+            <vscode-panel-tab aria-label="Example tab" style="font-size:1.15em;">Example Test&nbsp;
+              <span class="codicon codicon-person" style="font-size:1.15em"></span>
+            </vscode-panel-tab>
+            <vscode-panel-tab aria-label="Property tab" style="font-size:1.15em;">Property Test&nbsp;
+              <span class="codicon codicon-hubot" style="font-size:1.15em"></span>
+              <span class="codicon codicon-person" style="font-size:1.15em"></span>
+            </vscode-panel-tab>
+            <vscode-panel-tab aria-label="Custom tab" style="font-size:1.15em;">Custom&nbsp;
+              <span class="codicon codicon-debug" style="font-size:1em"></span>
+              <span class="codicon codicon-hubot" style="font-size:1.15em"></span>
+              <span class="codicon codicon-person" style="font-size:1.15em"></span>
+            </vscode-panel-tab>
+            <vscode-panel-view>
+          -->
+
           <!-- Fuzzer Output -->
           <div class="fuzzResults" ${
             this._state === FuzzPanelState.done
@@ -1430,6 +1515,11 @@ export function ${validatorPrefix}${
     html += /*html*/ `
             </vscode-panels>
           </div>`;
+
+    // THISISME
+    // html += `<vscode-panel-view>`;
+    // html += /*html*/ `
+    // </vscode-panels>`;
 
     // Hidden data for the client script to process
     html += /*html*/ `

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1085,10 +1085,10 @@ export function ${validatorPrefix}${
                 <vscode-checkbox id="fuzz-useProperty" ${this._fuzzEnv.options.useProperty ? "checked" : ""}>
                   Use custom functions <span id="validator-functionList" class="tooltipped tooltipped-n" aria-label=""> (see list) </span>
                 </vscode-checkbox>
-                <span id="validator.add" class="tooltipped tooltipped-n" aria-label="Add new custom function">
+                <span id="validator.add" class="tooltipped tooltipped-nw" aria-label="Add new custom function">
                   <span class="codicon codicon-add"></span>
                 </span>
-                <span id="validator.getList" class="tooltipped tooltipped-n" aria-label="Refresh list">
+                <span id="validator.getList" class="tooltipped tooltipped-nw" aria-label="Refresh list">
                   <span class="codicon codicon-refresh"></span>
                 </span>
               </span>

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -871,11 +871,15 @@ export function ${validatorPrefix}${
                   <span id="validator-functionList" class="tooltipped tooltipped-ne" aria-label=""> 
                   Use property validators </span>
                 </vscode-checkbox>
-                <span id="validator.add" class="tooltipped tooltipped-nw" aria-label="Add new property validator">
-                  <span class="codicon codicon-add"></span>
+                <span class="classAddRefreshValidator">
+                  <span id="validator.add" class="tooltipped tooltipped-nw" aria-label="Add new property validator">
+                    <span class="codicon codicon-add" style="padding-left:.2em; padding-right:-.1em;"></span>
+                  </span>
                 </span>
-                <span id="validator.getList" class="tooltipped tooltipped-nw" aria-label="Refresh list">
-                  <span class="codicon codicon-refresh"></span>
+                <span class="classAddRefreshValidator">
+                  <span id="validator.getList" class="tooltipped tooltipped-nw" aria-label="Refresh list">
+                    <span class="codicon codicon-refresh" style="padding-left:.1em;"></span>
+                  </span>
                 </span>
               </span>
             </div>

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1032,7 +1032,7 @@ export function ${validatorPrefix}${
           <!-- Function Arguments -->
           <div id="argDefs">${argDefHtml}</div>
 
-          
+          <vscode-divider></vscode-divider>
 
           <!-- Fuzzer Options -->
           <div id="fuzzOptions" class="hidden">

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -748,7 +748,7 @@ export function ${validatorPrefix}${
     });
 
     // Apply boolean fuzzer option changes
-    ["onlyFailures", "useImplicit", "useHuman"].forEach((e) => {
+    ["onlyFailures", "useImplicit", "useHuman", "useProperty"].forEach((e) => {
       if (e in panelInput.fuzzer && typeof panelInput.fuzzer[e] === "boolean") {
         this._fuzzEnv.options[e] = panelInput.fuzzer[e];
       }
@@ -1062,8 +1062,9 @@ export function ${validatorPrefix}${
 
           <!-- THISISME -->
           <!-- Basic dropdown -->
-          <p style="font-size:1.2em; margin-top: 0.1em; margin-bottom: 0.3em;"> <strong> Select validators</strong>:</p>
-          <div style="padding-left: .76em; padding-bottom: .5em;">
+          <p style="font-size:1.2em; margin-top: 0.1em; margin-bottom: 0.1em;"> <strong> Select validators</strong>:</p>
+          <div style="padding-left: .76em;">
+            <div class="hidden">
             <vscode-dropdown id="validator-dropdown" style="width: 26em;">
               <vscode-option id="dropdown.fuzz" ${env.options.mode === "Fuzz" ? "selected" : ""}> <!--  style="font-size:1.1em;" -->
                 Fuzz: quickly check for likely bugs &nbsp;
@@ -1081,14 +1082,41 @@ export function ${validatorPrefix}${
               </vscode-option>
               <!-- <vscode-option id="dropdown.custom"> Custom...</vscode-option> -->
             </vscode-dropdown>
+            <p></p>
+            </div>
             
-            <!-- checkboxes Currently not functional... -->
-            <!--
+            <!-- Checkboxes to select validator -->
             <div class="fuzzInputControlGroup">
-                  <vscode-checkbox id="fuzz-useImplicit" ${this._fuzzEnv.options.useImplicit ? "checked" : ""}>Use heuristic validator</vscode-checkbox>
-                  <vscode-checkbox id="fuzz-useHuman" ${this._fuzzEnv.options.useHuman ? "checked" : ""}>Use human validation</vscode-checkbox>
-                </div>
-                -->
+              <vscode-checkbox id="fuzz-useImplicit" ${this._fuzzEnv.options.useImplicit ? "checked" : ""}>Use heuristic validator</vscode-checkbox>
+              
+              <span style="padding-left:1.2em;"> </span>
+              <span>
+                <vscode-checkbox id="fuzz-useProperty" ${this._fuzzEnv.options.useProperty ? "checked" : ""}>Use custom functions 
+                  <span id="validator-functionList" class="tooltipped tooltipped-n" aria-label=""> (see list)
+                  </span>
+                </vscode-checkbox>
+
+                <span id="validator-functionList-icon" class="tooltipped tooltipped-n" aria-label="">
+                  <span class="codicon codicon-list-unordered"></span>
+                </span>
+                <span style="display:inline-block;">
+                  <span id="validator.add" class="tooltipped tooltipped-n" aria-label="Add new custom function">
+                    <span class="codicon codicon-add"></span>
+                  </span>
+                  <!-- <vscode-button ${disabledFlag} id="validator.add" appearance="icon" aria-label="Add" style="padding-bottom:5em;"> 
+                    <span class="tooltipped tooltipped-n" aria-label="New custom function">
+                      <span class="codicon codicon-add"></span>
+                    </span>
+                  </vscode-button>
+                  -->
+                  <vscode-button ${disabledFlag} id="validator.getList" appearance="icon" aria-label="Refresh" style="">
+                    <span class="tooltipped tooltipped-n" aria-label="Refresh list">
+                      <span class="codicon codicon-refresh"></span>
+                    </span>
+                  </vscode-button>
+                </span>
+              </span>
+            </div>
           </div>
 
           <vscode-divider></vscode-divider>
@@ -1228,7 +1256,7 @@ export function ${validatorPrefix}${
           <!-- Button Bar -->
           <div style="padding-top: .25em;">
             <vscode-button ${disabledFlag} id="fuzz.start" appearance="primary">
-              ${this._state === FuzzPanelState.busy ? "Testing..." : "Retest"}
+              ${this._state === FuzzPanelState.busy ? "Testing..." : "Test"}
             </vscode-button>
             <vscode-button  ${disabledFlag} id="fuzz.changeMode" appearance="secondary" aria-label="Change Mode">
               Change Mode
@@ -1374,11 +1402,9 @@ export function ${validatorPrefix}${
       (env.options.useHuman ? validatorsUsed : validatorsNotUsed).push(
         "<strong>human</strong>"
       );
-      if (
-        "validator" in env &&
-        env.validator &&
-        env.options.mode === "Property Test"
-      ) {
+      // THISISME
+      // checkboxes
+      if ("validator" in env && env.validator && env.options.useProperty) {
         env.validators.forEach((e) => {
           validatorsUsed.push(`<strong>custom function (${e.name})</strong>`);
         });
@@ -1989,6 +2015,7 @@ export const getDefaultFuzzOptions = (): fuzzer.FuzzOptions => {
       .get("onlyFailures", false),
     useHuman: true,
     useImplicit: true,
+    useProperty: false,
     mode: "Fuzz",
   };
 }; // fn: getDefaultFuzzOptions()

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -871,13 +871,13 @@ export function ${validatorPrefix}${
                   <span id="validator-functionList" class="tooltipped tooltipped-ne" aria-label=""> 
                   Use property validators </span>
                 </vscode-checkbox>
-                <span class="classAddRefreshValidator">
-                  <span id="validator.add" class="tooltipped tooltipped-nw" aria-label="Add new property validator">
+                <span id="validator.add" class="tooltipped tooltipped-nw" aria-label="Add new property validator">
+                  <span class="classAddRefreshValidator">
                     <span class="codicon codicon-add" style="padding-left:.2em; padding-right:-.1em;"></span>
                   </span>
                 </span>
-                <span class="classAddRefreshValidator">
-                  <span id="validator.getList" class="tooltipped tooltipped-nw" aria-label="Refresh list">
+                <span id="validator.getList" class="tooltipped tooltipped-nw" aria-label="Refresh list">
+                  <span class="classAddRefreshValidator">
                     <span class="codicon codicon-refresh" style="padding-left:.1em;"></span>
                   </span>
                 </span>


### PR DESCRIPTION
- Checkbox to turn on/off implicit validator and property validator
- Support for multiple property validators
- Expandable/collapsible columns for individual property validators; summary column for property validator
- Twistie column to expand only shows up if there are > 1 property validators
- Fixing bug where the strCharSet from the json config file was not being used to generate strings (might still be a better way to do this)
- Simplified `Result` data structure for writing property validators
- Changing opacity when clicking human validator buttons, plus (+), or refresh buttons (to make them 'blink')