### PR TITLE
Fix #143 and #136

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nanofuzz",
   "displayName": "NaNofuzz",
   "publisher": "penrose",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "NaNofuzz is a fast and easy-to-use automatic test suite generator for TypeScript that runs inside VS Code",
   "repository": "https://github.com/nanofuzz/nanofuzz.git",
   "author": "The NaNofuzz Team @ Carnegie Mellon University",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -2,7 +2,7 @@
   "name": "@nanofuzz/runtime",
   "displayName": "NaNofuzz runtime support",
   "publisher": "penrose",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Runtime support and types for NaNofuzz",
   "repository": {
     "type": "git",

--- a/src/fuzzer/Compiler.ts
+++ b/src/fuzzer/Compiler.ts
@@ -216,7 +216,9 @@ function compileTS(module: any) {
   // Execute the module script
   tscScript.runInNewContext(sandbox);
   if (exitCode !== 0) {
-    throw new Error("Unable to compile TypeScript file.");
+    throw new Error(
+      `Unable to compile TypeScript file. Please check it for errors.<br /><br />File: ${module.filename}`
+    );
   }
 
   return jsname;

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1422,7 +1422,7 @@ export function ${validatorPrefix}${
         html += " ";
         html += /*html*/ `<vscode-text-field size="10" ${disabledFlag} id="${idBase}-strCharset" name="${idBase}-strCharset" value="${htmlEscape(
           arg.getOptions().strCharset
-        )}">Characters</vscode-text-field>`;
+        )}">Character set</vscode-text-field>`;
         break;
       }
 
@@ -1722,7 +1722,11 @@ function _applyArgOverrides(
               min: Number(thisOverride.string.minStrLen),
               max: Number(thisOverride.string.maxStrLen),
             },
-            strCharset: thisOverride.string.strCharset,
+            // Character set: note: empty sets are invalid
+            strCharset:
+              thisOverride.string.strCharset === ""
+                ? " "
+                : thisOverride.string.strCharset,
           });
         }
         break;

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -212,7 +212,11 @@ export class FuzzPanel {
     this._sortColumns = testSet.sortColumns;
 
     // Apply argument ranges, etc. over the defaults
-    _applyArgOverrides(this._fuzzEnv.function, this._argOverrides);
+    _applyArgOverrides(
+      this._fuzzEnv.function,
+      this._argOverrides,
+      this._fuzzEnv.options.argDefaults
+    );
 
     // Set the webview's initial html content
     this._updateHtml();
@@ -708,7 +712,7 @@ export function ${validatorPrefix}${
     });
 
     // Apply the argument overrides from the front-end UI
-    _applyArgOverrides(fn, panelInput.args);
+    _applyArgOverrides(fn, panelInput.args, this._fuzzEnv.options.argDefaults);
 
     // Update the UI
     this._results = undefined;
@@ -1670,7 +1674,8 @@ export function provideCodeLenses(
  */
 function _applyArgOverrides(
   fn: fuzzer.FunctionDef,
-  argOverrides: fuzzer.FuzzArgOverride[]
+  argOverrides: fuzzer.FuzzArgOverride[],
+  argDefaults: fuzzer.ArgOptions
 ) {
   // Get the flattened list of function arguments
   const argsFlat = fn.getArgDefsFlat();
@@ -1722,10 +1727,10 @@ function _applyArgOverrides(
               min: Number(thisOverride.string.minStrLen),
               max: Number(thisOverride.string.maxStrLen),
             },
-            // Character set: note: empty sets are invalid
+            // Character set. Note: empty sets are invalid
             strCharset:
               thisOverride.string.strCharset === ""
-                ? " "
+                ? argDefaults.strCharset
                 : thisOverride.string.strCharset,
           });
         }


### PR DESCRIPTION
Fix #143 by using the fuzzer's default `strCharset` when the one from the UI is an empty string. This is similar to how we treat other UI fields when they are cleared.

Fix #136 by expanding the error message such that it now suggests the user check the file for errors and we also now provide the filename.

Update the NaNofuzz version to `v0.3.4`.