### PR TITLE
feat: make `FuzzTestResult` in the runtime package generic and use in the validator template

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -7,9 +7,17 @@ import * as build from "./build.json";
 export const versions = build.versions;
 
 /**
- * Simplified single Fuzzer Test Result
+ * Simplified single Fuzzer Test Result.
+ *
+ * Structurally equivalent to fuzzer.Result with more informative geenric
+ * types for in and out.
  */
-export type FuzzTestResult = fuzzer.Result;
+export type FuzzTestResult<T extends unknown[], U> = {
+  in: T; // function input
+  out: U; // function output
+  exception: boolean; // true if an exception was thrown
+  timeout: boolean; // true if the fn call timed out
+};
 
 /**
  * Fuzzer Input/Output Element; i.e., a concrete input or output value

--- a/src/fuzzer/analysis/typescript/FunctionDef.test.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.test.ts
@@ -215,6 +215,17 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
             },
           },
         ],
+        returnType: {
+          dims: 0,
+          isExported: false,
+          module: "dummy.ts",
+          optional: false,
+          type: {
+            children: [],
+            resolved: true,
+            type: "string",
+          },
+        },
       },
       {
         name: "test2",
@@ -224,6 +235,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         endOffset: 170,
         isExported: true,
         args: [],
+        returnType: undefined,
       },
       /*
       {
@@ -274,6 +286,17 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
           },
         },
       ],
+      returnType: {
+        dims: 0,
+        isExported: false,
+        module: "dummy.ts",
+        optional: false,
+        type: {
+          children: [],
+          resolved: true,
+          type: "string",
+        },
+      },
     });
   });
 
@@ -299,6 +322,17 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
           },
         },
       ],
+      returnType: {
+        dims: 0,
+        isExported: false,
+        module: "dummy.ts",
+        optional: false,
+        type: {
+          children: [],
+          resolved: true,
+          type: "string",
+        },
+      },
     });
   });
 });

--- a/src/fuzzer/analysis/typescript/FunctionDef.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.ts
@@ -1,6 +1,12 @@
 import * as JSON5 from "json5";
 import { ArgDef } from "./ArgDef";
-import { ArgType, FunctionRef, ArgOptionOverrides, ArgOptions } from "./Types";
+import {
+  ArgType,
+  FunctionRef,
+  ArgOptionOverrides,
+  ArgOptions,
+  TypeRef,
+} from "./Types";
 
 /**
  * The FunctionDef class represents a function definition in a Typescript source
@@ -118,6 +124,17 @@ export class FunctionDef {
   public getRef(): FunctionRef {
     return { ...this._ref };
   } // fn: getRef()
+
+  /**
+   * Returns the return type of the function, or undefined if the
+   * function does not have a return type annotation.
+   *
+   * @returns the return type of the function, or undefined if the
+   * function does not have a return type annotation.
+   */
+  public getReturnType(): TypeRef | undefined {
+    return this._ref.returnType;
+  } // fn: get
 
   /**
    * Returns true if the function is exported; false, otherwise.

--- a/src/fuzzer/analysis/typescript/Types.ts
+++ b/src/fuzzer/analysis/typescript/Types.ts
@@ -38,6 +38,7 @@ export type FunctionRef = {
   endOffset: number; // Ending offset of the function in the source file
   isExported: boolean; // True if the function is exported; false, otherwise
   args?: TypeRef[]; // Array of argument types
+  returnType?: TypeRef; // Return type of the function
 };
 
 /**

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -607,12 +607,16 @@ export class FuzzPanel {
       )
       .concat([`  const out${returnType ? ": " + returnType : ""} = r.out;`])
       .join("\n");
+    const argTypes = fn
+      .getArgDefs()
+      .map((argDef) => argDef.getType())
+      .join(", ");
     // prettier-ignore
     const skeleton = `
 
 export function ${validatorPrefix}${
         fnCounter === 0 ? "" : fnCounter
-      }(r: FuzzTestResult): boolean | undefined {
+      }(r: FuzzTestResult<[${argTypes}], ${returnType}>): boolean | undefined {
   // Array of inputs: r.in   Output: r.out
 ${inOutArgConsts}
   // return false; // <-- Unexpected; failed

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -597,6 +597,16 @@ export class FuzzPanel {
  *     ${"`"}yarn add nanofuzz/runtime -D${"`"}
  *  1. Add an import to the top of the file:
  *     ${"`"}import { FuzzTestResult } from "nanofuzz/runtime";${"`"}`;
+
+    const returnType = fn.getReturnType()?.type?.type;
+    const inOutArgConsts = fn
+      .getArgDefs()
+      .map(
+        (argDef, i) =>
+          `  const ${argDef.getName()}: ${argDef.getType()} = r.in[${i}];`
+      )
+      .concat([`  const out${returnType ? ": " + returnType : ""} = r.out;`])
+      .join("\n");
     // prettier-ignore
     const skeleton = `
 
@@ -604,6 +614,7 @@ export function ${validatorPrefix}${
         fnCounter === 0 ? "" : fnCounter
       }(r: FuzzTestResult): boolean | undefined {
   // Array of inputs: r.in   Output: r.out
+${inOutArgConsts}
   // return false; // <-- Unexpected; failed
   return true;
 }`;


### PR DESCRIPTION
...which helps creating templates like this:


```
import { FuzzTestResult } from "@nanofuzz/runtime";

/**
 * Adapted from: https://stackoverflow.com/questions/51180518/
 *
 * This function accepts an `array`, an `offset`, and a `dft` (default).
 * If the `array` at `offset` is undefined, return the `dft` value;
 * otherwise, return the value at `array[offset]`.
 *
 * @param array array of strings
 * @param offset finite integer offset into array of strings to retrieve
 * @param dft default string to return if array[offset] is undefined
 * @returns array[offset] if defined, otherwise dft
 */
export function getOffsetOrDefault(
  array: string[],
  offset: number,
  dft: string
): string {
  return array[offset] === "undefined" ? dft : array[offset];
}

export function getOffsetOrDefaultValidator(r: FuzzTestResult<[string, number, string], string>): boolean | undefined {
  // Array of inputs: r.in   Output: r.out
  const array: string = r.in[0];
  const offset: number = r.in[1];
  const dft: string = r.in[2];
  const out: string = r.out;
  // return false; // <-- Unexpected; failed
  return true;
}
```

And now the `consts` actually doesn't need explicit types.

Since this is experimental this is again based on #191 so these can be reviewed separately.