### PR TITLE
fix: avoid panel NaNs on upgrade to v0.3.6

### DIFF
--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -395,11 +395,11 @@ const _checkStopCondition = (
  * @returns true if the options are valid, false otherwise
  */
 const isOptionValid = (options: FuzzOptions): boolean => {
-  return !(
-    options.maxTests < 0 ||
-    options.maxDupeInputs < 0 ||
-    options.maxFailures < 0 ||
-    !ArgDef.isOptionValid(options.argDefaults)
+  return (
+    options.maxTests >= 0 &&
+    options.maxDupeInputs >= 0 &&
+    options.maxFailures >= 0 &&
+    ArgDef.isOptionValid(options.argDefaults)
   );
 }; // fn: isOptionValid()
 

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1851,7 +1851,7 @@ export const languages = ["typescript", "typescriptreact"];
 /**
  * The Fuzzer State Version we currently support.
  */
-const fuzzPanelStateVer = "FuzzPanelStateSerialized-0.2.1";
+const fuzzPanelStateVer = "FuzzPanelStateSerialized-0.3.6";
 
 /**
  * Current file format version for persisting test sets / pinned test cases


### PR DESCRIPTION
To avoid the possibility of a `NaN` on `maxDupeInputs`, force fuzz panel reload upon upgrade to v0.3.6. Also categorize `NaN` values as invalid for `maxDupeInputs`, `maxTests`, and `maxFailures`.