### PR TITLE
feat: generate type annotation for `out` in validator

### DIFF
--- a/src/fuzzer/analysis/typescript/ArgDef.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.ts
@@ -144,7 +144,7 @@ export class ArgDef<T extends ArgType> {
     // Ensure we have a resolved type
     if (!ref.type)
       throw new Error(
-        `Internal error: Creating ArgDef for unresolved TypeRef: ${JSON5.stringify(
+        `Internal error: unable to create ArgDef for unresolved TypeRef: ${JSON5.stringify(
           ref
         )}`
       );

--- a/src/fuzzer/analysis/typescript/FunctionDef.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.ts
@@ -134,7 +134,22 @@ export class FunctionDef {
    */
   public getReturnType(): TypeRef | undefined {
     return this._ref.returnType;
-  } // fn: get
+  } // fn: getReturnType()
+
+  /**
+   * Returns the return type of the function in the form of an ArgDef,
+   * or undefined if the function does not have a return type annotation.
+   *
+   * @returns the return ArgDef of the function, or undefined if the
+   * function does not have a return type annotation or the return
+   * type could not be resolved.
+   */
+  public getReturnArg(): ArgDef<ArgType> | undefined {
+    // If a return type is defined and resolved, convert it to an ArgDef
+    return this._ref.returnType && this._ref.returnType.type
+      ? ArgDef.fromTypeRef(this._ref.returnType, this._options)
+      : undefined;
+  } // fn: getReturnArg()
 
   /**
    * Returns true if the function is exported; false, otherwise.

--- a/src/fuzzer/analysis/typescript/ProgramDef.ts
+++ b/src/fuzzer/analysis/typescript/ProgramDef.ts
@@ -147,6 +147,8 @@ export class ProgramDef {
       for (const fnRef of Object.values(this._functions)) {
         let lastArgName: string | undefined;
         try {
+          // Attempt to resolve function argument types
+          // Note: failure to resolve any argument makes fn unsupported
           if (fnRef.args) {
             for (const fnArg of fnRef.args) {
               lastArgName = fnArg.name;
@@ -170,6 +172,18 @@ export class ProgramDef {
           };
           delete this._functions[fnRef.name];
           delete this._exportedFunctions[fnRef.name];
+        }
+        // Attempt to resolve function return types
+        // Note: failure to resolve return type does not make function unsupported
+        try {
+          if (fnRef.returnType) {
+            lastArgName = "return";
+            this._resolveTypeRef(fnRef.returnType);
+          }
+        } catch (e: any) {
+          console.debug(
+            `Error resolving return type for function '${fnRef.name}'; Reason: ${e.message}`
+          );
         }
       }
     }

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -608,9 +608,15 @@ export class FuzzPanel {
       )
       .join("\n");
 
+    const outTypeAsArg = fn.getReturnArg();
+    const outTypeAsString = outTypeAsArg
+      ? outTypeAsArg.getTypeAnnotation()
+      : undefined;
+
     const outArgConst = this.getOutArgConst(
       inArgs,
-      validatorArgs.resultArgName
+      validatorArgs.resultArgName,
+      outTypeAsString
     );
 
     // prettier-ignore


### PR DESCRIPTION
Adds type annotations to the `out` variable of the generated validator code in the case where the return type of the function is resolved and supported (e.g., can be represented as an `ArgDef`). In the case where the type cannot be resolved or is not yet supported (e.g., union types), no type annotation is generated.

This PR completes the functionality needed to resolve #164 and builds upon the strategy used in #191 where generation of the type annotation code is delegated to `ArgDef`.  Consequently, as support for further types is expanded in `ArgDef` (e.g., in #63), `FuzzPanel` will be able to generate the corresponding annotations for those further types.