### PR TITLE
feat: expand FuzzTestResult in the validator template

### DIFF
--- a/src/fuzzer/analysis/typescript/ArgDef.test.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.test.ts
@@ -1,0 +1,127 @@
+import { ArgTag, TypeRef, ArgType } from "./Types";
+import { ArgDef } from "./ArgDef";
+
+const argOptions = ArgDef.getDefaultOptions();
+const dummyModule = "dummy.ts";
+
+/**
+ * Helper functions for generating TypeRefs and ArgDefs
+ */
+function makeArgDef(
+  module: string,
+  name: string,
+  offset: number,
+  type: ArgTag,
+  argOptions = ArgDef.getDefaultOptions(),
+  dims: number,
+  optional: boolean = false,
+  children: TypeRef[] = [],
+  typeRefName?: string
+): ArgDef<ArgType> {
+  return ArgDef.fromTypeRef(
+    makeTypeRef(module, name, type, dims, optional, children, typeRefName),
+    argOptions,
+    offset
+  );
+}
+function makeTypeRef(
+  module: string,
+  name: string,
+  type: ArgTag,
+  dims: number,
+  optional: boolean = false,
+  children: TypeRef[] = [],
+  typeRefName?: string
+): TypeRef {
+  return {
+    name: name,
+    module: module,
+    typeRefName,
+    optional: optional ?? false,
+    dims: dims,
+    type: {
+      type: type,
+      children: children,
+    },
+    isExported: true,
+  };
+}
+
+/**
+ * Test that getTypeAnnotation returns the correct type annotation for a given
+ * function argument.
+ */
+describe("fuzzer/analysis/typescript/ArgDef: getTypeAnnotation", () => {
+  it.each([ArgTag.STRING, ArgTag.NUMBER, ArgTag.BOOLEAN])(
+    "should return %s for primitive type %s",
+    (tag: ArgTag) => {
+      const argDef = makeArgDef(dummyModule, "test", 0, tag, argOptions, 0);
+      expect(argDef.getTypeAnnotation()).toBe(tag);
+    }
+  );
+
+  it.each([1, 2, 3])(
+    'should return %s "[]"s for array type with %s dimensions',
+    (dims: number) => {
+      const argDef = makeArgDef(
+        dummyModule,
+        "test",
+        0,
+        ArgTag.STRING,
+        argOptions,
+        dims
+      );
+      expect(argDef.getTypeAnnotation()).toBe(
+        ArgTag.STRING + "[]".repeat(dims)
+      );
+    }
+  );
+
+  it.each([ArgTag.STRING, ArgTag.NUMBER, ArgTag.BOOLEAN])(
+    "should return '<type> | undefined' for optional types",
+    (tag: ArgTag) => {
+      const argDef = makeArgDef(
+        dummyModule,
+        "test",
+        0,
+        tag,
+        argOptions,
+        0,
+        true
+      );
+      expect(argDef.getTypeAnnotation()).toBe(tag + " | undefined");
+    }
+  );
+
+  test("should return type name for type refs", () => {
+    const argDef = makeArgDef(
+      dummyModule,
+      "test",
+      0,
+      ArgTag.OBJECT,
+      argOptions,
+      0,
+      false,
+      [],
+      "Type"
+    );
+    expect(argDef.getTypeAnnotation()).toBe("Type");
+  });
+
+  test("should return the literal type for literal types", () => {
+    const argDef = makeArgDef(
+      dummyModule,
+      "test",
+      0,
+      ArgTag.OBJECT,
+      argOptions,
+      0,
+      false,
+      [
+        makeTypeRef(dummyModule, "bool", ArgTag.BOOLEAN, 0),
+        makeTypeRef(dummyModule, "str", ArgTag.STRING, 0),
+      ]
+    );
+    expect(argDef.getTypeAnnotation()).toBe("{ bool: boolean; str: string }");
+  });
+});

--- a/src/fuzzer/analysis/typescript/ArgDef.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.ts
@@ -426,6 +426,22 @@ export class ArgDef<T extends ArgType> {
   } // fn: getChildrenFlat()
 
   /**
+   * Returns a string that works as the type annotation for the argument.
+   * @returns a string that works as the type annotation for the argument
+   */
+  public getTypeAnnotation(): string {
+    const dim = this.getDim();
+    const baseType = this.getTypeRef() ?? this.getType();
+    const type = `${baseType}${dim ? "[]".repeat(dim) : ""}`;
+
+    if (this.isOptional()) {
+      return `${type} | undefined`;
+    }
+
+    return type;
+  } // fn: getTypeAnnotation()
+
+  /**
    * Returns the default option set for signed integer values.
    *
    * @returns the default option set for signed integer values

--- a/src/fuzzer/analysis/typescript/ArgDef.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.ts
@@ -426,15 +426,35 @@ export class ArgDef<T extends ArgType> {
   } // fn: getChildrenFlat()
 
   /**
+   * Returns the base type of this ArgDef, i.e., its type without any
+   * dimensions or optionality.
+   */
+  private getBaseType(): string {
+    if (this.typeRef) {
+      return this.typeRef;
+    }
+
+    if (this.type === "object") {
+      // Probably an inline type given the lack of a typeRef, recursively walk
+      // the children to build the type.
+      const childTypeAnnotations = this.children.map(
+        (child) => `${child.getName()}: ${child.getTypeAnnotation()}`
+      );
+      return `{ ${childTypeAnnotations.join(", ")} }`;
+    }
+
+    return this.type;
+  }
+
+  /**
    * Returns a string that works as the type annotation for the argument.
    * @returns a string that works as the type annotation for the argument
    */
   public getTypeAnnotation(): string {
-    const dim = this.getDim();
-    const baseType = this.getTypeRef() ?? this.getType();
-    const type = `${baseType}${dim ? "[]".repeat(dim) : ""}`;
+    const baseType = this.getBaseType();
+    const type = `${baseType}${this.dims ? "[]".repeat(this.dims) : ""}`;
 
-    if (this.isOptional()) {
+    if (this.optional) {
       return `${type} | undefined`;
     }
 

--- a/src/fuzzer/analysis/typescript/ArgDef.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.ts
@@ -440,7 +440,7 @@ export class ArgDef<T extends ArgType> {
       const childTypeAnnotations = this.children.map(
         (child) => `${child.getName()}: ${child.getTypeAnnotation()}`
       );
-      return `{ ${childTypeAnnotations.join(", ")} }`;
+      return `{ ${childTypeAnnotations.join("; ")} }`;
     }
 
     return this.type;

--- a/src/fuzzer/analysis/typescript/ArgDef.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.ts
@@ -444,7 +444,7 @@ export class ArgDef<T extends ArgType> {
     }
 
     return this.type;
-  }
+  } // fn: getBaseType()
 
   /**
    * Returns a string that works as the type annotation for the argument.

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -607,7 +607,7 @@ export class FuzzPanel {
     const inArgConsts = inArgs
       .map(
         (argDef, i) =>
-          `  const ${argDef.getName()}: ${this.getTypeAnnotation(argDef)} = ${
+          `  const ${argDef.getName()}: ${argDef.getTypeAnnotation()} = ${
             validatorArgs.resultArgName
           }.in[${i}];`
       )
@@ -669,18 +669,6 @@ ${outArgConst}
     // In the extremely unlikely event that all 1000 names are taken, we'll
     // just return `r_conflicted` and not worry about potential conflicts.
     return { name: "r_conflicted", generated: true };
-  }
-
-  private getTypeAnnotation(argDef: fuzzer.ArgDef<fuzzer.ArgType>): string {
-    const dim = argDef.getDim();
-    const baseType = argDef.getTypeRef() ?? argDef.getType();
-    const type = `${baseType}${dim ? "[]".repeat(dim) : ""}`;
-
-    if (argDef.isOptional()) {
-      return `${type} | undefined`;
-    }
-
-    return type;
   }
 
   private getValidatorArgs(inArgs: fuzzer.ArgDef<fuzzer.ArgType>[]): {

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -646,7 +646,14 @@ ${outArgConst}
     }
   }
 
-  // Choose a name for an identifier that doesn't conflict with the input arguments
+  /**
+   * Choose a name for an identifier that doesn't conflict with the input arguments
+   *
+   * @param inArgs The input arguments
+   * @param candidateNames The candidate names to choose from
+   * @param maxSuffix The maximum suffix to use when generating a new name
+   * @returns The chosen name and whether it was generated
+   */
   private getIdentifierNameAvoidingConflicts(
     // The input arguments
     inArgs: fuzzer.ArgDef<fuzzer.ArgType>[],
@@ -668,17 +675,20 @@ ${outArgConst}
     }
 
     let i = 1;
-    // Generate a new one with a suffix
-    while (i <= maxSuffix) {
-      const name = `r_${i}`;
-      if (!inArgNames.includes(name)) {
-        return { name, generated: true };
+    // Generate a new name with a suffix
+    for (const candidateName of candidateNames) {
+      while (i <= maxSuffix) {
+        const name = `${candidateName}_${i}`;
+        if (!inArgNames.includes(name)) {
+          return { name, generated: true };
+        }
+        i++;
       }
-      i++;
     }
 
-    // In the extremely unlikely event that all 1000 names are taken, we'll
-    // just return `r_conflicted` and not worry about potential conflicts.
+    // In the extremely unlikely event that all the names generated above are
+    // already in `inArgNames`, we'll just return `r_conflicted` and not worry
+    // about potential conflicts.
     return { name: "r_conflicted", generated: true };
   } // fn: getIdentifierNameAvoidingConflicts()
 
@@ -736,15 +746,15 @@ ${outArgConst}
       outVarCandidateNames,
       maxOutVarSuffix
     );
-    const outVarString = `  const ${outVarName.name}${
+    const outVarString = `const ${outVarName.name}${
       returnType ? ": " + returnType : ""
     } = ${resultArgName}.out;`;
     if (!outVarName.generated) {
       return outVarString;
     }
 
-    return `// Generated name for the out variable to avoid conflicts
-${outVarString}`;
+    return `  // Generated name for the out variable to avoid conflicts
+  ${outVarString}`;
   } // fn: getOutConst()
 
   /**

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -597,6 +597,16 @@ export class FuzzPanel {
  *     ${"`"}yarn add nanofuzz/runtime -D${"`"}
  *  1. Add an import to the top of the file:
  *     ${"`"}import { FuzzTestResult } from "nanofuzz/runtime";${"`"}`;
+
+    const returnType = fn.getReturnType()?.type?.type;
+    const inOutArgConsts = fn
+      .getArgDefs()
+      .map(
+        (argDef, i) =>
+          `  const ${argDef.getName()}: ${argDef.getType()} = r.in[${i}];`
+      )
+      .concat([`  const out${returnType ? ": " + returnType : ""} = r.out;`])
+      .join("\n");
     // prettier-ignore
     const skeleton = `
 
@@ -604,6 +614,7 @@ export function ${validatorPrefix}${
         fnCounter === 0 ? "" : fnCounter
       }(r: FuzzTestResult): boolean | undefined {
   // Array of inputs: r.in   Output: r.out
+${inOutArgConsts}
   // return false; // <-- Unexpected; failed
   return true;
 }`;

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -607,7 +607,7 @@ export class FuzzPanel {
     const inArgConsts = inArgs
       .map(
         (argDef, i) =>
-          `  const ${argDef.getName()}: ${argDef.getType()} = ${
+          `  const ${argDef.getName()}: ${this.getTypeAnnotation(argDef)} = ${
             validatorArgs.resultArgName
           }.in[${i}];`
       )
@@ -669,6 +669,17 @@ ${outArgConst}
     // In the extremely unlikely event that all 1000 names are taken, we'll
     // just return `r_conflicted` and not worry about potential conflicts.
     return { name: "r_conflicted", generated: true };
+  }
+
+  private getTypeAnnotation(argDef: fuzzer.ArgDef<fuzzer.ArgType>): string {
+    const dim = argDef.getDim();
+    const type = `${argDef.getType()}${dim ? "[]".repeat(dim) : ""}`;
+
+    if (argDef.isOptional()) {
+      return `${type} | undefined`;
+    }
+
+    return type;
   }
 
   private getValidatorArgs(inArgs: fuzzer.ArgDef<fuzzer.ArgType>[]): {

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -673,7 +673,8 @@ ${outArgConst}
 
   private getTypeAnnotation(argDef: fuzzer.ArgDef<fuzzer.ArgType>): string {
     const dim = argDef.getDim();
-    const type = `${argDef.getType()}${dim ? "[]".repeat(dim) : ""}`;
+    const baseType = argDef.getTypeRef() ?? argDef.getType();
+    const type = `${baseType}${dim ? "[]".repeat(dim) : ""}`;
 
     if (argDef.isOptional()) {
       return `${type} | undefined`;


### PR DESCRIPTION
Initial support for #164. Note this is based on #190 and only the top commit is new ~~, and if it is to be merged it should be after #190~~ nvm just realized this is based on the main branch.

This also potentially would rename the validator argument `FuzzTestResult`, by choosing one of `["r", "result", "_r", "_result"]` first, and then fallback to `r_{i}` with i between 1 and 1000, and if there are still conflicts just use `r_conflict` with a possible conflict.

```
import { FuzzTestResult } from "@nanofuzz/runtime";

type T = {
  a: number;
};

export function a(
  r: number,
  result: number[],
  _r: T,
  _result: {
    num: number;
    nested?: {
      str?: string;
    };
  },
  r_1: number[][],
  out: number,
  output: number,
  _out: number,
  _output: number,
  out_1?: number,
): number {
  return r;
};


export function aValidator (
    // Generated name for the result argument to avoid conflicts
    r_2: FuzzTestResult
  ): boolean | undefined {
  const r: number = r_2.in[0];
  const result: number[] = r_2.in[1];
  const _r: T = r_2.in[2];
  const _result: { num: number; nested: { str: string | undefined } | undefined } = r_2.in[3];
  const r_1: number[][] = r_2.in[4];
  const out: number = r_2.in[5];
  const output: number = r_2.in[6];
  const _out: number = r_2.in[7];
  const _output: number = r_2.in[8];
  const out_1: number | undefined = r_2.in[9];
  // Generated name for the out variable to avoid conflicts
  const out_2 = r_2.out;
  // return false; // <-- Unexpected; failed
  return true;
}
```