### PR TITLE
feat: add support for literal types

### DIFF
--- a/assets/ui/FuzzPanelMain.js
+++ b/assets/ui/FuzzPanelMain.js
@@ -548,7 +548,7 @@ function handleCorrectToggle(button, row, type, tbody, cell1, cell2) {
     data[type][index][expectedLabel] = resultsData.results[id].output;
   }
 
-  // Redraw table !!!!! Do we need to do this?
+  // Redraw table
   drawTableBody(type, tbody, true, button);
 
   const onOff = JSON.parse(button.getAttribute("onOff"));

--- a/src/fuzzer/Fuzzer.test.ts
+++ b/src/fuzzer/Fuzzer.test.ts
@@ -76,6 +76,16 @@ export const testArrowVoidReturnException = (x: number): void => {
 };
 
 /**
+ * Fuzz targets with literal arguments
+ */
+export function testStandardVoidLiteralArgs(n: 5, n2: 5[]): void {
+  return;
+}
+export const testArrowVoidLiteralArgs = (n: 5, n2: 5[]): void => {
+  return;
+};
+
+/**
  * These tests currently just ensure that the fuzzer runs and produces output
  * for each example. TODO: Add tests that check the fuzzer output.
  */
@@ -445,5 +455,28 @@ describe("Fuzzer", () => {
     expect(results.length).not.toStrictEqual(0);
     expect(results.some((e) => e.passedImplicit)).toBeFalsy();
     expect(results.every((e) => e.exception)).toBeTruthy();
+  });
+
+  /**
+   * Test that `void` functions w/literal arguments (standard and arrow) pass
+   * when they return undefined.
+   */
+  test("Standard void literal arg fuzz target", async () => {
+    const results = (
+      await fuzz(
+        setup(intOptions, "./Fuzzer.test.ts", "testStandardVoidLiteralArgs")
+      )
+    ).results;
+    expect(results.length).not.toStrictEqual(0);
+    expect(results.some((e) => e.passedImplicit)).toBeTruthy();
+  });
+  test("Arrow void literal arg fuzz target", async () => {
+    const results = (
+      await fuzz(
+        setup(intOptions, "./Fuzzer.test.ts", "testArrowVoidLiteralArgs")
+      )
+    ).results;
+    expect(results.length).not.toStrictEqual(0);
+    expect(results.some((e) => e.passedImplicit)).toBeTruthy();
   });
 });

--- a/src/fuzzer/analysis/typescript/ArgDef.test.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.test.ts
@@ -53,6 +53,7 @@ function makeTypeRef(
  */
 describe("fuzzer/analysis/typescript/ArgDef: getTypeAnnotation", () => {
   it.each([ArgTag.STRING, ArgTag.NUMBER, ArgTag.BOOLEAN])(
+    // !!!!!! add tests for LITERAL
     "should return %s for primitive type %s",
     (tag: ArgTag) => {
       const argDef = makeArgDef(dummyModule, "test", 0, tag, argOptions, 0);
@@ -78,6 +79,7 @@ describe("fuzzer/analysis/typescript/ArgDef: getTypeAnnotation", () => {
   );
 
   it.each([ArgTag.STRING, ArgTag.NUMBER, ArgTag.BOOLEAN])(
+    // !!!!!! add tests for LITERAL
     "should return '<type> | undefined' for optional types",
     (tag: ArgTag) => {
       const argDef = makeArgDef(

--- a/src/fuzzer/analysis/typescript/ArgDef.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.ts
@@ -289,6 +289,16 @@ export class ArgDef<T extends ArgType> {
       throw new Error(
         `Invalid interval provided (max>min): ${JSON5.stringify(intervals)}`
       );
+    if (
+      this.type === ArgTag.LITERAL &&
+      (intervals.length !== 1 || intervals[0].max === intervals[0].min)
+    ) {
+      throw new Error(
+        `Invalid interval provided for LITERAL type: (req's one interval where max=min): ${JSON5.stringify(
+          intervals
+        )}`
+      );
+    }
     this.intervals = intervals;
   } // fn: setIntervals()
 

--- a/src/fuzzer/analysis/typescript/ArgDef.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.ts
@@ -50,7 +50,7 @@ export class ArgDef<T extends ArgType> {
    * @param options Specifies defaults to infer input intervals and any types
    * @param dims Dimensions of the value (e.g., number = 0, number[] = 1, etc.)
    * @param optional Indicates whether the argument is optional
-   * @param intervals Input intervals for the argument
+   * @param intervals Input intervals for the argument. REQUIRED for literal types.
    */
   private constructor(
     name: string,
@@ -80,18 +80,6 @@ export class ArgDef<T extends ArgType> {
           2
         )}`
       );
-
-    // Ensure the input intervals, if provided, are valid
-    if (intervals !== undefined && !intervals.some((e) => e.min > e.max))
-      throw new Error(
-        `Invalid intervals provided. Required: min <= max. ${JSON5.stringify(
-          options,
-          null,
-          2
-        )}`
-      );
-
-    // Ensure we have a sensible set of options. Watch out for mutable state here.
     this.options = { ...options };
 
     // Fill the array dimensions w/defaults if missing or incongruent with the AST
@@ -110,6 +98,11 @@ export class ArgDef<T extends ArgType> {
       );
     }
 
+    // Intervals are required for literal types
+    if (type === ArgTag.LITERAL && (!intervals || !intervals.length)) {
+      throw new Error(`An interval is required for the literal ArgDef type`);
+    }
+
     // If no interval is provided, use the type's default
     this.intervals =
       intervals === undefined ||
@@ -120,7 +113,9 @@ export class ArgDef<T extends ArgType> {
 
     // Ensure each non-array dimension is valid
     if (this.intervals.filter((e) => e.min > e.max).length) {
-      throw new Error(`Invalid interval: ${JSON5.stringify(this.intervals)}`);
+      throw new Error(
+        `Invalid interval: ${JSON5.stringify(this.intervals, undefined, 2)}`
+      );
     }
   } // end: constructor
 
@@ -149,6 +144,12 @@ export class ArgDef<T extends ArgType> {
         )}`
       );
 
+    // An interval is mandatory for the Literal type
+    const intervals: Interval<ArgType>[] | undefined =
+      ref.type.type === ArgTag.LITERAL && ref.type.value !== undefined
+        ? [{ min: ref.type.value, max: ref.type.value }]
+        : undefined;
+
     // Use the type reference to build the ArgDef
     return new ArgDef<ArgType>(
       ref.name ?? "unknown", // name
@@ -157,7 +158,7 @@ export class ArgDef<T extends ArgType> {
       options, // options
       ref.dims, // dims
       ref.optional, // optional
-      undefined, // intervals
+      intervals, // intervals
       ref.type.children.map((child) => ArgDef.fromTypeRef(child, options, i++)), // children
       ref.typeRefName // type reference
     );
@@ -192,6 +193,8 @@ export class ArgDef<T extends ArgType> {
       case ArgTag.BOOLEAN:
         return [{ min: false, max: true }];
       case ArgTag.OBJECT:
+        return [];
+      case ArgTag.LITERAL:
         return [];
       default:
         throw new Error(`Unsupported type: ${type}`);

--- a/src/fuzzer/analysis/typescript/ArgDef.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.ts
@@ -319,8 +319,7 @@ export class ArgDef<T extends ArgType> {
   public isConstant(): boolean {
     return (
       this.intervals.length === 1 &&
-      this.intervals[0].min === this.intervals[0].max &&
-      this.getDim() === 0
+      this.intervals[0].min === this.intervals[0].max
     );
   } // fn: isConstant()
 
@@ -444,6 +443,10 @@ export class ArgDef<T extends ArgType> {
         (child) => `${child.getName()}: ${child.getTypeAnnotation()}`
       );
       return `{ ${childTypeAnnotations.join("; ")} }`;
+    }
+
+    if (this.type === "literal") {
+      return `${this.getConstantValue()}`;
     }
 
     return this.type;

--- a/src/fuzzer/analysis/typescript/FunctionDef.test.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.test.ts
@@ -77,6 +77,7 @@ function makeTypeRef(
  */
 describe("fuzzer/analysis/typescript/FunctionDef", () => {
   test("arrowFunction", () => {
+    // !!!!!! add tests for LITERAL
     const src = `const $_f = (name: string, offset: number, happy: boolean, nums: number[][], obj: {num: number, numA: number[], str:string, strA: string[], bool: boolean, boolA: boolean[]}):void => {
       const whatever:string = name + offset + happy + JSON5.stringify(nums);}`;
     const thisProgram = dummyProgram.setSrc(() => src);
@@ -121,6 +122,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
   });
 
   test("standardFunction", () => {
+    // !!!!!! add tests for LITERAL
     const src = `function $_f(name: string, offset: number, happy: boolean, nums: number[][], obj: {num: number, numA: number[], str:string, strA: string[], bool: boolean, boolA: boolean[]}):void {
       const whatever:string = name + offset + happy + JSON5.stringify(nums);}`;
     const thisProgram = dummyProgram.setSrc(() => src);
@@ -660,6 +662,59 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         isExported: true,
         isVoid: false,
         args: [],
+        returnType: undefined,
+      },
+    ]);
+  });
+
+  test("findFnInSource: literal args", () => {
+    const src = `
+    export type litn = 3;
+    export type lita = "a";
+    export function testLit(n:litn,a:lita) {return;}
+    `;
+    const thisProgram = dummyProgram.setSrc(() => src);
+    expect(
+      Object.values(thisProgram.getFunctions()).map((e) => e.getRef())
+    ).toStrictEqual([
+      {
+        name: "testLit",
+        module: "dummy.ts",
+        src: "function testLit(n:litn,a:lita) {return;}",
+        startOffset: 66,
+        endOffset: 107,
+        isExported: true,
+        isVoid: false,
+        args: [
+          {
+            dims: 0,
+            isExported: false,
+            module: "dummy.ts",
+            name: "n",
+            optional: false,
+            type: {
+              children: [],
+              resolved: true,
+              value: 3,
+              type: "literal",
+            },
+            typeRefName: "litn",
+          },
+          {
+            dims: 0,
+            isExported: false,
+            module: "dummy.ts",
+            name: "a",
+            optional: false,
+            type: {
+              children: [],
+              resolved: true,
+              value: "a",
+              type: "literal",
+            },
+            typeRefName: "lita",
+          },
+        ],
         returnType: undefined,
       },
     ]);

--- a/src/fuzzer/analysis/typescript/FunctionDef.test.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.test.ts
@@ -29,18 +29,20 @@ function makeArgDef(
   argOptions = ArgDef.getDefaultOptions(),
   dims: number,
   optional: boolean = false,
-  children: TypeRef[] = []
+  children: TypeRef[] = [],
+  typeRefName?: string,
+  literalValue?: ArgType
 ): ArgDef<ArgType> {
   return ArgDef.fromTypeRef(
     makeTypeRef(
       module,
       name,
-      offset,
       type,
-      argOptions,
       dims,
       optional,
-      children
+      children,
+      typeRefName,
+      literalValue
     ),
     argOptions,
     offset
@@ -49,21 +51,23 @@ function makeArgDef(
 function makeTypeRef(
   module: string,
   name: string,
-  offset: number,
   type: ArgTag,
-  argOptions = ArgDef.getDefaultOptions(),
   dims: number,
   optional: boolean = false,
-  children: TypeRef[] = []
+  children: TypeRef[] = [],
+  typeRefName?: string,
+  literalValue?: ArgType
 ): TypeRef {
   return {
     name: name,
     module: module,
+    typeRefName,
     optional: optional ?? false,
     dims: dims,
     type: {
       type: type,
       children: children,
+      value: literalValue,
     },
     isExported: true,
   };
@@ -77,8 +81,7 @@ function makeTypeRef(
  */
 describe("fuzzer/analysis/typescript/FunctionDef", () => {
   test("arrowFunction", () => {
-    // !!!!!! add tests for LITERAL
-    const src = `const $_f = (name: string, offset: number, happy: boolean, nums: number[][], obj: {num: number, numA: number[], str:string, strA: string[], bool: boolean, boolA: boolean[]}):void => {
+    const src = `const $_f = (name: string, offset: number, happy: boolean, nums: number[][], lit: 5, obj: {num: number, numA: number[], str:string, strA: string[], bool: boolean, boolA: boolean[], lit:6, litA:6[]}):void => {
       const whatever:string = name + offset + happy + JSON5.stringify(nums);}`;
     const thisProgram = dummyProgram.setSrc(() => src);
 
@@ -89,32 +92,50 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
       makeArgDef(dummyRef.module, "nums", 3, ArgTag.NUMBER, argOptions, 2),
       makeArgDef(
         dummyRef.module,
-        "obj",
+        "lit",
         4,
+        ArgTag.LITERAL,
+        argOptions,
+        0,
+        undefined,
+        undefined,
+        undefined,
+        5
+      ),
+      makeArgDef(
+        dummyRef.module,
+        "obj",
+        5,
         ArgTag.OBJECT,
         argOptions,
         0,
         undefined,
         [
-          makeTypeRef(dummyRef.module, "num", 0, ArgTag.NUMBER, argOptions, 0),
-          makeTypeRef(dummyRef.module, "numA", 1, ArgTag.NUMBER, argOptions, 1),
-          makeTypeRef(dummyRef.module, "str", 2, ArgTag.STRING, argOptions, 0),
-          makeTypeRef(dummyRef.module, "strA", 3, ArgTag.STRING, argOptions, 1),
+          makeTypeRef(dummyRef.module, "num", ArgTag.NUMBER, 0),
+          makeTypeRef(dummyRef.module, "numA", ArgTag.NUMBER, 1),
+          makeTypeRef(dummyRef.module, "str", ArgTag.STRING, 0),
+          makeTypeRef(dummyRef.module, "strA", ArgTag.STRING, 1),
+          makeTypeRef(dummyRef.module, "bool", ArgTag.BOOLEAN, 0),
+          makeTypeRef(dummyRef.module, "boolA", ArgTag.BOOLEAN, 1),
           makeTypeRef(
             dummyRef.module,
-            "bool",
-            4,
-            ArgTag.BOOLEAN,
-            argOptions,
-            0
+            "lit",
+            ArgTag.LITERAL,
+            0,
+            undefined,
+            undefined,
+            undefined,
+            6
           ),
           makeTypeRef(
             dummyRef.module,
-            "boolA",
-            5,
-            ArgTag.BOOLEAN,
-            argOptions,
-            1
+            "litA",
+            ArgTag.LITERAL,
+            1,
+            undefined,
+            undefined,
+            undefined,
+            6
           ),
         ]
       ),
@@ -122,8 +143,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
   });
 
   test("standardFunction", () => {
-    // !!!!!! add tests for LITERAL
-    const src = `function $_f(name: string, offset: number, happy: boolean, nums: number[][], obj: {num: number, numA: number[], str:string, strA: string[], bool: boolean, boolA: boolean[]}):void {
+    const src = `function $_f(name: string, offset: number, happy: boolean, nums: number[][], lit: 5, obj: {num: number, numA: number[], str:string, strA: string[], bool: boolean, boolA: boolean[], lit: 6, litA: 6[]}):void {
       const whatever:string = name + offset + happy + JSON5.stringify(nums);}`;
     const thisProgram = dummyProgram.setSrc(() => src);
 
@@ -134,32 +154,50 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
       makeArgDef(dummyRef.module, "nums", 3, ArgTag.NUMBER, argOptions, 2),
       makeArgDef(
         dummyRef.module,
-        "obj",
+        "lit",
         4,
+        ArgTag.LITERAL,
+        argOptions,
+        0,
+        undefined,
+        undefined,
+        undefined,
+        5
+      ),
+      makeArgDef(
+        dummyRef.module,
+        "obj",
+        5,
         ArgTag.OBJECT,
         argOptions,
         0,
         undefined,
         [
-          makeTypeRef(dummyRef.module, "num", 0, ArgTag.NUMBER, argOptions, 0),
-          makeTypeRef(dummyRef.module, "numA", 1, ArgTag.NUMBER, argOptions, 1),
-          makeTypeRef(dummyRef.module, "str", 2, ArgTag.STRING, argOptions, 0),
-          makeTypeRef(dummyRef.module, "strA", 3, ArgTag.STRING, argOptions, 1),
+          makeTypeRef(dummyRef.module, "num", ArgTag.NUMBER, 0),
+          makeTypeRef(dummyRef.module, "numA", ArgTag.NUMBER, 1),
+          makeTypeRef(dummyRef.module, "str", ArgTag.STRING, 0),
+          makeTypeRef(dummyRef.module, "strA", ArgTag.STRING, 1),
+          makeTypeRef(dummyRef.module, "bool", ArgTag.BOOLEAN, 0),
+          makeTypeRef(dummyRef.module, "boolA", ArgTag.BOOLEAN, 1),
           makeTypeRef(
             dummyRef.module,
-            "bool",
-            4,
-            ArgTag.BOOLEAN,
-            argOptions,
-            0
+            "lit",
+            ArgTag.LITERAL,
+            0,
+            undefined,
+            undefined,
+            undefined,
+            6
           ),
           makeTypeRef(
             dummyRef.module,
-            "boolA",
-            5,
-            ArgTag.BOOLEAN,
-            argOptions,
-            1
+            "litA",
+            ArgTag.LITERAL,
+            1,
+            undefined,
+            undefined,
+            undefined,
+            6
           ),
         ]
       ),

--- a/src/fuzzer/analysis/typescript/FunctionDef.test.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.test.ts
@@ -671,7 +671,9 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
     const src = `
     export type litn = 3;
     export type lita = "a";
-    export function testLit(n:litn,a:lita) {return;}
+    export type litb = true;
+    export function testLit(n:litn,a:lita,b:litb) {return;}
+    const world = "earth";
     `;
     const thisProgram = dummyProgram.setSrc(() => src);
     expect(
@@ -680,9 +682,9 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
       {
         name: "testLit",
         module: "dummy.ts",
-        src: "function testLit(n:litn,a:lita) {return;}",
-        startOffset: 66,
-        endOffset: 107,
+        src: "function testLit(n:litn,a:lita,b:litb) {return;}",
+        startOffset: 95,
+        endOffset: 143,
         isExported: true,
         isVoid: false,
         args: [
@@ -713,6 +715,20 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
               type: "literal",
             },
             typeRefName: "lita",
+          },
+          {
+            dims: 0,
+            isExported: false,
+            module: "dummy.ts",
+            name: "b",
+            optional: false,
+            type: {
+              children: [],
+              resolved: true,
+              type: "literal",
+              value: true,
+            },
+            typeRefName: "litb",
           },
         ],
         returnType: undefined,

--- a/src/fuzzer/analysis/typescript/ProgramDef.ts
+++ b/src/fuzzer/analysis/typescript/ProgramDef.ts
@@ -972,10 +972,6 @@ export class ProgramDef {
       case AST_NODE_TYPES.TSTypeLiteral:
         return [ArgTag.OBJECT, 0];
       case AST_NODE_TYPES.TSLiteralType:
-        //console.debug(
-        //  "case AST_NODE_TYPES.TSLiteralType: " +
-        //    JSON5.stringify(node, removeParents, 2)
-        //); // !!!!!!
         return [
           ArgTag.LITERAL,
           0,

--- a/src/fuzzer/analysis/typescript/ProgramDef.ts
+++ b/src/fuzzer/analysis/typescript/ProgramDef.ts
@@ -844,8 +844,6 @@ export class ProgramDef {
       | TSTypeAliasDeclaration
       | TSTypeAnnotation
   ): TypeRef {
-    //console.debug(JSON5.stringify(node, removeParents, 2)); // !!!!!
-
     // Throw an error if type annotations are missing
     if (node.typeAnnotation === undefined) {
       throw new Error(
@@ -979,11 +977,11 @@ export class ProgramDef {
           this._getLiteralValueFromNode(node),
         ];
       case AST_NODE_TYPES.TSArrayType: {
-        const [type, dims, typeName] = this._getTypeFromAstNode(
+        const [type, dims, typeName, literalValue] = this._getTypeFromAstNode(
           node.elementType,
           options
         );
-        return [type, dims + 1, typeName];
+        return [type, dims + 1, typeName, literalValue];
       }
       case AST_NODE_TYPES.TSTypeReference: {
         return [ArgTag.UNRESOLVED, 0, getIdentifierName(node.typeName)];

--- a/src/fuzzer/analysis/typescript/Types.ts
+++ b/src/fuzzer/analysis/typescript/Types.ts
@@ -54,6 +54,7 @@ export type TypeRef = {
   type?: {
     type: ArgTag; // Concrete type of the type
     children: TypeRef[]; // Array of child types
+    value?: ArgType; // Value if a literal type
     resolved?: boolean; // True if the type's children have been resolved; false, otherwise
   };
   isExported: boolean; // True if the type is exported; false, otherwise
@@ -67,6 +68,7 @@ export enum ArgTag {
   STRING = "string",
   BOOLEAN = "boolean",
   OBJECT = "object",
+  LITERAL = "literal",
   UNRESOLVED = "unresolved", // unresolved type reference
 }
 export type ArgType = number | string | boolean | Record<string, unknown>;

--- a/src/fuzzer/generators/GeneratorFactory.ts
+++ b/src/fuzzer/generators/GeneratorFactory.ts
@@ -23,8 +23,9 @@ export function GeneratorFactory<T extends ArgType>(
   arg: ArgDef<T>,
   prng: seedrandom.prng
 ): () => any {
-  // For constant values, return the constant
-  if (arg.isConstant()) return () => arg.getConstantValue();
+  // For constant values of no dimensions, return the constant
+  if (arg.isConstant() && arg.getDim() === 0)
+    return () => arg.getConstantValue();
 
   let randFn: typeof getRandomNumber;
 

--- a/src/fuzzer/generators/GeneratorFactory.ts
+++ b/src/fuzzer/generators/GeneratorFactory.ts
@@ -38,6 +38,9 @@ export function GeneratorFactory<T extends ArgType>(
     case "string":
       randFn = getRandomString;
       break;
+    case "literal":
+      randFn = getLiteral;
+      break;
     case "object":
       // We generate this here using arg
       randFn = <T extends ArgType>(
@@ -155,6 +158,27 @@ const getRandomBool = <T extends ArgType>(
   if (!min && !max) return false as T;
   return (prng() >= 0.5) as T;
 }; // getRandomBool()
+
+/**
+ * Returns a literal value
+ *
+ * @param prng pesudo-random number generator
+ * @param min minimum value allowed (inclusive)
+ * @param max maximum value allowed (inclusive)
+ * @param options argument option set
+ * @returns the constant
+ *
+ * Throws an exception if min and max are not the same
+ */
+const getLiteral = <T extends ArgType>(
+  prng: seedrandom.prng,
+  min: T,
+  max: T,
+  options: ArgOptions
+): T => {
+  if (min === max) return min as T;
+  throw new Error("Min and max must be the same for literals");
+}; // getLiteral()
 
 /**
  * Returns a random string >= min and <= max with

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -362,6 +362,14 @@ export class FuzzPanel {
       if (inputTests.version === CURR_FILE_FMT_VER) {
         // current format -- no changes needed
         return inputTests;
+      } else if (inputTests.version === "0.3.3") {
+        // v0.3.3 format -- only additions such as isVoid and literal types that
+        // older versions of NaNofuzz will not interpret
+        const testSet = { ...inputTests, version: CURR_FILE_FMT_VER };
+        console.info(
+          `Upgraded test set in file ${jsonFile} to ${inputTests.version} to ${testSet.version}`
+        );
+        return testSet;
       } else if (inputTests.version === "0.3.0") {
         // v0.3.0 format -- infer arg strCharset override from function default
         const testSet = { ...inputTests, version: CURR_FILE_FMT_VER };
@@ -1980,7 +1988,7 @@ const fuzzPanelStateVer = "FuzzPanelStateSerialized-0.3.6";
 /**
  * Current file format version for persisting test sets / pinned test cases
  */
-const CURR_FILE_FMT_VER = "0.3.3"; // !!!! Increment if file format changes
+const CURR_FILE_FMT_VER = "0.3.6"; // !!!! Increment if file format changes
 
 // ----------------------------- Types ----------------------------- //
 

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1501,7 +1501,11 @@ ${inArgConsts}
       typeString = argTypeRef.substring(argTypeRef.lastIndexOf(".") + 1);
     } else {
       typeString =
-        argType === fuzzer.ArgTag.OBJECT ? "Object" : argType.toLowerCase();
+        argType === fuzzer.ArgTag.OBJECT
+          ? "Object"
+          : argType === fuzzer.ArgTag.LITERAL && arg.isConstant()
+          ? htmlEscape(JSON5.stringify(arg.getConstantValue(), undefined, 2))
+          : argType.toLowerCase();
     }
 
     // prettier-ignore
@@ -1512,7 +1516,11 @@ ${inArgConsts}
       <div class="argDef-name" style="font-size:1.25em;">
         <strong>${htmlEscape(
           arg.getName()
-        )}</strong>${optionalString}: ${typeString}${dimString} =
+        )}</strong>${optionalString}: ${typeString}${dimString} 
+        ${argType === fuzzer.ArgTag.LITERAL
+          ? ""
+          : "="
+        }
         ${argType === fuzzer.ArgTag.OBJECT
           ? ' {'
           : ''


### PR DESCRIPTION
This PR adds support for basic literal types `string`, `number`, and `boolean` such as in the following example:

```TypeScript
type litn = 3;
type lita = "a";
type litb = true;
export function testLit(n:litn, a:lita, b:litb) {return;}
```

Optionality and dimensions are supported. At this time we do not support `RegEx`, `null`, or `bigint` literals nor `TemplateLiteral`, `UnaryExpression`, `UpdateExpression` expressions.