### PR TITLE
feat: add returnType to FunctionRef

### DIFF
--- a/src/fuzzer/analysis/typescript/FunctionDef.test.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.test.ts
@@ -215,6 +215,17 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
             },
           },
         ],
+        returnType: {
+          dims: 0,
+          isExported: false,
+          module: "dummy.ts",
+          optional: false,
+          type: {
+            children: [],
+            resolved: true,
+            type: "string",
+          },
+        },
       },
       {
         name: "test2",
@@ -224,6 +235,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         endOffset: 170,
         isExported: true,
         args: [],
+        returnType: undefined,
       },
       /*
       {
@@ -274,6 +286,17 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
           },
         },
       ],
+      returnType: {
+        dims: 0,
+        isExported: false,
+        module: "dummy.ts",
+        optional: false,
+        type: {
+          children: [],
+          resolved: true,
+          type: "string",
+        },
+      },
     });
   });
 
@@ -299,6 +322,17 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
           },
         },
       ],
+      returnType: {
+        dims: 0,
+        isExported: false,
+        module: "dummy.ts",
+        optional: false,
+        type: {
+          children: [],
+          resolved: true,
+          type: "string",
+        },
+      },
     });
   });
 });

--- a/src/fuzzer/analysis/typescript/FunctionDef.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.ts
@@ -1,6 +1,12 @@
 import * as JSON5 from "json5";
 import { ArgDef } from "./ArgDef";
-import { ArgType, FunctionRef, ArgOptionOverrides, ArgOptions } from "./Types";
+import {
+  ArgType,
+  FunctionRef,
+  ArgOptionOverrides,
+  ArgOptions,
+  TypeRef,
+} from "./Types";
 
 /**
  * The FunctionDef class represents a function definition in a Typescript source
@@ -118,6 +124,17 @@ export class FunctionDef {
   public getRef(): FunctionRef {
     return { ...this._ref };
   } // fn: getRef()
+
+  /**
+   * Returns the return type of the function, or undefined if the
+   * function does not have a return type annotation.
+   *
+   * @returns the return type of the function, or undefined if the
+   * function does not have a return type annotation.
+   */
+  public getReturnType(): TypeRef | undefined {
+    return this._ref.returnType;
+  } // fn: get
 
   /**
    * Returns true if the function is exported; false, otherwise.

--- a/src/fuzzer/analysis/typescript/Types.ts
+++ b/src/fuzzer/analysis/typescript/Types.ts
@@ -38,6 +38,7 @@ export type FunctionRef = {
   endOffset: number; // Ending offset of the function in the source file
   isExported: boolean; // True if the function is exported; false, otherwise
   args?: TypeRef[]; // Array of argument types
+  returnType?: TypeRef; // Return type of the function
 };
 
 /**


### PR DESCRIPTION
Adds returnType to FunctionRef so we can use this information.

Potentially this would also allow the implicit oracle to verify the return type matches the value since TypeScript's type system isn't sound? Gradual typing while fuzzing maybe?

Note this is based on #187 and only the top commit is new ~~and if it is to be merged it should be after #187~~ nvm just realized this is based on the main branch.