### PR TITLE
feat: support union types (#63)

### DIFF
--- a/assets/ui/FuzzPanelMain.css
+++ b/assets/ui/FuzzPanelMain.css
@@ -121,6 +121,10 @@ td.clickable {
   clear: both;
 }
 
+.argDef-preClose {
+  clear: both;
+}
+
 .argDef-close {
   float: left;
 }

--- a/assets/ui/FuzzPanelMain.css
+++ b/assets/ui/FuzzPanelMain.css
@@ -111,6 +111,35 @@ td.clickable {
   opacity: 50%;
 }
 
+.argDef-name {
+  float: left;
+}
+
+.argDef,
+.argDef-type,
+.argDef-array {
+  clear: both;
+}
+
+.argDef-close {
+  float: left;
+}
+
+.isNoInput {
+  float: right;
+  padding-right: 0.85em;
+}
+
+.isNoInput vscode-checkbox {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.faded {
+  background-color: var(--vscode-list-inactiveSelectionBackground);
+  opacity: 50%;
+}
+
 /* Expected output panel */
 td.classErrorCell {
   text-decoration: red underline wavy;

--- a/assets/ui/FuzzPanelMain.js
+++ b/assets/ui/FuzzPanelMain.js
@@ -468,9 +468,17 @@ function setIsNoInput(vsCodeCheckbox, isChecked) {
   });
   // Hide/Show the arg settings
   thisArg
-    .querySelectorAll(":scope > .argDef-type, :scope > .argDef-array")
+    .querySelectorAll(
+      ":scope > .argDef-type, :scope > .argDef-array, :scope > .argDef-preClose"
+    )
     .forEach((child) => {
       (isChecked ? show : hide)(child);
+    });
+  // Hide/Show the ellipsis
+  thisArg
+    .querySelectorAll(":scope > .argDef-name > .argDef-ellipsis")
+    .forEach((child) => {
+      (isChecked ? hide : show)(child);
     });
 } // fn: setIsNoInput()
 

--- a/assets/ui/FuzzPanelMain.js
+++ b/assets/ui/FuzzPanelMain.js
@@ -103,6 +103,23 @@ function main() {
     .getElementById("fuzzOptions-close")
     .addEventListener("click", (e) => toggleFuzzOptions(e));
 
+  // Add event listeners for all the union generate checkboxes
+  document.querySelectorAll(".isNoInput vscode-checkbox").forEach((element) => {
+    element.addEventListener("click", (e) =>
+      setIsNoInput(
+        e.target,
+        (e.target.getAttribute("value") ??
+          e.target.getAttribute("current-checked")) !== "true" // changing state
+      )
+    );
+    // Set the UI state
+    setIsNoInput(
+      element,
+      (element.getAttribute("value") ??
+        element.getAttribute("current-checked")) === "true" // steady state
+    );
+  });
+
   // Load the fuzzer results data from the HTML
   resultsData = JSON5.parse(
     htmlUnescape(document.getElementById("fuzzResultsData").innerHTML)
@@ -429,6 +446,33 @@ function toggleFuzzOptions(e) {
   // Refresh the list of validators
   handleGetListOfValidators();
 } // fn: toggleFuzzOptions()
+
+/**
+ * Sets whether the argument should generate inputs
+ *
+ * @param e onClick() event target
+ */
+function setIsNoInput(vsCodeCheckbox, isChecked) {
+  const checkboxWrapper = vsCodeCheckbox.parentElement;
+  const thisArg = vsCodeCheckbox.parentElement.parentElement;
+
+  // Fade/un-fade the arg (except the checkbox wrapper)
+  thisArg.querySelectorAll(":scope > div").forEach((child) => {
+    if (child != checkboxWrapper) {
+      if (isChecked) {
+        child.classList.remove("faded");
+      } else {
+        child.classList.add("faded");
+      }
+    }
+  });
+  // Hide/Show the arg settings
+  thisArg
+    .querySelectorAll(":scope > .argDef-type, :scope > .argDef-array")
+    .forEach((child) => {
+      (isChecked ? show : hide)(child);
+    });
+} // fn: setIsNoInput()
 
 /**
  * Toggles whether a test is pinned for CI and the next test run.
@@ -1313,6 +1357,8 @@ function handleFuzzStart(eCurrTarget) {
     const minStrLen = document.getElementById(idBase + "-minStrLen");
     const maxStrLen = document.getElementById(idBase + "-maxStrLen");
     const strCharset = document.getElementById(idBase + "-strCharset");
+    const isNoInput = document.getElementById(idBase + "-isNoInput");
+    console.debug(idBase + "-isNoInput"); // !!!!!
 
     // Process numeric overrides
     if (numInteger !== null) {
@@ -1359,6 +1405,14 @@ function handleFuzzStart(eCurrTarget) {
         };
       }
     } // TODO: Validation !!!
+
+    // Process isNoInput overrides
+    if (isNoInput !== null) {
+      disableArr.push(isNoInput);
+      thisOverride["isNoInput"] =
+        (isNoInput.getAttribute("value") ??
+          isNoInput.getAttribute("current-checked")) !== "true";
+    }
 
     // Process array dimension overrides
     const dimLength = [];

--- a/src/fuzzer/Fuzzer.test.ts
+++ b/src/fuzzer/Fuzzer.test.ts
@@ -86,6 +86,25 @@ export const testArrowVoidLiteralArgs = (n: 5, n2: 5[]): void => {
 };
 
 /**
+ * Fuzz targets with union arguments
+ */
+type hellos = "hello" | "bonjour" | "olá" | "ciao" | "hej";
+type stringOrNumber = string | number;
+type maybeString = string | undefined;
+export function testStandardUnionArgs(
+  a: stringOrNumber,
+  b: maybeString[]
+): boolean | undefined {
+  return;
+}
+export const testArrowUnionArgs = (
+  a: stringOrNumber,
+  b: maybeString[]
+): boolean | undefined => {
+  return;
+};
+
+/**
  * These tests currently just ensure that the fuzzer runs and produces output
  * for each example. TODO: Add tests that check the fuzzer output.
  */
@@ -478,5 +497,23 @@ describe("Fuzzer", () => {
     ).results;
     expect(results.length).not.toStrictEqual(0);
     expect(results.some((e) => e.passedImplicit)).toBeTruthy();
+  });
+
+  /**
+   * Test that we can fuzz functions with union arguments.
+   */
+  test("Standard union arg fuzz target", async () => {
+    const results = (
+      await fuzz(setup(intOptions, "./Fuzzer.test.ts", "testStandardUnionArgs"))
+    ).results;
+    expect(results.length).not.toStrictEqual(0);
+    expect(results.some((e) => e.passedImplicit)).toBeFalsy();
+  });
+  test("Arrow union arg fuzz target", async () => {
+    const results = (
+      await fuzz(setup(intOptions, "./Fuzzer.test.ts", "testArrowUnionArgs"))
+    ).results;
+    expect(results.length).not.toStrictEqual(0);
+    expect(results.some((e) => e.passedImplicit)).toBeFalsy();
   });
 });

--- a/src/fuzzer/Types.ts
+++ b/src/fuzzer/Types.ts
@@ -135,6 +135,7 @@ export type FuzzArgOverride = {
   array?: {
     dimLength: { min: number; max: number }[];
   };
+  isNoInput?: boolean;
 };
 
 /**

--- a/src/fuzzer/analysis/typescript/ArgDef.test.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.test.ts
@@ -139,7 +139,7 @@ describe("fuzzer/analysis/typescript/ArgDef: getTypeAnnotation", () => {
       [],
       "Type"
     );
-    expect(argDef.getTypeAnnotation()).toBe("Type");
+    expect(argDef.getTypeAnnotation()).toStrictEqual("Type");
   });
 
   test("should return the literal type for literal types", () => {
@@ -156,6 +156,243 @@ describe("fuzzer/analysis/typescript/ArgDef: getTypeAnnotation", () => {
         makeTypeRef(dummyModule, "str", ArgTag.STRING, 0),
       ]
     );
-    expect(argDef.getTypeAnnotation()).toBe("{ bool: boolean; str: string }");
+    expect(argDef.getTypeAnnotation()).toStrictEqual(
+      "{ bool: boolean; str: string }"
+    );
+  });
+
+  test("type annotation for union with dimensions", () => {
+    const argDef = makeArgDef(
+      dummyModule,
+      "test",
+      0,
+      ArgTag.UNION,
+      argOptions,
+      1,
+      false,
+      [
+        makeTypeRef(dummyModule, "bool", ArgTag.BOOLEAN, 1),
+        makeTypeRef(dummyModule, "str", ArgTag.STRING, 0),
+        makeTypeRef(
+          dummyModule,
+          "litn",
+          ArgTag.LITERAL,
+          0,
+          undefined,
+          undefined,
+          undefined,
+          5
+        ),
+        makeTypeRef(
+          dummyModule,
+          "lita",
+          ArgTag.LITERAL,
+          0,
+          undefined,
+          undefined,
+          undefined,
+          "x"
+        ),
+        makeTypeRef(
+          dummyModule,
+          "und",
+          ArgTag.LITERAL,
+          0,
+          undefined,
+          undefined,
+          undefined,
+          undefined
+        ),
+      ]
+    );
+    expect(argDef.getTypeAnnotation()).toStrictEqual(
+      "(boolean[] | string | 5 | 'x' | undefined)[]"
+    );
+  });
+
+  test("type annotation for union with dimensions and optionality", () => {
+    const argDef = makeArgDef(
+      dummyModule,
+      "test",
+      0,
+      ArgTag.UNION,
+      argOptions,
+      1,
+      true,
+      [
+        makeTypeRef(dummyModule, "bool", ArgTag.BOOLEAN, 1),
+        makeTypeRef(dummyModule, "str", ArgTag.STRING, 0),
+        makeTypeRef(
+          dummyModule,
+          "litn",
+          ArgTag.LITERAL,
+          0,
+          undefined,
+          undefined,
+          undefined,
+          5
+        ),
+        makeTypeRef(
+          dummyModule,
+          "lita",
+          ArgTag.LITERAL,
+          0,
+          undefined,
+          undefined,
+          undefined,
+          "x"
+        ),
+        makeTypeRef(
+          dummyModule,
+          "und",
+          ArgTag.LITERAL,
+          0,
+          undefined,
+          undefined,
+          undefined,
+          undefined
+        ),
+      ]
+    );
+    expect(argDef.getTypeAnnotation()).toStrictEqual(
+      "(boolean[] | string | 5 | 'x' | undefined)[] | undefined"
+    );
+  });
+
+  test("type annotation for union w/o dimensions", () => {
+    const argDef = makeArgDef(
+      dummyModule,
+      "test",
+      0,
+      ArgTag.UNION,
+      argOptions,
+      0,
+      false,
+      [
+        makeTypeRef(dummyModule, "bool", ArgTag.BOOLEAN, 1),
+        makeTypeRef(dummyModule, "str", ArgTag.STRING, 0),
+        makeTypeRef(
+          dummyModule,
+          "litn",
+          ArgTag.LITERAL,
+          0,
+          undefined,
+          undefined,
+          undefined,
+          5
+        ),
+        makeTypeRef(
+          dummyModule,
+          "lita",
+          ArgTag.LITERAL,
+          0,
+          undefined,
+          undefined,
+          undefined,
+          "x"
+        ),
+        makeTypeRef(
+          dummyModule,
+          "und",
+          ArgTag.LITERAL,
+          0,
+          undefined,
+          undefined,
+          undefined,
+          undefined
+        ),
+      ]
+    );
+    expect(argDef.getTypeAnnotation()).toStrictEqual(
+      "boolean[] | string | 5 | 'x' | undefined"
+    );
+  });
+
+  test("type annotation for union w/double optionality", () => {
+    const argDef = makeArgDef(
+      dummyModule,
+      "test",
+      0,
+      ArgTag.UNION,
+      argOptions,
+      0,
+      true,
+      [
+        makeTypeRef(dummyModule, "bool", ArgTag.BOOLEAN, 1),
+        makeTypeRef(dummyModule, "str", ArgTag.STRING, 0),
+        makeTypeRef(
+          dummyModule,
+          "litn",
+          ArgTag.LITERAL,
+          0,
+          undefined,
+          undefined,
+          undefined,
+          5
+        ),
+        makeTypeRef(
+          dummyModule,
+          "lita",
+          ArgTag.LITERAL,
+          0,
+          undefined,
+          undefined,
+          undefined,
+          "x"
+        ),
+        makeTypeRef(
+          dummyModule,
+          "und",
+          ArgTag.LITERAL,
+          0,
+          undefined,
+          undefined,
+          undefined,
+          undefined
+        ),
+      ]
+    );
+    expect(argDef.getTypeAnnotation()).toStrictEqual(
+      "boolean[] | string | 5 | 'x' | undefined"
+    );
+  });
+
+  test("type annotation for union w/single optionality", () => {
+    const argDef = makeArgDef(
+      dummyModule,
+      "test",
+      0,
+      ArgTag.UNION,
+      argOptions,
+      0,
+      true,
+      [
+        makeTypeRef(dummyModule, "bool", ArgTag.BOOLEAN, 1),
+        makeTypeRef(dummyModule, "str", ArgTag.STRING, 0),
+        makeTypeRef(
+          dummyModule,
+          "litn",
+          ArgTag.LITERAL,
+          0,
+          undefined,
+          undefined,
+          undefined,
+          5
+        ),
+        makeTypeRef(
+          dummyModule,
+          "lita",
+          ArgTag.LITERAL,
+          0,
+          undefined,
+          undefined,
+          undefined,
+          "x"
+        ),
+      ]
+    );
+    expect(argDef.getTypeAnnotation()).toStrictEqual(
+      "boolean[] | string | 5 | 'x' | undefined"
+    );
   });
 });

--- a/src/fuzzer/analysis/typescript/ArgDef.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.ts
@@ -376,7 +376,9 @@ export class ArgDef<T extends ArgType> {
    *
    * @param options the argument's option set
    */
-  public setOptions(options: ArgOptions | ArgOptionOverride): void {
+  public setOptions(inOptions: ArgOptions | ArgOptionOverride): void {
+    const options = { ...inOptions };
+
     // Cascade child options to child arguments
     if ("children" in options) {
       for (const child in options.children) {
@@ -397,8 +399,12 @@ export class ArgDef<T extends ArgType> {
     }
 
     // Merge the two option sets; incoming has precedence
-    const newOptions = { ...this.options, ...options };
-    delete newOptions["children"], newOptions["numMin"], newOptions["numMax"];
+    const newOptions: ArgOptions = { ...this.options, ...options };
+
+    // Handle isNoInput
+    if (options.isNoInput === false) {
+      delete newOptions.isNoInput;
+    }
 
     // Ensure the options are valid before ingesting them
     if (!ArgDef.isOptionValid(newOptions))

--- a/src/fuzzer/analysis/typescript/ArgDef.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.ts
@@ -102,7 +102,7 @@ export class ArgDef<T extends ArgType> {
     // Intervals are required for literal types !!!!!
     // if (type === ArgTag.LITERAL && (!intervals || !intervals.length)) {
     //  throw new Error(`An interval is required for the literal ArgDef type`);
-    //}
+    // }
 
     // If no interval is provided, use the type's default
     this.intervals =
@@ -268,6 +268,17 @@ export class ArgDef<T extends ArgType> {
   public isOptional(): boolean {
     return this.optional;
   } // fn: isOptional()
+
+  /**
+   * Returns whether the argument should receive input.
+   *
+   * Only applies to union members.
+   *
+   * @returns true if the argument should not receive input.
+   */
+  public isNoInput(): boolean {
+    return this.options.noInput ?? false;
+  } // fn: isNoInput()
 
   /**
    * Returns the input intervals for the argument.

--- a/src/fuzzer/analysis/typescript/ArgDef.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.ts
@@ -277,7 +277,7 @@ export class ArgDef<T extends ArgType> {
    * @returns true if the argument should not receive input.
    */
   public isNoInput(): boolean {
-    return this.options.noInput ?? false;
+    return this.options.isNoInput ?? false;
   } // fn: isNoInput()
 
   /**

--- a/src/fuzzer/analysis/typescript/ArgDef.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.ts
@@ -474,7 +474,7 @@ export class ArgDef<T extends ArgType> {
     let baseType = this.getBaseType();
 
     // Wrap union types w/dims in parens prior to adding the dims
-    if (this.type === ArgTag.UNION && this.dims) {
+    if (this.type === ArgTag.UNION && this.dims && this.typeRef === undefined) {
       baseType = `(${baseType})`;
     }
 

--- a/src/fuzzer/analysis/typescript/FunctionDef.test.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.test.ts
@@ -773,4 +773,136 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
       },
     ]);
   });
+
+  test("findFnInSource: union args", () => {
+    const src = `
+    type hellos = "hello" | "bonjour" | "olá" | "ciao" | "hej";
+    type stringOrNumber = string | number;
+    type maybeString = string | undefined;
+    export function test(a:stringOrNumber,b:maybeString[]):boolean | undefined {return;}
+    `;
+    const thisProgram = dummyProgram.setSrc(() => src);
+    expect(
+      Object.values(thisProgram.getFunctions()).map((e) => e.getRef())
+    ).toStrictEqual([
+      {
+        name: "test",
+        module: "dummy.ts",
+        src: "function test(a:stringOrNumber,b:maybeString[]):boolean | undefined {return;}",
+        startOffset: 162,
+        endOffset: 239,
+        isExported: true,
+        isVoid: false,
+        args: [
+          {
+            dims: 0,
+            isExported: false,
+            module: "dummy.ts",
+            name: "a",
+            optional: false,
+            type: {
+              children: [
+                {
+                  dims: 0,
+                  isExported: false,
+                  module: "dummy.ts",
+                  optional: false,
+                  type: {
+                    children: [],
+                    resolved: true,
+                    type: "string",
+                  },
+                },
+                {
+                  dims: 0,
+                  isExported: false,
+                  module: "dummy.ts",
+                  optional: false,
+                  type: {
+                    children: [],
+                    resolved: true,
+                    type: "number",
+                  },
+                },
+              ],
+              resolved: true,
+              type: "union",
+            },
+            typeRefName: "stringOrNumber",
+          },
+          {
+            dims: 1,
+            isExported: false,
+            module: "dummy.ts",
+            name: "b",
+            optional: false,
+            type: {
+              children: [
+                {
+                  dims: 0,
+                  isExported: false,
+                  module: "dummy.ts",
+                  optional: false,
+                  type: {
+                    children: [],
+                    resolved: true,
+                    type: "string",
+                  },
+                },
+                {
+                  dims: 0,
+                  isExported: false,
+                  module: "dummy.ts",
+                  optional: false,
+                  type: {
+                    children: [],
+                    resolved: true,
+                    type: "literal",
+                  },
+                },
+              ],
+              resolved: true,
+              type: "union",
+            },
+            typeRefName: "maybeString",
+          },
+        ],
+        returnType: {
+          dims: 0,
+          isExported: false,
+          module: "dummy.ts",
+          optional: false,
+          type: {
+            resolved: true,
+            type: "union",
+            children: [
+              {
+                dims: 0,
+                isExported: false,
+                module: "dummy.ts",
+                optional: false,
+                type: {
+                  children: [],
+                  resolved: true,
+                  type: "boolean",
+                },
+              },
+              {
+                dims: 0,
+                isExported: false,
+                module: "dummy.ts",
+                optional: false,
+                type: {
+                  children: [],
+                  resolved: true,
+                  type: "literal",
+                  value: undefined,
+                },
+              },
+            ],
+          },
+        },
+      },
+    ]);
+  });
 });

--- a/src/fuzzer/analysis/typescript/Types.ts
+++ b/src/fuzzer/analysis/typescript/Types.ts
@@ -97,6 +97,9 @@ export type ArgOptions = {
   // for number[][]: dimLength[0] = length of 1st dimension
   // and dimLength[1] = length of 2nd dimension.
   dftDimLength: Interval<number>; // Length of any dimension not specified in dimLength.
+
+  // For members of a union, suppress input generation
+  noInput?: boolean; // true=do not generate inputs (unions only)
 };
 
 /**
@@ -117,6 +120,7 @@ export type ArgOptionOverride = {
   strLength?: Interval<number>;
   strCharset?: string;
   children?: ArgOptionOverrides;
+  noInput?: boolean;
 };
 
 /**

--- a/src/fuzzer/analysis/typescript/Types.ts
+++ b/src/fuzzer/analysis/typescript/Types.ts
@@ -99,7 +99,7 @@ export type ArgOptions = {
   dftDimLength: Interval<number>; // Length of any dimension not specified in dimLength.
 
   // For members of a union, suppress input generation
-  noInput?: boolean; // true=do not generate inputs (unions only)
+  isNoInput?: boolean; // true=do not generate inputs (unions only)
 };
 
 /**
@@ -120,7 +120,7 @@ export type ArgOptionOverride = {
   strLength?: Interval<number>;
   strCharset?: string;
   children?: ArgOptionOverrides;
-  noInput?: boolean;
+  isNoInput?: boolean;
 };
 
 /**

--- a/src/fuzzer/analysis/typescript/Types.ts
+++ b/src/fuzzer/analysis/typescript/Types.ts
@@ -69,6 +69,7 @@ export enum ArgTag {
   BOOLEAN = "boolean",
   OBJECT = "object",
   LITERAL = "literal",
+  UNION = "union",
   UNRESOLVED = "unresolved", // unresolved type reference
 }
 export type ArgType = number | string | boolean | Record<string, unknown>;

--- a/src/fuzzer/generators/GeneratorFactory.ts
+++ b/src/fuzzer/generators/GeneratorFactory.ts
@@ -52,7 +52,10 @@ export function GeneratorFactory<T extends ArgType>(
       ): T => {
         if (typeof min !== "object" || typeof max !== "object")
           throw new Error("Min and max must be objects");
-        const children = arg.getChildren();
+        let children = arg.getChildren().filter((child) => !child.isNoInput());
+        if (!children.length) {
+          children = arg.getChildren();
+        }
         const rn = getRandomNumber(
           prng,
           0,

--- a/src/fuzzer/generators/GeneratorFactory.ts
+++ b/src/fuzzer/generators/GeneratorFactory.ts
@@ -102,7 +102,13 @@ export function GeneratorFactory<T extends ArgType>(
   // Callback fn to generate random value
   const randFnWrapper = () => {
     if (type === ArgTag.OBJECT) return randFn(prng, {}, {}, options);
-    if (type === ArgTag.UNION) return randFn(prng, {}, {}, options);
+    if (type === ArgTag.UNION) {
+      if (arg.getChildren().filter((child) => !child.isNoInput()).length) {
+        return randFn(prng, {}, {}, options);
+      } else {
+        return undefined; // no active union members
+      }
+    }
     if (type === ArgTag.LITERAL && !intervals.length) return undefined;
 
     // TODO: weight interval selection based on the size of the interval !!!

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1577,7 +1577,7 @@ ${inArgConsts}
       // prettier-ignore
       html += /*html*/ `
         <div class="isNoInput tooltipped tooltipped-nw" aria-label="Generate inputs of this type?">
-          <vscode-checkbox id="${idBase}-isNoInput" ${disabledFlag} ${arg.isNoInput() ? "" : "checked"}></vscode-checkbox>
+          <vscode-checkbox id="${idBase}-isNoInput" ${disabledFlag} ${arg.isNoInput() ? "" : "checked"} current-checked="${arg.isNoInput() ? "false" : "true"}"></vscode-checkbox>
         </div>`
     }
 

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1511,6 +1511,7 @@ ${inArgConsts}
       this._state === FuzzPanelState.busy ? ` disabled ` : ""; // Disable inputs if busy
     const dimString = "[]".repeat(arg.getDim()); // Text indicating array dimensions
     const optionalString = arg.isOptional() ? "?" : ""; // Text indication arg optionality
+    const htmlEllipsis = `<span class="hidden argDef-ellipsis">...</span>`;
 
     let typeString: string; // Text indicating the type of argument
     const argTypeRef = arg.getTypeRef();
@@ -1562,10 +1563,10 @@ ${inArgConsts}
         sep = ":";
         break;
       case fuzzer.ArgTag.OBJECT:
-        sep = " = {";
+        sep = ` = {` + htmlEllipsis;
         break;
       default:
-        sep = " =";
+        sep = " = " + htmlEllipsis;
     }
     // prettier-ignore
     html += /*html*/ `
@@ -1706,7 +1707,7 @@ ${inArgConsts}
     html += `</div>`;
     // For objects: output the end of object character ("}") here
     if (argType === fuzzer.ArgTag.OBJECT) {
-      html += /*html*/ `<div class="argDef-close" style="font-size:1.25em;">}${endSep}</div>`;
+      html += /*html*/ `<div class="argDef-preClose"></div><div class="argDef-close" style="font-size:1.25em;">}${endSep}</div>`;
     }
     html += `</div>`;
 

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -941,553 +941,546 @@ ${inArgConsts}
    * TODO: Move styles to CSS !!!
    */
   _updateHtml(): void {
-    const webview: vscode.Webview = this._panel.webview; // Current webview
-    const extensionUri: vscode.Uri = this._extensionUri; // Extension URI
-    const disabledFlag =
-      this._state === FuzzPanelState.busy ? ` disabled ` : ""; // Disable inputs if busy
-    const resultSummary = {
-      failure: 0,
-      timeout: 0,
-      exception: 0,
-      badValue: 0,
-      ok: 0,
-      disagree: 0,
-    }; // Summary of fuzzing results
-    const toolkitUri = getUri(webview, extensionUri, [
-      "node_modules",
-      "@vscode",
-      "webview-ui-toolkit",
-      "dist",
-      "toolkit.js",
-    ]); // URI to the VS Code webview ui toolkit
-    const codiconsUri = getUri(webview, extensionUri, [
-      "node_modules",
-      "@vscode",
-      "codicons",
-      "dist",
-      "codicon.css",
-    ]);
-    const json5Uri = getUri(webview, extensionUri, [
-      "node_modules",
-      "json5",
-      "dist",
-      "index.js",
-    ]); // URI to the json5 library
-    const scriptUrl = getUri(webview, extensionUri, [
-      "assets",
-      "ui",
-      "FuzzPanelMain.js",
-    ]); // URI to client-side panel script
-    const cssUrl = getUri(webview, extensionUri, [
-      "assets",
-      "ui",
-      "FuzzPanelMain.css",
-    ]); // URI to client-side panel script
-    const env = this._fuzzEnv; // Fuzzer environment
-    const fn = env.function; // Function under test
-    const counter = { id: 0 }; // Unique counter for argument ids
-    let argDefHtml = ""; // HTML representing argument definitions
-    const heuristicValidatorDescription = fn.isVoid()
-      ? "Heuristic validator (for void functions). Fails: timeout, exception, values !==undefined"
-      : "Heuristic validator. Fails: timeout, exception, null, undefined, Infinity, NaN";
+    let html = "";
+    try {
+      const webview: vscode.Webview = this._panel.webview; // Current webview
+      const extensionUri: vscode.Uri = this._extensionUri; // Extension URI
+      const disabledFlag =
+        this._state === FuzzPanelState.busy ? ` disabled ` : ""; // Disable inputs if busy
+      const resultSummary = {
+        failure: 0,
+        timeout: 0,
+        exception: 0,
+        badValue: 0,
+        ok: 0,
+        disagree: 0,
+      }; // Summary of fuzzing results
+      const toolkitUri = getUri(webview, extensionUri, [
+        "node_modules",
+        "@vscode",
+        "webview-ui-toolkit",
+        "dist",
+        "toolkit.js",
+      ]); // URI to the VS Code webview ui toolkit
+      const codiconsUri = getUri(webview, extensionUri, [
+        "node_modules",
+        "@vscode",
+        "codicons",
+        "dist",
+        "codicon.css",
+      ]);
+      const json5Uri = getUri(webview, extensionUri, [
+        "node_modules",
+        "json5",
+        "dist",
+        "index.js",
+      ]); // URI to the json5 library
+      const scriptUrl = getUri(webview, extensionUri, [
+        "assets",
+        "ui",
+        "FuzzPanelMain.js",
+      ]); // URI to client-side panel script
+      const cssUrl = getUri(webview, extensionUri, [
+        "assets",
+        "ui",
+        "FuzzPanelMain.css",
+      ]); // URI to client-side panel script
+      const env = this._fuzzEnv; // Fuzzer environment
+      const fn = env.function; // Function under test
+      const counter = { id: 0 }; // Unique counter for argument ids
+      let argDefHtml = ""; // HTML representing argument definitions
+      const heuristicValidatorDescription = fn.isVoid()
+        ? "Heuristic validator (for void functions). Fails: timeout, exception, values !==undefined"
+        : "Heuristic validator. Fails: timeout, exception, null, undefined, Infinity, NaN";
 
-    // If fuzzer results are available, calculate how many tests passed, failed, etc.
-    if (this._state === FuzzPanelState.done && this._results !== undefined) {
-      this._results.results.forEach((result) => {
-        resultSummary[result.category]++;
-      });
-    } // if: results are available
+      // If fuzzer results are available, calculate how many tests passed, failed, etc.
+      if (this._state === FuzzPanelState.done && this._results !== undefined) {
+        this._results.results.forEach((result) => {
+          resultSummary[result.category]++;
+        });
+      } // if: results are available
 
-    // Render the HTML for each argument
-    fn.getArgDefs().forEach(
-      (arg, i) =>
-        (argDefHtml += this._argDefToHtmlForm(
-          arg,
-          counter,
-          i === fn.getArgDefs().length - 1
-        ))
-    );
+      // Render the HTML for each argument
+      fn.getArgDefs().forEach(
+        (arg, i) =>
+          (argDefHtml += this._argDefToHtmlForm(
+            arg,
+            counter,
+            "",
+            i === fn.getArgDefs().length - 1 ? "" : ","
+          ))
+      );
 
-    // Prettier abhorrently butchers this HTML, so disable prettier here
-    // prettier-ignore
-    let html = /*html*/ `
-      <!DOCTYPE html>
-      <html lang="en">
-        <head>
-          <meta charset="UTF-8">
-          <meta name="viewport" content="width=device-width, initial-scale=1.0">
-          <script type="module" src="${toolkitUri}"></script>
-          <script src="${json5Uri}"></script>
-          <script type="module" src="${scriptUrl}"></script>
-          <link rel="stylesheet" type="text/css" href="${cssUrl}">
-          <link rel="stylesheet" type="text/css" href="${codiconsUri}">
-          <title>${toolName} Panel</title>
-        </head>
-        <body>
-          
-        <!-- ${toolName} pane -->
-        <div id="pane-nanofuzz"> 
-          <h2 style="font-size:1.75em; padding-top:.2em; margin-bottom:.2em;"> ${this._state === FuzzPanelState.busy ? "Testing..." : "Test: "+htmlEscape(
-            fn.getName())+"()"} </h2>
+      // Prettier abhorrently butchers this HTML, so disable prettier here
+      // prettier-ignore
+      html += /*html*/ `
+        <!DOCTYPE html>
+        <html lang="en">
+          <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <script type="module" src="${toolkitUri}"></script>
+            <script src="${json5Uri}"></script>
+            <script type="module" src="${scriptUrl}"></script>
+            <link rel="stylesheet" type="text/css" href="${cssUrl}">
+            <link rel="stylesheet" type="text/css" href="${codiconsUri}">
+            <title>${toolName} Panel</title>
+          </head>
+          <body>
+            
+          <!-- ${toolName} pane -->
+          <div id="pane-nanofuzz"> 
+            <h2 style="font-size:1.75em; padding-top:.2em; margin-bottom:.2em;"> ${this._state === FuzzPanelState.busy ? "Testing..." : "Test: "+htmlEscape(
+              fn.getName())+"()"} </h2>
 
-          <!-- Function Arguments -->
-          <div id="argDefs">${argDefHtml}</div>
+            <!-- Function Arguments -->
+            <div id="argDefs">${argDefHtml}</div>
 
-          <!-- Change Validators Options -->
-          <p style="font-size:1.2em; margin-top: 0.1em; margin-bottom: 0.1em;"><strong>Categorize output using:</strong></p>
-          <div style="padding-left: .76em;">
-            <!-- Checkboxes -->
-            <div class="fuzzInputControlGroup">
-              <vscode-checkbox ${disabledFlag} id="fuzz-useImplicit" ${this._fuzzEnv.options.useImplicit ? "checked" : ""}>
-                <span class="tooltipped tooltipped-ne" aria-label="${heuristicValidatorDescription}">
-                Heuristic validator 
-                </span>
-              </vscode-checkbox>
-              <span style="padding-left:1.3em;"> </span>
-              <span style="display:inline-block;">
-                <vscode-checkbox ${disabledFlag} id="fuzz-useProperty" ${this._fuzzEnv.options.useProperty ? "checked" : ""}>
-                  <span id="validator-functionList" class="tooltipped tooltipped-ne" aria-label=""> 
-                  Property validator(s) </span>
+            <!-- Change Validators Options -->
+            <p style="font-size:1.2em; margin-top: 0.1em; margin-bottom: 0.1em;"><strong>Categorize output using:</strong></p>
+            <div style="padding-left: .76em;">
+              <!-- Checkboxes -->
+              <div class="fuzzInputControlGroup">
+                <vscode-checkbox ${disabledFlag} id="fuzz-useImplicit" ${this._fuzzEnv.options.useImplicit ? "checked" : ""}>
+                  <span class="tooltipped tooltipped-ne" aria-label="${heuristicValidatorDescription}">
+                  Heuristic validator 
+                  </span>
                 </vscode-checkbox>
-                <span id="validator.add" class="tooltipped tooltipped-nw" aria-label="Add new property validator">
-                  <span class="classAddRefreshValidator">
-                    <span class="codicon codicon-add" style="padding-left:.2em; padding-right:-.1em;"></span>
+                <span style="padding-left:1.3em;"> </span>
+                <span style="display:inline-block;">
+                  <vscode-checkbox ${disabledFlag} id="fuzz-useProperty" ${this._fuzzEnv.options.useProperty ? "checked" : ""}>
+                    <span id="validator-functionList" class="tooltipped tooltipped-ne" aria-label=""> 
+                    Property validator(s) </span>
+                  </vscode-checkbox>
+                  <span id="validator.add" class="tooltipped tooltipped-nw" aria-label="Add new property validator">
+                    <span class="classAddRefreshValidator">
+                      <span class="codicon codicon-add" style="padding-left:.2em; padding-right:-.1em;"></span>
+                    </span>
+                  </span>
+                  <span id="validator.getList" class="tooltipped tooltipped-nw" aria-label="Refresh list">
+                    <span class="classAddRefreshValidator">
+                      <span class="codicon codicon-refresh" style="padding-left:.1em;"></span>
+                    </span>
                   </span>
                 </span>
-                <span id="validator.getList" class="tooltipped tooltipped-nw" aria-label="Refresh list">
-                  <span class="classAddRefreshValidator">
-                    <span class="codicon codicon-refresh" style="padding-left:.1em;"></span>
-                  </span>
-                </span>
-              </span>
+              </div>
             </div>
-          </div>
-
-          <vscode-divider></vscode-divider>
-
-          <!-- Fuzzer Options -->
-          <div id="fuzzOptions" class="hidden">
-            <div class="panelButton">
-              <span class="codicon codicon-close" id="fuzzOptions-close"></span>
-            </div>
-            <h2>More options</h2>
-
-            <vscode-panels aria-label="Options tabs" class="fuzzTabStrip">
-              <!-- <vscode-panel-tab aria-label="Validating options tab">Validating</vscode-panel-tab> -->
-              <vscode-panel-tab aria-label="Reporting options tab">Reporting</vscode-panel-tab>
-              <vscode-panel-tab aria-label="Stopping options tab">Stopping</vscode-panel-tab>
-
-              <!-- <vscode-panel-view class="hidden">
-                  <p>
-                    Use a <strong>custom validator function</strong> to automatically categorize outputs as passed (✔︎) or failed (X). 
-                    Click the (+) button to create a new custom validator function.
-                  </p>
-                  <div id="validatorFunctions-edit">
-                    <div> 
-                    <vscode-radio-group id="validatorFunctions-radios">
-                      <vscode-button ${disabledFlag} id="validator.addHIDDEN" appearance="icon" aria-label="Add">
-                        <span class="tooltipped tooltipped-n" aria-label="New validator function">
-                          <span class="codicon codicon-add"></span>
-                        </span>
-                      </vscode-button>
-                      <vscode-button ${disabledFlag} id="validator.getListHIDDEN" appearance="icon" aria-label="Refresh">
-                        <span class="tooltipped tooltipped-n" aria-label="Refresh list">
-                          <span class="codicon codicon-refresh"></span>
-                        </span>
-                      </vscode-button>
-                    </vscode-radio-group>
-                    </div> 
-                  </div>
-              </vscode-panel-view> 
-              -->
-
-              <vscode-panel-view>
-                <p>
-                  Choose what test results to report.
-                </p>
-                <div class="fuzzInputControlGroup">
-                  <vscode-radio-group id="fuzz-onlyFailures">
-                    <vscode-radio ${disabledFlag} id="onlyFailures.false" name="onlyFailures.false" value="false" ${
-                      !this._fuzzEnv.options.onlyFailures ? "checked" : ""}>Report all test results</vscode-radio>
-                    <vscode-radio ${disabledFlag} id="onlyFailures.true" name="onlyFailures.true" value="true" ${
-                      this._fuzzEnv.options.onlyFailures ? "checked" : ""}>Report only failed test results</vscode-radio>
-                  </vscode-radio-group>
-                </div>
-              </vscode-panel-view>
-
-              <vscode-panel-view>
-                <p>
-                  These settings control how long testing runs. Testing stops when any limit is reached.  
-                  Saved or pinned tests count against the maximum runtime and number of failures but do not count against the maximum number of tests. 
-                  For max runtime and number of failed tests, 0 indicates no limit.
-                </p>
-                <div class="fuzzInputControlGroup">
-                  <vscode-text-field ${disabledFlag} size="3" id="fuzz-suiteTimeout" name="fuzz-suiteTimeout" value="${this._fuzzEnv.options.suiteTimeout}">
-                    Max runtime (ms)
-                  </vscode-text-field>
-                  <vscode-text-field ${disabledFlag} size="3" id="fuzz-maxTests" name="fuzz-maxTests" value="${this._fuzzEnv.options.maxTests}">
-                    Max number of tests
-                  </vscode-text-field>
-                  <vscode-text-field ${disabledFlag} size="3" id="fuzz-maxFailures" name="fuzz-maxFailures" value="${this._fuzzEnv.options.maxFailures}">
-                    Max failed tests
-                  </vscode-text-field>
-                  <vscode-text-field ${disabledFlag} size="3" id="fuzz-maxDupeInputs" name="fuzz-maxDupeInputs" value="${this._fuzzEnv.options.maxDupeInputs}">
-                    Max dupe inputs
-                  </vscode-text-field>
-                </div>
-  
-                <p>
-                  To ensure testing completes, stop long-running function calls and categorize them as timeouts.
-                </p>
-                <div class="fuzzInputControlGroup">
-                  <vscode-text-field ${disabledFlag} size="3" id="fuzz-fnTimeout" name="fuzz-fnTimeout" value="${this._fuzzEnv.options.fnTimeout}">
-                    Test function timeout (ms)
-                  </vscode-text-field>
-                </div>
-              </vscode-panel-view>
-              </vscode-panels>
 
             <vscode-divider></vscode-divider>
-          </div>
 
-          <!-- Button Bar -->
-          <div style="padding-top: .25em;">
-            <vscode-button ${disabledFlag} id="fuzz.start" appearance="primary">
-              ${this._state === FuzzPanelState.busy ? "Testing..." : "Test"}
-            </vscode-button>
-            <vscode-button  ${disabledFlag} class="hidden" id="fuzz.changeMode" appearance="secondary" aria-label="Change Mode">
-              Change Mode
-            </vscode-button>
-            <vscode-button ${disabledFlag} ${ 
-              vscode.workspace
-                .getConfiguration("nanofuzz.ui")
-                .get("hideMoreOptionsButton")
-                  ? `class="hidden" ` 
-                  : ``
-              } id="fuzz.options" appearance="secondary" aria-label="Fuzzer Options">
-              More options...
+            <!-- Fuzzer Options -->
+            <div id="fuzzOptions" class="hidden">
+              <div class="panelButton">
+                <span class="codicon codicon-close" id="fuzzOptions-close"></span>
+              </div>
+              <h2>More options</h2>
+
+              <vscode-panels aria-label="Options tabs" class="fuzzTabStrip">
+                <!-- <vscode-panel-tab aria-label="Validating options tab">Validating</vscode-panel-tab> -->
+                <vscode-panel-tab aria-label="Reporting options tab">Reporting</vscode-panel-tab>
+                <vscode-panel-tab aria-label="Stopping options tab">Stopping</vscode-panel-tab>
+
+
+                <vscode-panel-view>
+                  <p>
+                    Choose what test results to report.
+                  </p>
+                  <div class="fuzzInputControlGroup">
+                    <vscode-radio-group id="fuzz-onlyFailures">
+                      <vscode-radio ${disabledFlag} id="onlyFailures.false" name="onlyFailures.false" value="false" ${
+                        !this._fuzzEnv.options.onlyFailures ? "checked" : ""}>Report all test results</vscode-radio>
+                      <vscode-radio ${disabledFlag} id="onlyFailures.true" name="onlyFailures.true" value="true" ${
+                        this._fuzzEnv.options.onlyFailures ? "checked" : ""}>Report only failed test results</vscode-radio>
+                    </vscode-radio-group>
+                  </div>
+                </vscode-panel-view>
+
+                <vscode-panel-view>
+                  <p>
+                    These settings control how long testing runs. Testing stops when any limit is reached.  
+                    Saved or pinned tests count against the maximum runtime and number of failures but do not count against the maximum number of tests. 
+                    For max runtime and number of failed tests, 0 indicates no limit.
+                  </p>
+                  <div class="fuzzInputControlGroup">
+                    <vscode-text-field ${disabledFlag} size="3" id="fuzz-suiteTimeout" name="fuzz-suiteTimeout" value="${this._fuzzEnv.options.suiteTimeout}">
+                      Max runtime (ms)
+                    </vscode-text-field>
+                    <vscode-text-field ${disabledFlag} size="3" id="fuzz-maxTests" name="fuzz-maxTests" value="${this._fuzzEnv.options.maxTests}">
+                      Max number of tests
+                    </vscode-text-field>
+                    <vscode-text-field ${disabledFlag} size="3" id="fuzz-maxFailures" name="fuzz-maxFailures" value="${this._fuzzEnv.options.maxFailures}">
+                      Max failed tests
+                    </vscode-text-field>
+                    <vscode-text-field ${disabledFlag} size="3" id="fuzz-maxDupeInputs" name="fuzz-maxDupeInputs" value="${this._fuzzEnv.options.maxDupeInputs}">
+                      Max dupe inputs
+                    </vscode-text-field>
+                  </div>
+    
+                  <p>
+                    To ensure testing completes, stop long-running function calls and categorize them as timeouts.
+                  </p>
+                  <div class="fuzzInputControlGroup">
+                    <vscode-text-field ${disabledFlag} size="3" id="fuzz-fnTimeout" name="fuzz-fnTimeout" value="${this._fuzzEnv.options.fnTimeout}">
+                      Test function timeout (ms)
+                    </vscode-text-field>
+                  </div>
+                </vscode-panel-view>
+                </vscode-panels>
+
+              <vscode-divider></vscode-divider>
+            </div>
+
+            <!-- Button Bar -->
+            <div style="padding-top: .25em;">
+              <vscode-button ${disabledFlag} id="fuzz.start" appearance="primary">
+                ${this._state === FuzzPanelState.busy ? "Testing..." : "Test"}
               </vscode-button>
-          </div>
+              <vscode-button  ${disabledFlag} class="hidden" id="fuzz.changeMode" appearance="secondary" aria-label="Change Mode">
+                Change Mode
+              </vscode-button>
+              <vscode-button ${disabledFlag} ${ 
+                vscode.workspace
+                  .getConfiguration("nanofuzz.ui")
+                  .get("hideMoreOptionsButton")
+                    ? `class="hidden" ` 
+                    : ``
+                } id="fuzz.options" appearance="secondary" aria-label="Fuzzer Options">
+                More options...
+                </vscode-button>
+            </div>
 
-          <!-- Fuzzer Errors -->
-          <div class="fuzzErrors${
-            this._state === FuzzPanelState.error
-              ? ""
-              : " hidden"
-          }">
-            <h3>Testing stopped with this error:</h3>
-            <p>${this._errorMessage ?? "Unknown error"}</p>
-          </div>
+            <!-- Fuzzer Errors -->
+            <div class="fuzzErrors${
+              this._state === FuzzPanelState.error
+                ? ""
+                : " hidden"
+            }">
+              <h3>Testing stopped with this error:</h3>
+              <p>${this._errorMessage ?? "Unknown error"}</p>
+            </div>
 
-          <!-- Fuzzer Warnings -->
-          <div class="fuzzWarnings${
-            this._state === FuzzPanelState.done && !this._fuzzEnv.options.useHuman && !this._fuzzEnv.options.useImplicit && (!this._fuzzEnv.options.useProperty || !this._fuzzEnv.validators.length )
-              ? ""
-              : " hidden"
-          }">
-            <p>No validators were selected, so all tests below will pass. You can change this by turning on one or more validators.</p>
-          </div>
+            <!-- Fuzzer Warnings -->
+            <div class="fuzzWarnings${
+              this._state === FuzzPanelState.done && !this._fuzzEnv.options.useHuman && !this._fuzzEnv.options.useImplicit && (!this._fuzzEnv.options.useProperty || !this._fuzzEnv.validators.length )
+                ? ""
+                : " hidden"
+            }">
+              <p>No validators were selected, so all tests below will pass. You can change this by turning on one or more validators.</p>
+            </div>
 
-          <div class="fuzzWarnings${
-            this._state === FuzzPanelState.done && this._fuzzEnv.options.useProperty && !(this._fuzzEnv.validators.length)
-              ? ""
-              : " hidden"
-          }">
-            <p>No property validators were found, so the property validator column is blank. Click (+) to add a property validator.</p>
-          </div>
+            <div class="fuzzWarnings${
+              this._state === FuzzPanelState.done && this._fuzzEnv.options.useProperty && !(this._fuzzEnv.validators.length)
+                ? ""
+                : " hidden"
+            }">
+              <p>No property validators were found, so the property validator column is blank. Click (+) to add a property validator.</p>
+            </div>
 
-          <!-- Fuzzer Info -->
-          <div class="fuzzInfo${
-            this._state === FuzzPanelState.done && this._fuzzEnv.options.onlyFailures && this._results?.results.length === 0 
-              ? ""
-              : " hidden"
-          }">
-            <p>All tests passed.</p>
-          </div>
-          
-          <!-- Fuzzer Output -->
-          <div class="fuzzResults" ${
-            this._state === FuzzPanelState.done
-              ? ""
-              : /*html*/ `style="display:none;"`
-          }>
-            <vscode-panels aria-label="Test result tabs" class="fuzzTabStrip">`;
+            <!-- Fuzzer Info -->
+            <div class="fuzzInfo${
+              this._state === FuzzPanelState.done && this._fuzzEnv.options.onlyFailures && this._results?.results.length === 0 
+                ? ""
+                : " hidden"
+            }">
+              <p>All tests passed.</p>
+            </div>
+            
+            <!-- Fuzzer Output -->
+            <div class="fuzzResults" ${
+              this._state === FuzzPanelState.done
+                ? ""
+                : /*html*/ `style="display:none;"`
+            }>
+              <vscode-panels aria-label="Test result tabs" class="fuzzTabStrip">`;
 
-    // If we have results, render the output tabs to display the results.
-    const tabs: (
-      | {
-          id: fuzzer.FuzzResultCategory;
-          name: string;
-          description: string;
-          hasGrid: boolean;
+      // If we have results, render the output tabs to display the results.
+      const tabs: (
+        | {
+            id: fuzzer.FuzzResultCategory;
+            name: string;
+            description: string;
+            hasGrid: boolean;
+          }
+        | {
+            id: "runInfo";
+            name: string;
+            description: string;
+            hasGrid: false;
+          }
+      )[] = [
+        {
+          id: "failure",
+          name: "Validator Error",
+          description: `A property validator threw an exception for these inputs. Fix the bug in the property validator and re-test.`,
+          hasGrid: true,
+        },
+        {
+          id: "disagree",
+          name: "Disagree",
+          description: `The property and human validators disagreed about how to categorize these outputs. Correct one of the validators and re-test.`,
+          hasGrid: true,
+        },
+        {
+          id: "timeout",
+          name: "Timeouts",
+          description: `These inputs did not terminate within ${this._fuzzEnv.options.fnTimeout}ms, and no validator categorized them as passed.`,
+          hasGrid: true,
+        },
+        {
+          id: "exception",
+          name: "Exceptions",
+          description: `These inputs resulted in a runtime exception, and no validator categorized them as passed.`,
+          hasGrid: true,
+        },
+        {
+          id: "badValue",
+          name: "Failed",
+          description: `${
+            this._fuzzEnv.options.useProperty // if using property validator
+              ? `The property or human validator categorized these outputs as failed.`
+              : this._fuzzEnv.options.useImplicit // if using heuristic validator
+              ? `The heuristic or human validator categorized these outputs as failed.`
+              : `The human validator categorized these outputs as failed.`
+          }`,
+          // description: `A validator categorized these outputs as failed. The heuristic validator by default fails outputs that contain null, NaN, Infinity, or undefined if no other validator categorizes them as passed.`,
+          hasGrid: true,
+        },
+        {
+          id: "ok",
+          name: "Passed",
+          description: `A validator categorized these outputs as passed, or no validator categorized them as failed.`,
+          // description: `Passed. No validator categorized these outputs as failed.`,
+          // description: `No validator categorized these outputs as failed, or a validator categorized them as passed.`,
+          hasGrid: true,
+        },
+      ];
+      if (this._results) {
+        // prettier-ignore
+        const textReason = {
+          [fuzzer.FuzzStopReason.CRASH]: `because it crashed.`,
+          [fuzzer.FuzzStopReason.MAXTIME]: `because it exceeded the maximum time configured (${
+              this._results.env.options.suiteTimeout
+            } ms) for it to run.`,
+          [fuzzer.FuzzStopReason.MAXFAILURES]: `because it found ${
+              this._results.env.options.maxFailures
+            } failing test${
+              this._results.env.options.maxFailures !== 1 ? "s" : ""
+            }. This is the maximum number configured.`,
+          [fuzzer.FuzzStopReason.MAXTESTS]: `because it reached the maximum number of new tests configured (${
+              this._results.env.options.maxTests
+            }). This is in addition to the ${this._results.inputsSaved} saved test${
+              this._results.inputsSaved !== 1 ? "s" : ""
+            } ${toolName} also executed.`,
+          [fuzzer.FuzzStopReason.MAXDUPES]: `because it reached the maximum number of sequentially-generated duplicate inputs configured (${
+              this._results.env.options.maxDupeInputs
+            }). This can mean that NaNofuzz is having difficulty generating further new inputs: the function's input space might be small or near exhaustion. You can change this setting in More Options.`,
+          "": `because of an unknown reason.`,
+        };
+
+        // Build the list of validators used/not used
+        const validatorsUsed: string[] = [];
+        const validatorsNotUsed: string[] = [];
+        let validatorsUsedText: string;
+        let validatorsUsedText2 = "";
+        (env.options.useImplicit ? validatorsUsed : validatorsNotUsed).push(
+          "<strong><u>heuristic</u></strong>"
+        );
+        (env.options.useHuman ? validatorsUsed : validatorsNotUsed).push(
+          "<strong><u>human</u></strong>"
+        );
+        if (env.validators.length && env.options.useProperty) {
+          env.validators.forEach((e) => {
+            validatorsUsed.push(`<strong><u>property:${e.name}</u></strong>`);
+          });
+        } else if (!env.options.useProperty) {
+          validatorsNotUsed.push(`<strong><u>property</u></strong>`);
+        } else {
+          validatorsUsedText2 = `The <strong><u>property</u></strong> validator was active, but no property validators were found, so ${toolName} raised an on-screen warning.`;
         }
-      | {
-          id: "runInfo";
-          name: string;
-          description: string;
-          hasGrid: false;
+        if (validatorsUsed.length) {
+          validatorsUsedText = `
+            ${toolName} categorized outputs using the ${toPrettyList(
+            validatorsUsed
+          )} validator${validatorsUsed.length > 1 ? "s" : ""}. `;
+          if (validatorsNotUsed.length) {
+            validatorsUsedText += `The ${toPrettyList(
+              validatorsNotUsed
+            )} validator${
+              validatorsNotUsed.length > 1 ? "s were" : " was"
+            } not configured.`;
+          }
+        } else {
+          validatorsUsedText = `${toolName} did not use any validators in this test. This means that all tests were categorized as passed.`;
         }
-    )[] = [
-      {
-        id: "failure",
-        name: "Validator Error",
-        description: `A property validator threw an exception for these inputs. Fix the bug in the property validator and re-test.`,
-        hasGrid: true,
-      },
-      {
-        id: "disagree",
-        name: "Disagree",
-        description: `The property and human validators disagreed about how to categorize these outputs. Correct one of the validators and re-test.`,
-        hasGrid: true,
-      },
-      {
-        id: "timeout",
-        name: "Timeouts",
-        description: `These inputs did not terminate within ${this._fuzzEnv.options.fnTimeout}ms, and no validator categorized them as passed.`,
-        hasGrid: true,
-      },
-      {
-        id: "exception",
-        name: "Exceptions",
-        description: `These inputs resulted in a runtime exception, and no validator categorized them as passed.`,
-        hasGrid: true,
-      },
-      {
-        id: "badValue",
-        name: "Failed",
-        description: `${
-          this._fuzzEnv.options.useProperty // if using property validator
-            ? `The property or human validator categorized these outputs as failed.`
-            : this._fuzzEnv.options.useImplicit // if using heuristic validator
-            ? `The heuristic or human validator categorized these outputs as failed.`
-            : `The human validator categorized these outputs as failed.`
-        }`,
-        // description: `A validator categorized these outputs as failed. The heuristic validator by default fails outputs that contain null, NaN, Infinity, or undefined if no other validator categorizes them as passed.`,
-        hasGrid: true,
-      },
-      {
-        id: "ok",
-        name: "Passed",
-        description: `A validator categorized these outputs as passed, or no validator categorized them as failed.`,
-        // description: `Passed. No validator categorized these outputs as failed.`,
-        // description: `No validator categorized these outputs as failed, or a validator categorized them as passed.`,
-        hasGrid: true,
-      },
-    ];
-    if (this._results) {
-      // prettier-ignore
-      const textReason = {
-        [fuzzer.FuzzStopReason.CRASH]: `because it crashed.`,
-        [fuzzer.FuzzStopReason.MAXTIME]: `because it exceeded the maximum time configured (${
-            this._results.env.options.suiteTimeout
-          } ms) for it to run.`,
-        [fuzzer.FuzzStopReason.MAXFAILURES]: `because it found ${
-            this._results.env.options.maxFailures
-          } failing test${
-            this._results.env.options.maxFailures !== 1 ? "s" : ""
-          }. This is the maximum number configured.`,
-        [fuzzer.FuzzStopReason.MAXTESTS]: `because it reached the maximum number of new tests configured (${
-            this._results.env.options.maxTests
-          }). This is in addition to the ${this._results.inputsSaved} saved test${
+
+        // Add the run info tab to the panel
+        tabs.push({
+          id: "runInfo",
+          name: `<div class="codicon codicon-info"></div>`,
+          description: /*html*/ `
+
+          <div class="fuzzResultHeading">What did ${toolName} do?</div>
+          <p>
+            ${toolName} ran for ${this._results.elapsedTime} ms, re-tested ${
+            this._results.inputsSaved
+          } saved input${
             this._results.inputsSaved !== 1 ? "s" : ""
-          } ${toolName} also executed.`,
-        [fuzzer.FuzzStopReason.MAXDUPES]: `because it reached the maximum number of sequentially-generated duplicate inputs configured (${
-            this._results.env.options.maxDupeInputs
-          }). This can mean that NaNofuzz is having difficulty generating further new inputs: the function's input space might be small or near exhaustion. You can change this setting in More Options.`,
-        "": `because of an unknown reason.`,
-      };
+          }, generated ${this._results.inputsGenerated} new input${
+            this._results.inputsGenerated !== 1 ? "s" : ""
+          } (${this._results.dupesGenerated} of which ${
+            this._results.dupesGenerated !== 1
+              ? "were duplicates"
+              : "was a duplicate"
+          } ${toolName} previously tested), and reported ${
+            this._results.results.length
+          } test result${
+            this._results.results.length !== 1 ? "s" : ""
+          } before stopping.
+          </p>
 
-      // Build the list of validators used/not used
-      const validatorsUsed: string[] = [];
-      const validatorsNotUsed: string[] = [];
-      let validatorsUsedText: string;
-      let validatorsUsedText2 = "";
-      (env.options.useImplicit ? validatorsUsed : validatorsNotUsed).push(
-        "<strong><u>heuristic</u></strong>"
-      );
-      (env.options.useHuman ? validatorsUsed : validatorsNotUsed).push(
-        "<strong><u>human</u></strong>"
-      );
-      if (env.validators.length && env.options.useProperty) {
-        env.validators.forEach((e) => {
-          validatorsUsed.push(`<strong><u>property:${e.name}</u></strong>`);
-        });
-      } else if (!env.options.useProperty) {
-        validatorsNotUsed.push(`<strong><u>property</u></strong>`);
-      } else {
-        validatorsUsedText2 = `The <strong><u>property</u></strong> validator was active, but no property validators were found, so ${toolName} raised an on-screen warning.`;
-      }
-      if (validatorsUsed.length) {
-        validatorsUsedText = `
-          ${toolName} categorized outputs using the ${toPrettyList(
-          validatorsUsed
-        )} validator${validatorsUsed.length > 1 ? "s" : ""}. `;
-        if (validatorsNotUsed.length) {
-          validatorsUsedText += `The ${toPrettyList(
-            validatorsNotUsed
-          )} validator${
-            validatorsNotUsed.length > 1 ? "s were" : " was"
-          } not configured.`;
-        }
-      } else {
-        validatorsUsedText = `${toolName} did not use any validators in this test. This means that all tests were categorized as passed.`;
-      }
-
-      // Add the run info tab to the panel
-      tabs.push({
-        id: "runInfo",
-        name: `<div class="codicon codicon-info"></div>`,
-        description: /*html*/ `
-
-        <div class="fuzzResultHeading">What did ${toolName} do?</div>
-        <p>
-          ${toolName} ran for ${this._results.elapsedTime} ms, re-tested ${
-          this._results.inputsSaved
-        } saved input${this._results.inputsSaved !== 1 ? "s" : ""}, generated ${
-          this._results.inputsGenerated
-        } new input${this._results.inputsGenerated !== 1 ? "s" : ""} (${
-          this._results.dupesGenerated
-        } of which ${
-          this._results.dupesGenerated !== 1
-            ? "were duplicates"
-            : "was a duplicate"
-        } ${toolName} previously tested), and reported ${
-          this._results.results.length
-        } test result${
-          this._results.results.length !== 1 ? "s" : ""
-        } before stopping.
-        </p>
-
-        <div class="fuzzResultHeading">How were outputs categorized?</div>
-        <p>
-          ${validatorsUsedText} ${validatorsUsedText2}
-        </p>
-        
-        <div class="fuzzResultHeading">Why did testing stop?</div>
-        <p>
-          ${toolName} stopped testing ${
-          this._results.stopReason in textReason
-            ? textReason[this._results.stopReason]
-            : textReason[""]
-        }
-        </p>
-        
-        <div class="fuzzResultHeading">What was returned?</div>
-        <p>
-          ${toolName} is configured to return <strong>${
-          this._results.env.options.onlyFailures ? "only failed" : "all"
-        }</strong> test results, and it found ${
-          this._results.results.length
-        } of these to return. ${
-          this._results.results.length
-            ? "You can view these returned results in the other tabs."
-            : ""
-        }${
-          this._results.results.length === 0 &&
-          this._results.env.options.onlyFailures
-            ? "In other words, all tests passed."
-            : ""
-        }
-        </p>
-        
-        <p ${
-          vscode.workspace
-            .getConfiguration("nanofuzz.ui")
-            .get("hideMoreOptionsButton")
-            ? `class="hidden" `
-            : ``
-        }>
-          You may change the configuration using the <strong>More options</strong> button, or the options at the top of the screen.
-        </p>
-`,
-        hasGrid: false,
-      });
-    }
-    tabs.forEach((e) => {
-      if (!e.hasGrid || resultSummary[e.id] > 0) {
-        // prettier-ignore
-        html += /*html*/ `
-              <vscode-panel-tab id="tab-${e.id}" style="font-size:1.15em;">
-                ${e.name}`;
-        if (e.hasGrid) {
-          // prettier-ignore
-          html += /*html*/ `
-                <vscode-badge appearance="secondary">${
-                  resultSummary[e.id]
-                }</vscode-badge>`;
-        }
-        // prettier-ignore
-        html += /*html*/ `
-              </vscode-panel-tab>`;
-      }
-    });
-
-    tabs.forEach((e) => {
-      if (!e.hasGrid || resultSummary[e.id] > 0) {
-        html += /*html*/ `
-              <vscode-panel-view class="fuzzGridPanel" id="view-${e.id}">
-                <section>
-                  <div class="fuzzPanelDescription">${e.description}</div>`;
-        if (e.hasGrid) {
-          // prettier-ignore
-          html += /*html*/ `
-                  <div id="fuzzResultsGrid-${e.id}">
-                    <table class="fuzzGrid">
-                      <thead class="columnSortOrder" id="fuzzResultsGrid-${e.id}-thead" /> 
-                      <tbody id="fuzzResultsGrid-${e.id}-tbody" />
-                    </table>
-                  </div>`;
-        }
-        // prettier-ignore
-        html += /*html*/ `
-                </section>
-              </vscode-panel-view>`;
-      }
-    });
-
-    // prettier-ignore
-    html += /*html*/ `
-            </vscode-panels>
-          </div>`;
-
-    // Hidden data for the client script to process
-    html += /*html*/ `
-          <!-- Fuzzer Result Payload: for the client script to process -->
-          <div id="fuzzResultsData" style="display:none">
-            ${
-              this._results === undefined
-                ? "{}"
-                : htmlEscape(JSON5.stringify(this._results))
-            }
-          </div>
-
-          <!-- Fuzzer Sort Columns: for the client script to process -->
-          <div id="fuzzSortColumns" style="display:none">
-            ${
-              this._sortColumns === undefined
-                ? "{}"
-                : htmlEscape(JSON5.stringify(this._sortColumns))
-            }
-          </div>
+          <div class="fuzzResultHeading">How were outputs categorized?</div>
+          <p>
+            ${validatorsUsedText} ${validatorsUsedText2}
+          </p>
           
-          <!-- Validator Functions: for the client script to process -->
-          <div id="validators" style="display:none">
-            ${htmlEscape(
-              JSON5.stringify({
-                disabled: !!disabledFlag,
-                validators: this._fuzzEnv.validators.map((e) => e.name),
-              })
-            )}
-          </div>
+          <div class="fuzzResultHeading">Why did testing stop?</div>
+          <p>
+            ${toolName} stopped testing ${
+            this._results.stopReason in textReason
+              ? textReason[this._results.stopReason]
+              : textReason[""]
+          }
+          </p>
+          
+          <div class="fuzzResultHeading">What was returned?</div>
+          <p>
+            ${toolName} is configured to return <strong>${
+            this._results.env.options.onlyFailures ? "only failed" : "all"
+          }</strong> test results, and it found ${
+            this._results.results.length
+          } of these to return. ${
+            this._results.results.length
+              ? "You can view these returned results in the other tabs."
+              : ""
+          }${
+            this._results.results.length === 0 &&
+            this._results.env.options.onlyFailures
+              ? "In other words, all tests passed."
+              : ""
+          }
+          </p>
+          
+          <p ${
+            vscode.workspace
+              .getConfiguration("nanofuzz.ui")
+              .get("hideMoreOptionsButton")
+              ? `class="hidden" `
+              : ``
+          }>
+            You may change the configuration using the <strong>More options</strong> button, or the options at the top of the screen.
+          </p>
+  `,
+          hasGrid: false,
+        });
+      }
+      tabs.forEach((e) => {
+        if (!e.hasGrid || resultSummary[e.id] > 0) {
+          // prettier-ignore
+          html += /*html*/ `
+                <vscode-panel-tab id="tab-${e.id}" style="font-size:1.15em;">
+                  ${e.name}`;
+          if (e.hasGrid) {
+            // prettier-ignore
+            html += /*html*/ `
+                  <vscode-badge appearance="secondary">${
+                    resultSummary[e.id]
+                  }</vscode-badge>`;
+          }
+          // prettier-ignore
+          html += /*html*/ `
+                </vscode-panel-tab>`;
+        }
+      });
 
-          <!-- Fuzzer State Payload: for the client script to persist -->
-          <div id="fuzzPanelState" style="display:none">
-            ${htmlEscape(JSON5.stringify(this.getState()))}
+      tabs.forEach((e) => {
+        if (!e.hasGrid || resultSummary[e.id] > 0) {
+          html += /*html*/ `
+                <vscode-panel-view class="fuzzGridPanel" id="view-${e.id}">
+                  <section>
+                    <div class="fuzzPanelDescription">${e.description}</div>`;
+          if (e.hasGrid) {
+            // prettier-ignore
+            html += /*html*/ `
+                    <div id="fuzzResultsGrid-${e.id}">
+                      <table class="fuzzGrid">
+                        <thead class="columnSortOrder" id="fuzzResultsGrid-${e.id}-thead" /> 
+                        <tbody id="fuzzResultsGrid-${e.id}-tbody" />
+                      </table>
+                    </div>`;
+          }
+          // prettier-ignore
+          html += /*html*/ `
+                  </section>
+                </vscode-panel-view>`;
+        }
+      });
+
+      // prettier-ignore
+      html += /*html*/ `
+              </vscode-panels>
+            </div>`;
+
+      // Hidden data for the client script to process
+      html += /*html*/ `
+            <!-- Fuzzer Result Payload: for the client script to process -->
+            <div id="fuzzResultsData" style="display:none">
+              ${
+                this._results === undefined
+                  ? "{}"
+                  : htmlEscape(JSON5.stringify(this._results))
+              }
+            </div>
+
+            <!-- Fuzzer Sort Columns: for the client script to process -->
+            <div id="fuzzSortColumns" style="display:none">
+              ${
+                this._sortColumns === undefined
+                  ? "{}"
+                  : htmlEscape(JSON5.stringify(this._sortColumns))
+              }
+            </div>
+            
+            <!-- Validator Functions: for the client script to process -->
+            <div id="validators" style="display:none">
+              ${htmlEscape(
+                JSON5.stringify({
+                  disabled: !!disabledFlag,
+                  validators: this._fuzzEnv.validators.map((e) => e.name),
+                })
+              )}
+            </div>
+
+            <!-- Fuzzer State Payload: for the client script to persist -->
+            <div id="fuzzPanelState" style="display:none">
+              ${htmlEscape(JSON5.stringify(this.getState()))}
+            </div>
           </div>
-        </div>
-        </body>
-      </html>
-    `;
+          </body>
+        </html>
+      `;
+    } catch (e: any) {
+      html = /*html*/ `
+      <head></head>
+      <body>
+        <h1>:-(</h1>
+        <p>Unable to render this panel due to an internal error in FuzzPanel.updateHtml().</p>
+        <p>Stack trace:</p>
+        <pre>${e.stack}</pre>
+      <body>`;
+      console.debug(
+        `Exception in updateHtml(): ${e.message} stack: ${e.stack}`
+      );
+    }
 
     // Update the webview with the new HTML
     this._panel.webview.html = html;
@@ -1505,11 +1498,13 @@ ${inArgConsts}
   private _argDefToHtmlForm(
     arg: fuzzer.ArgDef<fuzzer.ArgType>,
     counter: { id: number }, // pass counter by reference
-    isLast: boolean
+    beginSep: string,
+    endSep: string
   ): string {
     const id = counter.id++; // unique id for each argument
     const idBase = `argDef-${id}`; // base HTML id for this argument
     const argType = arg.getType(); // type of argument
+    const argName = arg.getName(); // name of the argument
     const disabledFlag =
       this._state === FuzzPanelState.busy ? ` disabled ` : ""; // Disable inputs if busy
     const dimString = "[]".repeat(arg.getDim()); // Text indicating array dimensions
@@ -1518,14 +1513,25 @@ ${inArgConsts}
     let typeString: string; // Text indicating the type of argument
     const argTypeRef = arg.getTypeRef();
     if (argTypeRef !== undefined) {
-      typeString = argTypeRef.substring(argTypeRef.lastIndexOf(".") + 1);
+      typeString = htmlEscape(
+        argTypeRef.substring(argTypeRef.lastIndexOf(".") + 1)
+      );
     } else {
-      typeString =
-        argType === fuzzer.ArgTag.OBJECT
-          ? "Object"
-          : argType === fuzzer.ArgTag.LITERAL && arg.isConstant()
-          ? htmlEscape(JSON5.stringify(arg.getConstantValue(), undefined, 2))
-          : argType.toLowerCase();
+      typeString = htmlEscape(argType.toLowerCase());
+      switch (argType) {
+        case fuzzer.ArgTag.OBJECT:
+          typeString = "Object";
+          break;
+        case fuzzer.ArgTag.LITERAL:
+          if (arg.isConstant()) {
+            const constantValue = arg.getConstantValue();
+            typeString =
+              constantValue === undefined
+                ? "undefined"
+                : htmlEscape(JSON5.stringify(constantValue, undefined, 2));
+          }
+          break;
+      }
     }
 
     // prettier-ignore
@@ -1533,17 +1539,32 @@ ${inArgConsts}
     <!-- Argument Definition -->
     <div class="argDef" id="${idBase}">
       <!-- Argument Name -->
-      <div class="argDef-name" style="font-size:1.25em;">
-        <strong>${htmlEscape(
-          arg.getName()
-        )}</strong>${optionalString}: ${typeString}${dimString}${argType === fuzzer.ArgTag.LITERAL
-          ? isLast ? "" : ","
-          : " ="
-        }
-        ${argType === fuzzer.ArgTag.OBJECT
-          ? ' {'
-          : ''
-        }
+      <div class="argDef-name" style="font-size:1.25em;">${beginSep}`;
+
+    if (argName !== "unknown") {
+      // prettier-ignore
+      html += /*html*/ `
+          <strong>${arg.getName()}</strong>${optionalString}: 
+        `
+    }
+
+    let sep: string;
+    switch (argType) {
+      case fuzzer.ArgTag.LITERAL:
+        sep = endSep;
+        break;
+      case fuzzer.ArgTag.UNION:
+        sep = ":";
+        break;
+      case fuzzer.ArgTag.OBJECT:
+        sep = " = {";
+        break;
+      default:
+        sep = " =";
+    }
+    // prettier-ignore
+    html += /*html*/ `
+         ${typeString}${dimString}${sep}
       </div>`;
 
     html += /*html*/ `
@@ -1619,9 +1640,9 @@ ${inArgConsts}
         break;
       }
 
-      // Object-specific Options
-      case fuzzer.ArgTag.OBJECT: {
-        // Only for objects: output the array form prior to the child arguments.
+      // Union-specific Options
+      case fuzzer.ArgTag.UNION: {
+        // Output the array form prior to the child arguments.
         // This seems odd, but the screen reads better to the user this way.
         html += this._argDefArrayToHtmlForm(arg, idBase, disabledFlag);
         html += `<div>`;
@@ -1631,7 +1652,28 @@ ${inArgConsts}
             (html += this._argDefToHtmlForm(
               child,
               counter,
-              i === children.length - 1
+              !i ? "" : " | ",
+              ""
+            ))
+        );
+        html += `</div>`;
+        break;
+      }
+
+      // Object-specific Options
+      case fuzzer.ArgTag.OBJECT: {
+        // Output the array form prior to the child arguments.
+        // This seems odd, but the screen reads better to the user this way.
+        html += this._argDefArrayToHtmlForm(arg, idBase, disabledFlag);
+        html += `<div>`;
+        const children = arg.getChildren();
+        children.forEach(
+          (child, i) =>
+            (html += this._argDefToHtmlForm(
+              child,
+              counter,
+              "",
+              i === children.length - 1 ? "" : ","
             ))
         );
         html += `</div>`;
@@ -1639,17 +1681,15 @@ ${inArgConsts}
       }
     }
 
-    // For objects: output any sub-arguments.
-    if (argType !== fuzzer.ArgTag.OBJECT) {
+    // For objects & unions: output any sub-arguments.
+    if (argType !== fuzzer.ArgTag.OBJECT && argType !== fuzzer.ArgTag.UNION) {
       html += this._argDefArrayToHtmlForm(arg, idBase, disabledFlag);
     }
 
     html += `</div>`;
     // For objects: output the end of object character ("}") here
     if (argType === fuzzer.ArgTag.OBJECT) {
-      html += /*html*/ `<span style="font-size:1.25em;">}${
-        isLast ? "" : ","
-      }</span>`;
+      html += /*html*/ `<span style="font-size:1.25em;">}${endSep}</span>`;
     }
     html += `</div>`;
 

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1646,16 +1646,12 @@ ${inArgConsts}
         // This seems odd, but the screen reads better to the user this way.
         html += this._argDefArrayToHtmlForm(arg, idBase, disabledFlag);
         html += `<div>`;
-        const children = arg.getChildren();
-        children.forEach(
-          (child, i) =>
-            (html += this._argDefToHtmlForm(
-              child,
-              counter,
-              !i ? "" : " | ",
-              ""
-            ))
-        );
+        arg
+          .getChildren()
+          .forEach(
+            (child) =>
+              (html += this._argDefToHtmlForm(child, counter, " | ", ""))
+          );
         html += `</div>`;
         break;
       }

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1000,7 +1000,12 @@ ${inArgConsts}
 
     // Render the HTML for each argument
     fn.getArgDefs().forEach(
-      (arg) => (argDefHtml += this._argDefToHtmlForm(arg, counter))
+      (arg, i) =>
+        (argDefHtml += this._argDefToHtmlForm(
+          arg,
+          counter,
+          i === fn.getArgDefs().length - 1
+        ))
     );
 
     // Prettier abhorrently butchers this HTML, so disable prettier here
@@ -1499,7 +1504,8 @@ ${inArgConsts}
    */
   private _argDefToHtmlForm(
     arg: fuzzer.ArgDef<fuzzer.ArgType>,
-    counter: { id: number } // pass counter by reference
+    counter: { id: number }, // pass counter by reference
+    isLast: boolean
   ): string {
     const id = counter.id++; // unique id for each argument
     const idBase = `argDef-${id}`; // base HTML id for this argument
@@ -1530,10 +1536,9 @@ ${inArgConsts}
       <div class="argDef-name" style="font-size:1.25em;">
         <strong>${htmlEscape(
           arg.getName()
-        )}</strong>${optionalString}: ${typeString}${dimString} 
-        ${argType === fuzzer.ArgTag.LITERAL
-          ? ""
-          : "="
+        )}</strong>${optionalString}: ${typeString}${dimString}${argType === fuzzer.ArgTag.LITERAL
+          ? isLast ? "" : ","
+          : " ="
         }
         ${argType === fuzzer.ArgTag.OBJECT
           ? ' {'
@@ -1620,9 +1625,15 @@ ${inArgConsts}
         // This seems odd, but the screen reads better to the user this way.
         html += this._argDefArrayToHtmlForm(arg, idBase, disabledFlag);
         html += `<div>`;
-        arg
-          .getChildren()
-          .forEach((child) => (html += this._argDefToHtmlForm(child, counter)));
+        const children = arg.getChildren();
+        children.forEach(
+          (child, i) =>
+            (html += this._argDefToHtmlForm(
+              child,
+              counter,
+              i === children.length - 1
+            ))
+        );
         html += `</div>`;
         break;
       }
@@ -1636,7 +1647,9 @@ ${inArgConsts}
     html += `</div>`;
     // For objects: output the end of object character ("}") here
     if (argType === fuzzer.ArgTag.OBJECT) {
-      html += /*html*/ `<span style="font-size:1.25em;">}</span>`;
+      html += /*html*/ `<span style="font-size:1.25em;">}${
+        isLast ? "" : ","
+      }</span>`;
     }
     html += `</div>`;
 


### PR DESCRIPTION
This PR adds support for OR / Union types for the generator, fuzzer, `FuzzPanel`, `TypeDef`, `ArgDef`, and analysis and fuzzer end-to-end unit tests. Some terrible examples of union types:

```TypeScript
type hellos = "hello" | "bonjour" | "olá" | "ciao" | "hej";
type stringOrNumber = string | number;
type maybeString = string | undefined;
```

Union types are implemented in the back-end in a similar way as object types such that each type option is a child type of the union. The generator for union then randomly selects one of the children to generate similar to how it randomly selects intervals.

The `FuzzPanel` UI allows the user to select which OR types to generate during testing along with the usual type-specific options for the input generation (ranges and so-on).

## User Interface

![image](https://github.com/user-attachments/assets/6d106cea-61d0-460c-bc28-94a53727b9d7)


## Limitations

- The `undefined` literal, in this PR, is represented as a literal `ArgDef` with no intervals. This seems limiting and non-obvious so that as we add support for other keywords (e.g., #203) we may want to explore other options for representing such special keyword literals.
- In the case where all union members are marked as `isNoInput`, then the union will generate value `undefined`.