### PR TITLE
fix: clarify maxDupeInputs on (i) tab

### DIFF
--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1142,7 +1142,7 @@ export function ${validatorPrefix}${
           } ${toolName} also executed.`,
         [fuzzer.FuzzStopReason.MAXDUPES]: `because it reached the configured maximum number of sequentially-generated duplicate inputs configured (${
             this._results.env.options.maxDupeInputs
-          }). This can mean that NaNofuzz is having difficulty generating new inputs: the function's input space may be small or near exhaustion. You can change this setting in More Options.`,
+          }). This can mean that NaNofuzz is having difficulty generating further new inputs: the function's input space might be small or near exhaustion. You can change this setting in More Options.`,
         "": `because of an unknown reason.`,
       };
 

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1140,7 +1140,7 @@ export function ${validatorPrefix}${
           }). This is in addition to the ${this._results.inputsSaved} saved test${
             this._results.inputsSaved !== 1 ? "s" : ""
           } ${toolName} also executed.`,
-        [fuzzer.FuzzStopReason.MAXDUPES]: `because it reached the configured maximum number of sequentially-generated duplicate inputs configured (${
+        [fuzzer.FuzzStopReason.MAXDUPES]: `because it reached the maximum number of sequentially-generated duplicate inputs configured (${
             this._results.env.options.maxDupeInputs
           }). This can mean that NaNofuzz is having difficulty generating further new inputs: the function's input space might be small or near exhaustion. You can change this setting in More Options.`,
         "": `because of an unknown reason.`,

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1140,9 +1140,9 @@ export function ${validatorPrefix}${
           }). This is in addition to the ${this._results.inputsSaved} saved test${
             this._results.inputsSaved !== 1 ? "s" : ""
           } ${toolName} also executed.`,
-        [fuzzer.FuzzStopReason.MAXDUPES]: `because it reached the maximum number of duplicate tests configured (${
+        [fuzzer.FuzzStopReason.MAXDUPES]: `because it reached the configured maximum number of sequentially-generated duplicate inputs configured (${
             this._results.env.options.maxDupeInputs
-          }). Often this means the function's input space is small.`,
+          }). This can mean that NaNofuzz is having difficulty generating new inputs: the function's input space may be small or near exhaustion. You can change this setting in More Options.`,
         "": `because of an unknown reason.`,
       };
 


### PR DESCRIPTION
Fixed #185 by clarifying `maxDupeInputs` meaning on (i) tab:

> NaNofuzz stopped testing because it reached the configured maximum number of sequentially-generated duplicate inputs (maxDupeInputs). This can mean NaNofuzz is having difficulty generating further new inputs: the function's input space might be small or near exhaustion. You can change this setting in More Options.