### PR TITLE
[HOLD] feat: support string min/max ranges in generator

### DIFF
--- a/src/fuzzer/generators/GeneratorFactory.test.ts
+++ b/src/fuzzer/generators/GeneratorFactory.test.ts
@@ -230,15 +230,21 @@ const testRandomString = (
   for (let i = 0; i < 1000; i++) {
     results.push(gen());
   }
-  //if (strMin !== strMax) {
-  //  expect(results.some((e) => e !== strMin)).toBeTruthy();
-  //  expect(results.some((e) => e !== strMax)).toBeTruthy();
-  //}
+  if (strMin !== strMax) {
+    // Expect: strMin <= output <= strMax
+    expect(results.every((e) => e >= strMin && e <= strMax)).toBeTruthy();
+    // Ensure that we're not always generating strMin or strMax
+    expect(results.some((e) => e !== strMin)).toBeTruthy();
+    expect(results.some((e) => e !== strMax)).toBeTruthy();
+  } else if (strMin === strMax) {
+    // Constant value, so all outputs should = strMin
+    expect(results.every((e) => e === strMin)).toBeTruthy();
+  }
   results.forEach((result) => {
     expect(result.length).toBeGreaterThanOrEqual(strLenMin);
     expect(result.length).toBeLessThanOrEqual(strLenMax);
-    //expect(result >= strMin).toBeTruthy();
-    //expect(result <= strMax).toBeTruthy();
+    expect(result >= strMin).toBeTruthy();
+    expect(result <= strMax).toBeTruthy();
   });
 };
 

--- a/src/fuzzer/generators/GeneratorFactory.ts
+++ b/src/fuzzer/generators/GeneratorFactory.ts
@@ -187,6 +187,9 @@ const getRandomString = <T extends ArgType>(
   const charSet = options.strCharset;
   const intOptions = ArgDef.getDefaultOptions(); // use default for integer selection
 
+  // TODO: Add Support for strMin & strMax such that strMin <= output strMax
+  //       See pre-v0.3.3 code for a partially working example !!!!!!
+
   // This generator does not currently support min and max, but we don't make
   // that option available in the UI anyway. Find the old code in v0.3.2 and fix
   // intervals for string types when it's time to implement this.


### PR DESCRIPTION
This set of WIP changes aims to complete the pre-v0.3.3 support for `strMin` and `strMax` for strings by, e.g., redetermining intervals when `strMin`, `strMax`, or `strCharset` are changed. Consider this to be starter code--much more work is needed to complete this change. This PR aims to resolve #141.