### PR TITLE
fix: Change the validator generator output to use `boolean | undefined` as the return type

### DIFF
--- a/src/fuzzer/Types.ts
+++ b/src/fuzzer/Types.ts
@@ -1,5 +1,13 @@
 import { ArgOptions } from "./analysis/typescript/Types";
 
+export type ResultCateogry =
+  | "failure"
+  | "timeout"
+  | "exception"
+  | "badValue"
+  | "ok"
+  | "disagree";
+
 /**
  * Single Fuzzer Test Result
  */
@@ -20,7 +28,7 @@ export type FuzzTestResult = {
   validatorExceptionStack?: string; // validator stack trace if exception was thrown
   elapsedTime: number; // elapsed time of test
   expectedOutput?: FuzzIoElement[]; // the expected output, if any
-  category: string; // the ResultCategory of the test result
+  category: ResultCateogry; // the ResultCategory of the test result
 };
 
 /**

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -672,14 +672,26 @@ export function ${validatorPrefix}${
     const fn = this._fuzzEnv.function;
 
     // Apply numeric fuzzer option changes
-    ["suiteTimeout", "maxTests", "maxFailures", "fnTimeout"].forEach((e) => {
+    const numericOptions = [
+      "suiteTimeout",
+      "maxTests",
+      "maxFailures",
+      "fnTimeout",
+    ] as const;
+    numericOptions.forEach((e) => {
       if (e in panelInput.fuzzer && typeof panelInput.fuzzer[e] === "number") {
         this._fuzzEnv.options[e] = panelInput.fuzzer[e];
       }
     });
 
     // Apply boolean fuzzer option changes
-    ["onlyFailures", "useImplicit", "useHuman", "useProperty"].forEach((e) => {
+    const booleanOptions = [
+      "onlyFailures",
+      "useImplicit",
+      "useHuman",
+      "useProperty",
+    ] as const;
+    booleanOptions.forEach((e) => {
       if (e in panelInput.fuzzer && typeof panelInput.fuzzer[e] === "boolean") {
         this._fuzzEnv.options[e] = panelInput.fuzzer[e];
       }
@@ -1041,7 +1053,20 @@ export function ${validatorPrefix}${
             <vscode-panels aria-label="Test result tabs" class="fuzzTabStrip">`;
 
     // If we have results, render the output tabs to display the results.
-    const tabs = [
+    const tabs: (
+      | {
+          id: fuzzer.ResultCateogry;
+          name: string;
+          description: string;
+          hasGrid: boolean;
+        }
+      | {
+          id: "runInfo";
+          name: string;
+          description: string;
+          hasGrid: false;
+        }
+    )[] = [
       {
         id: "failure",
         name: "Validator Error",

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -602,7 +602,7 @@ export class FuzzPanel {
 
 export function ${validatorPrefix}${
         fnCounter === 0 ? "" : fnCounter
-      }(r: FuzzTestResult): boolean {
+      }(r: FuzzTestResult): boolean | undefined {
   // Array of inputs: r.in   Output: r.out
   // return false; // <-- Unexpected; failed
   return true;


### PR DESCRIPTION
Fixes #168.

Note this is PR contains the changes in #177 - I was trying to create dependent PRs but forgot it cannot target #177 since it is from a fork and not a branch in the main repository 😅 