### PR TITLE
fix: resolve #147

### DIFF
--- a/assets/ui/FuzzPanelMain.js
+++ b/assets/ui/FuzzPanelMain.js
@@ -1392,69 +1392,11 @@ function handleFuzzStart(eCurrTarget) {
  * }
  */
 function refreshValidators(validatorList) {
-  // If no default validator is selected or the selected validator does not
-  // exist, then select the implicit validator
-  if (
-    "validator" in validatorList &&
-    validatorList.validator !== undefined &&
-    validatorList.validators.some((e) => e === validatorList.validator)
-  ) {
-    // noop; we have a valid validator
-  } else {
-    validatorList.validator = implicitOracleValidatorName;
-  }
-
   const validatorFnList = document.getElementById("validator-functionList");
   validatorFnList.setAttribute(
     "aria-label",
     listForValidatorFnTooltip(validatorList)
   );
-
-  // // Get the current list of validator controls
-  // const validatorFnGrp = document.getElementById("validatorFunctions-radios");
-
-  // // Add the validator function buttons to the delete list & delete them
-  // const deleteList = [];
-  // for (const child of validatorFnGrp.children) {
-  //   if (child.tagName === "VSCODE-RADIO") {
-  //     deleteList.push(child);
-  //   }
-  // }
-  // deleteList.forEach((e) => validatorFnGrp.removeChild(e)); // buh bye
-
-  // // Add buttons w/event listeners for each validator option
-  // [implicitOracleValidatorName, ...validatorList.validators]
-  //   .reverse() // because of pre-pending before add and refresh buttons
-  //   .forEach((name) => {
-  //     // The implicit oracle has a special display name
-  //     const displayName =
-  //       name === implicitOracleValidatorName ? "(none)" : `${name}()`;
-
-  //     // Create the radio button
-  //     const radio = document.createElement("vscode-radio");
-  //     radio.setAttribute("id", `validator-${name}`);
-  //     radio.setAttribute("name", name);
-  //     radio.setAttribute("value", name);
-  //     if (validatorList.disabled) {
-  //       radio.setAttribute("disabled", "true");
-  //     }
-  //     radio.innerHTML = displayName;
-  //     if (name === validatorList.validator) {
-  //       radio.setAttribute("checked", "true");
-  //     }
-
-  //     // Add the radio button to the radio group
-  //     validatorFnGrp.prepend(radio);
-
-  //     // Add the onClick event handler
-  //     radio.addEventListener("click", (e) => {
-  //       handleSetValidator(e);
-  //     });
-  //   });
-
-  // // Set the radio group's value b/c this is necessary to maintain
-  // // consistent button state when a selected radio is deleted
-  // validatorFnGrp.setAttribute("value", validatorList.validator);
 } // fn: refreshValidators
 
 /**
@@ -1469,24 +1411,6 @@ function handleAddValidator(e) {
     json: JSON5.stringify(""),
   });
 } // fn: handleAddValidator()
-
-/**
- * Send message to back-end to save the validator that the user selected
- * using the radio buttons
- *
- * @param e on-click event
- */
-function handleSetValidator(validatorList) {
-  const validatorName = validatorList.currentTarget.getAttribute("name");
-
-  // Update the back-end with the newly-selected validator function
-  vscode.postMessage({
-    command: "validator.set",
-    json: JSON5.stringify(
-      validatorName === implicitOracleValidatorName ? "" : validatorName
-    ),
-  });
-} // fn: handleSetValidator()
 
 /**
  * Send message to back-end to refresh the validators

--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -252,11 +252,7 @@ export const fuzz = async (
 
     // CUSTOM VALIDATOR ------------------------------------------
     // If a custom validator is selected, call it to evaluate the result
-    if (
-      "validator" in env &&
-      env.validators.length &&
-      env.options.useProperty
-    ) {
+    if (env.validators.length && env.options.useProperty) {
       // const fnName = env.validator;
       result.passedValidators = [];
 
@@ -589,7 +585,6 @@ export function categorizeResult(
 export type FuzzEnv = {
   options: FuzzOptions; // fuzzer options
   function: FunctionDef; // the function to fuzz
-  validator?: string; // name of the current validator function (if any)
   validators: FunctionRef[]; // list of the module's functions
 };
 

--- a/src/fuzzer/Types.ts
+++ b/src/fuzzer/Types.ts
@@ -45,7 +45,7 @@ export type FuzzTestsFunction = {
   options: FuzzOptions; // fuzzer options
   argOverrides?: FuzzArgOverride[]; // argument overrides
   sortColumns?: FuzzSortColumns; // column sort order
-  validator?: string; // validator function
+  validators: string[]; // validator functions
   tests: Record<string, FuzzPinnedTest>; // pinned tests
 };
 

--- a/src/fuzzer/adapters/JestAdapter.ts
+++ b/src/fuzzer/adapters/JestAdapter.ts
@@ -1,4 +1,4 @@
-import { FuzzTests, FuzzTestResult, implicitOracle } from "../Fuzzer";
+import { FuzzTests, Result, implicitOracle } from "../Fuzzer";
 import * as JSON5 from "json5";
 import * as os from "os";
 import * as path from "path";
@@ -14,16 +14,11 @@ import * as path from "path";
 export const toString = (testSet: FuzzTests, module: string): string => {
   const jestData: string[] = [];
   const moduleFn = path.basename(module).split(".").slice(0, -1).join("."); // remove .ts/.tsx
-  const result: FuzzTestResult = {
-    passedImplicit: false,
-    validatorException: false,
+  const result: Result = {
     timeout: false,
     exception: false,
-    input: [],
-    output: [{ name: "0", offset: 0, value: undefined }],
-    elapsedTime: 0,
-    category: "unknown",
-    pinned: true,
+    in: [],
+    out: undefined,
   };
 
   // Auto-generated warning comment
@@ -33,6 +28,8 @@ export const toString = (testSet: FuzzTests, module: string): string => {
     ` *`,
     ` * This file is auto-generated and maintained by NaNofuzz.`,
     ` * NaNofuzz will overwrite changes made to this file.`,
+    ` *`,
+    ` * NaNofuzz version: ${testSet.version}`,
     ` */`
   );
 
@@ -45,23 +42,18 @@ export const toString = (testSet: FuzzTests, module: string): string => {
     `const implicitOracle = ${implicitOracle.toString()};`,
     ``,
     `// @ts-ignore`,
-    `const runCustomValidator = (input,testFn,validFn,timeout,useImplicit) => {`,
-    `  const testResult = ${JSON5.stringify(result)};`,
-    `  testResult.input = input;`,
+    `const runCustomValidator = (input,testFn,validFn,timeout) => {`,
+    `  const result = {...${JSON5.stringify(result)},out:undefined};`,
+    `  result.in = input;`,
     `  const startElapsedTime = performance.now(); // start timer`,
     `  try {`,
-    `    testResult.output[0]["value"] = testFn();`,
+    `    result.out = testFn();`,
     `  } catch(e: any) {`,
-    `    testResult.exception = true;`,
-    `    testResult["exceptionMessage"] = e.message;`,
+    `    result.exception = true;`,
     `  }`,
-    `  testResult.elapsedTime = performance.now() - startElapsedTime; // stop timer`,
-    `  testResult.passedImplicit = useImplicit`,
-    `   ? implicitOracle(testResult.output[0]["value"])`,
-    `   : true;`,
-    `  testResult["passedValidator"] = validFn({...testResult})["passedValidator"];`,
-    `  testResult.timeout = testResult.elapsedTime > timeout;`,
-    `  return testResult;`,
+    `  const elapsedTime = performance.now() - startElapsedTime; // stop timer`,
+    `  result.timeout = elapsedTime > timeout;`,
+    `  return validFn({...result});`,
     `}`,
     ``
   );
@@ -115,30 +107,24 @@ export const toString = (testSet: FuzzTests, module: string): string => {
           );
         }
       }
-
-      // Custom validator
-      if (thisFn.validator) {
-        // prettier-ignore
-        jestData.push(
+      // Property validators
+      if (thisFn.options.useProperty) {
+        for (const validator of thisFn.validators) {
+          // prettier-ignore
+          jestData.push(
           `  // Expect custom validator to not return false`,
-          `  // If no validator decision, fallback to heuristic oracle`,
-          `  test("${fn}.${i}.custom", () => {`,
-          `    const testResult = runCustomValidator( ${JSON5.stringify(thisTest.input)}, () => themodule.${fn}(${inputStr}), themodule.${thisFn.validator}, ${timeout}, ${thisFn.options.useImplicit});`,
-          `    expect(testResult.timeout).toBeFalsy();`,
-          `    if(testResult["passedValidator"]!==undefined) {`,
-          `      expect(testResult["passedValidator"]).not.toBeFalsy();`,
-          `    } else {`,
-          `      expect(testResult["passedImplicit"]).not.toBeFalsy();`,
-          `    }`,
+          `  test("${fn}.${i}.${validator}", () => {`,
+          `    expect(runCustomValidator( ${JSON5.stringify(thisTest.input)}, () => themodule.${fn}(${inputStr}), themodule.${validator}, ${thisFn.options.fnTimeout})).not.toBeFalsy();`,
           `  });`,
           ``,
         );
+        }
       }
 
       // Heuristic oracle - run only if it is turned on AND no other oracle is present
       if (
         thisFn.options.useImplicit &&
-        !thisFn.validator &&
+        !(thisFn.options.useProperty && thisFn.validators.length) &&
         !(thisFn.options.useHuman && expectedOutput)
       ) {
         jestData.push(


### PR DESCRIPTION
Output Jest test cases for each pinned test and property validator used by the fuzzer when property validation is enabled. This change also removes the old `validator?` fields as they are unused.