### PR TITLE
Fix #139: Input ranges not restored

### DIFF
--- a/assets/ui/FuzzPanelMain.js
+++ b/assets/ui/FuzzPanelMain.js
@@ -419,7 +419,7 @@ function toggleFuzzOptions(e) {
     fuzzOptionsButton.innerHTML = "Fewer options";
   } else {
     toggleHidden(fuzzOptions);
-    fuzzOptionsButton.innerHTML = "More options";
+    fuzzOptionsButton.innerHTML = "More options...";
   }
 
   // Refresh the list of validators

--- a/assets/ui/FuzzPanelMain.js
+++ b/assets/ui/FuzzPanelMain.js
@@ -1289,6 +1289,7 @@ function handleFuzzStart(eCurrTarget) {
     const falseOnly = document.getElementById(idBase + "-falseOnly");
     const minStrLen = document.getElementById(idBase + "-minStrLen");
     const maxStrLen = document.getElementById(idBase + "-maxStrLen");
+    const strCharset = document.getElementById(idBase + "-strCharset");
 
     // Process numeric overrides
     if (numInteger !== null) {
@@ -1323,6 +1324,7 @@ function handleFuzzStart(eCurrTarget) {
       disableArr.push(minStrLen, maxStrLen);
       const minStrLenVal = minStrLen.getAttribute("current-value");
       const maxStrLenVal = maxStrLen.getAttribute("current-value");
+      const strCharsetVal = strCharset.getAttribute("current-value");
       if (minStrLenVal !== undefined && maxStrLenVal !== undefined) {
         thisOverride.string = {
           minStrLen: Math.max(
@@ -1330,6 +1332,7 @@ function handleFuzzStart(eCurrTarget) {
             Math.min(Number(minStrLenVal), Number(maxStrLenVal))
           ),
           maxStrLen: Math.max(Number(minStrLenVal), Number(maxStrLenVal), 0),
+          strCharset: strCharsetVal,
         };
       }
     } // TODO: Validation !!!

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nanofuzz",
   "displayName": "NaNofuzz",
   "publisher": "penrose",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "NaNofuzz is a fast and easy-to-use automatic test suite generator for TypeScript that runs inside VS Code",
   "repository": "https://github.com/nanofuzz/nanofuzz.git",
   "author": "The NaNofuzz Team @ Carnegie Mellon University",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,12 @@
           "default": true,
           "description": "Show 'NaNofuzz' button for property validator functions?"
         },
+        "nanofuzz.ui.codeLens.ignoreFilePattern": {
+          "title": "Regex of files for NaNofuzz to ignore",
+          "type": "string",
+          "default": "",
+          "description": "Regex of files for NaNofuzz to ignore"
+        },
         "nanofuzz.argdef.strCharset": {
           "title": "String character set",
           "type": "string",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -2,7 +2,7 @@
   "name": "@nanofuzz/runtime",
   "displayName": "NaNofuzz runtime support",
   "publisher": "penrose",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Runtime support and types for NaNofuzz",
   "repository": {
     "type": "git",

--- a/src/fuzzer/Types.ts
+++ b/src/fuzzer/Types.ts
@@ -130,6 +130,7 @@ export type FuzzArgOverride = {
   string?: {
     minStrLen: number;
     maxStrLen: number;
+    strCharset: string;
   };
   array?: {
     dimLength: { min: number; max: number }[];

--- a/src/fuzzer/generators/GeneratorFactory.test.ts
+++ b/src/fuzzer/generators/GeneratorFactory.test.ts
@@ -230,15 +230,15 @@ const testRandomString = (
   for (let i = 0; i < 1000; i++) {
     results.push(gen());
   }
-  if (strMin !== strMax) {
-    expect(results.some((e) => e !== strMin)).toBeTruthy();
-    expect(results.some((e) => e !== strMax)).toBeTruthy();
-  }
+  //if (strMin !== strMax) {
+  //  expect(results.some((e) => e !== strMin)).toBeTruthy();
+  //  expect(results.some((e) => e !== strMax)).toBeTruthy();
+  //}
   results.forEach((result) => {
     expect(result.length).toBeGreaterThanOrEqual(strLenMin);
     expect(result.length).toBeLessThanOrEqual(strLenMax);
-    expect(result >= strMin).toBeTruthy();
-    expect(result <= strMax).toBeTruthy();
+    //expect(result >= strMin).toBeTruthy();
+    //expect(result <= strMax).toBeTruthy();
   });
 };
 

--- a/src/fuzzer/generators/GeneratorFactory.ts
+++ b/src/fuzzer/generators/GeneratorFactory.ts
@@ -187,49 +187,23 @@ const getRandomString = <T extends ArgType>(
   const charSet = options.strCharset;
   const intOptions = ArgDef.getDefaultOptions(); // use default for integer selection
 
-  // Happify tsc
-  let minStr: string = min;
-  let maxStr: string = max;
-
-  // Determine the length of the output string
-  const strLen =
-    options.strLength.min === options.strLength.max
-      ? options.strLength.min
-      : getRandomNumber(
-          prng,
-          Math.max(options.strLength.min, min.length),
-          options.strLength.max,
-          intOptions
-        ); // use default for integer selection
-
-  // Pad min and max to the minimum length, if required
-  if (minStr.length < strLen) minStr = minStr.padEnd(strLen, charSet[0]);
-  if (maxStr.length < strLen) maxStr = maxStr.padEnd(strLen, charSet[0]);
+  // This generator does not currently support min and max, but we don't make
+  // that option available in the UI anyway. Find the old code in v0.3.2 and fix
+  // intervals for string types when it's time to implement this.
+  const strLen = getRandomNumber(
+    prng,
+    options.strLength.min,
+    options.strLength.max,
+    intOptions
+  ); // use default for integer selection
 
   // Sequentially choose each character in the string
   // Note: This provides a uniform distribution at each position, but
   //       the distribution of output is not uniform.
+  const charSetLen = charSet.length - 1;
   let outStr = "";
   for (let i = 0; i < strLen; i++) {
-    const minThisCharPos = charSet.indexOf(
-      outStr === minStr.substring(0, i) ? minStr[i] : charSet[0]
-    );
-    const maxThisCharPos = charSet.indexOf(
-      outStr === maxStr.substring(0, i)
-        ? maxStr[i]
-        : charSet[charSet.length - 1]
-    );
-    const thisChar =
-      charSet[
-        minThisCharPos === maxThisCharPos
-          ? minThisCharPos
-          : getRandomNumber(prng, minThisCharPos, maxThisCharPos, intOptions)
-      ];
-    outStr += thisChar;
-
-    // Break out of the loop if we reach the max padded value
-    if (outStr === max.padEnd(options.strLength.min, options.strCharset[0]))
-      break;
+    outStr += charSet[getRandomNumber(prng, 0, charSetLen, intOptions)];
   }
 
   return outStr as T;

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -210,11 +210,9 @@ export class FuzzPanel {
     this._fuzzEnv.options = testSet.options;
     this._argOverrides = testSet.argOverrides ?? [];
     this._sortColumns = testSet.sortColumns;
+
+    // Apply argument ranges, etc. over the defaults
     _applyArgOverrides(this._fuzzEnv.function, this._argOverrides);
-    // TODO: There is likely a bug somewhere related to initializing the arg options !!!
-    // Options configured in the json file are correct in `this._fuzzEnv.options`, but are not carried over
-    // in `this._fuzzEnv.function._argDefs`
-    this._fuzzEnv.function.applyOptions(testSet.options.argDefaults);
 
     // Set the webview's initial html content
     this._updateHtml();
@@ -357,6 +355,25 @@ export class FuzzPanel {
       if (inputTests.version === CURR_FILE_FMT_VER) {
         // current format -- no changes needed
         return inputTests;
+      } else if (inputTests.version === "0.3.0") {
+        // v0.3.0 format -- infer arg strCharset override from function default
+        const testSet = { ...inputTests, version: CURR_FILE_FMT_VER };
+        for (const fn in testSet.functions) {
+          const thisFn = testSet.functions[fn];
+          if (thisFn.argOverrides) {
+            for (const i in thisFn.argOverrides) {
+              const arg = thisFn.argOverrides[i];
+              // strings overrides only
+              if (arg.string && !arg.string.strCharset) {
+                arg.string.strCharset = thisFn.options.argDefaults.strCharset;
+              }
+            }
+          }
+        }
+        console.info(
+          `Upgraded test set in file ${jsonFile} to ${inputTests.version} to ${testSet.version}`
+        );
+        return testSet;
       } else if (inputTests.version === "0.2.1") {
         // v0.2.1 format -- infer useProperty option & turn on useHuman (the latter
         // is req'd b/c we eliminated the UI button that controls this)
@@ -1402,6 +1419,10 @@ export function ${validatorPrefix}${
         html += /*html*/ `<vscode-text-field size="3" ${disabledFlag} id="${idBase}-maxStrLen" name="${idBase}-max" value="${htmlEscape(
           arg.getOptions().strLength.max.toString()
         )}">Max length</vscode-text-field>`;
+        html += " ";
+        html += /*html*/ `<vscode-text-field size="10" ${disabledFlag} id="${idBase}-strCharset" name="${idBase}-strCharset" value="${htmlEscape(
+          arg.getOptions().strCharset
+        )}">Characters</vscode-text-field>`;
         break;
       }
 
@@ -1692,6 +1713,7 @@ function _applyArgOverrides(
               min: Number(thisOverride.string.minStrLen),
               max: Number(thisOverride.string.maxStrLen),
             },
+            strCharset: thisOverride.string.strCharset,
           });
         }
         break;
@@ -1799,7 +1821,7 @@ const fuzzPanelStateVer = "FuzzPanelStateSerialized-0.2.1";
 /**
  * Current file format version for persisting test sets / pinned test cases
  */
-const CURR_FILE_FMT_VER = "0.3.0"; // !!!! Increment if file format changes
+const CURR_FILE_FMT_VER = "0.3.3"; // !!!! Increment if file format changes
 
 // ----------------------------- Types ----------------------------- //
 

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1614,6 +1614,15 @@ export function provideCodeLenses(
     const program = ProgramDef.fromModuleAndSource(document.fileName, () =>
       document.getText()
     );
+    // Skip analyzing files that we are configured to ignore
+    const fuzzIgnore: string = vscode.workspace
+      .getConfiguration("nanofuzz.ui.codeLens")
+      .get("ignoreFilePattern", "");
+    if (fuzzIgnore !== "" && document.fileName.match(fuzzIgnore)) {
+      return [];
+    }
+
+    // Skip decorating validators if configured to skip them
     const fuzzValidators: boolean = vscode.workspace
       .getConfiguration("nanofuzz.ui.codeLens")
       .get("includeValidators", true);


### PR DESCRIPTION
Corrects the issue where input ranges were not restored when reloading the fuzz panel. This change also:
- Adds an UI control on the fuzz panel so the user may set the string generator alphabet
- Adds a new option (`nanofuzz.ui.codeLens.ignoreFilePattern`) that tells NaNofuzz to ignore files that match a regex. This feature is mostly to support running studies.