### PR TITLE
feat: `isNoInput` support for optional object members

### DIFF
--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -8,7 +8,7 @@
 export const workspace = {
   getConfiguration: (k: string) => {
     return {
-      get: (k: string, dft?: any) => dft,
+      get: (k: string, dft?: string | number | boolean | undefined) => dft,
     };
   },
 };

--- a/src/fuzzer/Compiler.ts
+++ b/src/fuzzer/Compiler.ts
@@ -117,7 +117,7 @@ function isModified(tsname: string, jsname: string) {
  *
  * @return {string} js file path
  */
-function compileTS(module: any) {
+function compileTS(module: NodeJS.Module) {
   let exitCode = 0;
   const moduleDirName = path.dirname(module.filename);
   const relativeFolder =
@@ -231,7 +231,7 @@ function compileTS(module: any) {
  * @param module Javqscript module
  * @returns The script result, if any
  */
-function runJS(jsname: string, module: any) {
+function runJS(jsname: string, module: NodeJS.Module) {
   const content = fs.readFileSync(jsname, "utf8");
 
   const sandbox: { [k: string]: any } = {};

--- a/src/fuzzer/Fuzzer.test.ts
+++ b/src/fuzzer/Fuzzer.test.ts
@@ -401,8 +401,13 @@ describe("Fuzzer", () => {
     const results = (
       await fuzz(setup(intOptions, "./Fuzzer.test.ts", "testChangeInput"))
     ).results;
+    const resultValue = results[0].input[0].value;
     expect(results.length).not.toStrictEqual(0);
-    expect(results[0].input[0].value.b).toBeUndefined();
+    expect(
+      resultValue !== undefined &&
+        typeof resultValue === "object" &&
+        !("b" in resultValue)
+    ).toBeTruthy();
   });
 
   /**

--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -3,7 +3,7 @@ import * as JSON5 from "json5";
 import vm from "vm";
 import seedrandom from "seedrandom";
 import { ArgDef } from "./analysis/typescript/ArgDef";
-import { FunctionRef } from "./analysis/typescript/Types";
+import { ArgValueType, FunctionRef } from "./analysis/typescript/Types";
 import { GeneratorFactory } from "./generators/GeneratorFactory";
 import * as compiler from "./Compiler";
 import { ProgramDef } from "./analysis/typescript/ProgramDef";
@@ -266,7 +266,7 @@ export const fuzz = async (
         // Build the validator function wrapper
         const validatorFnWrapper = functionTimeout(
           (result: FuzzTestResult): FuzzTestResult => {
-            const inParams: any[] = []; // array of input parameters
+            const inParams: ArgValueType[] = []; // array of input parameters
             result.input.forEach((e) => {
               const param = e.value;
               inParams.push(param);
@@ -444,7 +444,7 @@ export const implicitOracle = (x: any): boolean => {
 export default function functionTimeout(function_: any, timeout: number): any {
   const script = new vm.Script("returnValue = function_()");
 
-  const wrappedFunction = (...arguments_: any[]) => {
+  const wrappedFunction = (...arguments_: ArgValueType[]) => {
     const context = {
       returnValue: undefined,
       function_: () => function_(...arguments_),

--- a/src/fuzzer/Types.ts
+++ b/src/fuzzer/Types.ts
@@ -1,4 +1,4 @@
-import { ArgOptions } from "./analysis/typescript/Types";
+import { ArgOptions, ArgValueType } from "./analysis/typescript/Types";
 
 /**
  * Single Fuzzer Test Result
@@ -27,7 +27,7 @@ export type FuzzTestResult = {
  * Simplified single test result for writing custom validator
  */
 export type Result = {
-  in: any[]; // function input
+  in: ArgValueType[]; // function input
   out: any; // function output
   exception: boolean; // true if an exception was thrown
   timeout: boolean; // true if the fn call timed out
@@ -68,7 +68,7 @@ export type FuzzIoElement = {
   offset: number; // offset of element (0-based)
   isException?: boolean; // true if element is an exception
   isTimeout?: boolean; // true if element is a timeout
-  value: any; // value of element
+  value: ArgValueType; // value of element
 };
 
 /**

--- a/src/fuzzer/analysis/typescript/Types.ts
+++ b/src/fuzzer/analysis/typescript/Types.ts
@@ -73,6 +73,7 @@ export enum ArgTag {
   UNRESOLVED = "unresolved", // unresolved type reference
 }
 export type ArgType = number | string | boolean | Record<string, unknown>;
+export type ArgValueType = ArgType | ArgValueType[] | undefined;
 
 /**
  * The set of options for an argument.  This option set is used to "fill in" information

--- a/src/fuzzer/analysis/typescript/Util.ts
+++ b/src/fuzzer/analysis/typescript/Util.ts
@@ -11,7 +11,7 @@ import {
  * @param value The value of the property being stringified
  * @returns undefined if key==='parent', otherwise value
  */
-export function removeParents(key: any, value: any): any {
+export function removeParents(key: string, value: unknown): unknown {
   if (key === "parent") {
     return undefined;
   } else {

--- a/src/fuzzer/generators/GeneratorFactory.test.ts
+++ b/src/fuzzer/generators/GeneratorFactory.test.ts
@@ -2,7 +2,7 @@ import { ArgDef } from "../analysis/typescript/ArgDef";
 import { GeneratorFactory } from "./GeneratorFactory";
 import seedrandom from "seedrandom";
 import { ProgramDef } from "fuzzer/analysis/typescript/ProgramDef";
-import { ArgOptions } from "fuzzer/analysis/typescript/Types";
+import { ArgOptions, ArgValueType } from "fuzzer/analysis/typescript/Types";
 
 /**
  * Provide a seed to ensure tests are deterministic.
@@ -123,7 +123,8 @@ const testRandomInt = (intMin: number, intMax: number): void => {
   arg[0].setIntervals([{ min: intMin, max: intMax }]);
   const gen = GeneratorFactory(arg[0], prng);
   for (let i = 0; i < 1000; i++) {
-    const result: number = gen();
+    const result: ArgValueType = gen();
+    expect(typeof result === "number" && Number.isInteger(result)).toBeTruthy();
     expect(result).toBeGreaterThanOrEqual(intMin);
     expect(result).toBeLessThanOrEqual(intMax);
   }
@@ -154,7 +155,8 @@ const testRandomFloat = (floatMin: number, floatMax: number): void => {
   arg[0].setIntervals([{ min: floatMin, max: floatMax }]);
   const gen = GeneratorFactory(arg[0], prng);
   for (let i = 0; i < 1000; i++) {
-    const result: number = gen();
+    const result: ArgValueType = gen();
+    expect(typeof result === "number").toBeTruthy();
     expect(result).toBeGreaterThanOrEqual(floatMin);
     expect(result).toBeLessThanOrEqual(floatMax);
   }
@@ -187,10 +189,11 @@ const testRandomBool = (boolMin: boolean, boolMax: boolean): void => {
   const gen = GeneratorFactory(arg[0], prng);
 
   // Test that the generator generates booleans within the bounds
-  const results: boolean[] = [];
+  const results: ArgValueType[] = [];
   for (let i = 0; i < 1000; i++) {
     results.push(gen());
   }
+  expect(results.every((e) => typeof e === "boolean")).toBeTruthy();
   expect(results.some((e) => e === boolMin)).toBeTruthy();
   expect(results.some((e) => e === boolMax)).toBeTruthy();
 };
@@ -226,7 +229,7 @@ const testRandomString = (
   const gen = GeneratorFactory(arg[0], prng);
 
   // Test that the generator generates strings within the bounds
-  const results: string[] = [];
+  const results: ArgValueType[] = [];
   for (let i = 0; i < 1000; i++) {
     results.push(gen());
   }
@@ -235,10 +238,13 @@ const testRandomString = (
   //  expect(results.some((e) => e !== strMax)).toBeTruthy();
   //}
   results.forEach((result) => {
-    expect(result.length).toBeGreaterThanOrEqual(strLenMin);
-    expect(result.length).toBeLessThanOrEqual(strLenMax);
-    //expect(result >= strMin).toBeTruthy();
-    //expect(result <= strMax).toBeTruthy();
+    expect(typeof result === "string").toBeTruthy();
+    if (typeof result === "string") {
+      expect(result.length).toBeGreaterThanOrEqual(strLenMin);
+      expect(result.length).toBeLessThanOrEqual(strLenMax);
+      //expect(result >= strMin).toBeTruthy();
+      //expect(result <= strMax).toBeTruthy();
+    }
   });
 };
 

--- a/src/fuzzer/generators/GeneratorFactory.ts
+++ b/src/fuzzer/generators/GeneratorFactory.ts
@@ -58,8 +58,7 @@ export function GeneratorFactory<T extends ArgType>(
       randFn = (
         prng: seedrandom.prng,
         min: ArgValueType,
-        max: ArgValueType,
-        options: ArgOptions
+        max: ArgValueType
       ): ArgValueType => {
         if (typeof min !== "object" || typeof max !== "object")
           throw new Error("Min and max must be objects");
@@ -81,8 +80,7 @@ export function GeneratorFactory<T extends ArgType>(
       randFn = (
         prng: seedrandom.prng,
         min: ArgValueType,
-        max: ArgValueType,
-        options: ArgOptions
+        max: ArgValueType
       ): ArgValueType => {
         if (typeof min !== "object" || typeof max !== "object")
           throw new Error("Min and max must be objects");
@@ -193,8 +191,7 @@ const getRandomNumber = (
 const getRandomBool: PrivateRandFn = (
   prng: seedrandom.prng,
   min: ArgValueType,
-  max: ArgValueType,
-  options: ArgOptions
+  max: ArgValueType
 ): boolean => {
   if (typeof min !== "boolean" || typeof max !== "boolean")
     throw new Error("Min and max must be booleans");
@@ -217,8 +214,7 @@ const getRandomBool: PrivateRandFn = (
 const getLiteral: PrivateRandFn = (
   prng: seedrandom.prng,
   min: ArgValueType,
-  max: ArgValueType,
-  options: ArgOptions
+  max: ArgValueType
 ): ArgValueType => {
   if (min === max) return min;
   throw new Error("Min and max must be the same for literals");

--- a/src/fuzzer/generators/GeneratorFactory.ts
+++ b/src/fuzzer/generators/GeneratorFactory.ts
@@ -3,6 +3,7 @@ import { ArgDef } from "../analysis/typescript/ArgDef";
 import {
   ArgTag,
   ArgType,
+  ArgValueType,
   ArgOptions,
   Interval,
 } from "../analysis/typescript/Types";
@@ -19,15 +20,25 @@ import {
  *
  * TODO: bias selection of input interval based on interval size
  */
+
+type PrivateRandFn = (
+  prng: seedrandom.prng,
+  min: ArgValueType,
+  max: ArgValueType,
+  options: ArgOptions
+) => ArgValueType;
+
+type PublicRandFn = () => ArgValueType;
+
 export function GeneratorFactory<T extends ArgType>(
   arg: ArgDef<T>,
   prng: seedrandom.prng
-): () => any {
-  // For constant values of no dimensions, return the constant
-  if (arg.isConstant() && arg.getDim() === 0)
-    return () => arg.getConstantValue();
+): PublicRandFn {
+  let randFn: PrivateRandFn;
 
-  let randFn: typeof getRandomNumber;
+  // For constant values of no dimensions, return the constant
+  //if (arg.isConstant() && arg.getDim() === 0 && !arg.isNoInput())
+  //  return () => arg.getConstantValue();
 
   switch (arg.getType()) {
     case "number":
@@ -44,12 +55,12 @@ export function GeneratorFactory<T extends ArgType>(
       break;
     case "union":
       // We generate this here using arg
-      randFn = <T extends ArgType>(
+      randFn = (
         prng: seedrandom.prng,
-        min: T,
-        max: T,
+        min: ArgValueType,
+        max: ArgValueType,
         options: ArgOptions
-      ): T => {
+      ): ArgValueType => {
         if (typeof min !== "object" || typeof max !== "object")
           throw new Error("Min and max must be objects");
         let children = arg.getChildren().filter((child) => !child.isNoInput());
@@ -67,15 +78,15 @@ export function GeneratorFactory<T extends ArgType>(
       break;
     case "object":
       // We generate this here using arg
-      randFn = <T extends ArgType>(
+      randFn = (
         prng: seedrandom.prng,
-        min: T,
-        max: T,
+        min: ArgValueType,
+        max: ArgValueType,
         options: ArgOptions
-      ): T => {
+      ): ArgValueType => {
         if (typeof min !== "object" || typeof max !== "object")
           throw new Error("Min and max must be objects");
-        const outObj: { [key: string]: any } = {};
+        const outObj: { [key: string]: ArgValueType } = {};
         for (const child of arg.getChildren()) {
           outObj[child.getName()] = GeneratorFactory(child, prng)();
 
@@ -85,7 +96,7 @@ export function GeneratorFactory<T extends ArgType>(
             delete outObj[child.getName()];
           }
         }
-        return outObj as T;
+        return outObj;
       };
       break;
     default:
@@ -99,8 +110,9 @@ export function GeneratorFactory<T extends ArgType>(
   const dimLength = arg.getOptions().dimLength;
   const isOptional = arg.isOptional();
 
-  // Callback fn to generate random value
-  const randFnWrapper = () => {
+  // Callback fn to generate value
+  const randFnWrapper: PublicRandFn = () => {
+    if (arg.isNoInput()) return undefined;
     if (type === ArgTag.OBJECT) return randFn(prng, {}, {}, options);
     if (type === ArgTag.UNION) {
       if (arg.getChildren().filter((child) => !child.isNoInput()).length) {
@@ -125,7 +137,7 @@ export function GeneratorFactory<T extends ArgType>(
   };
 
   // If the arg is an array, return the array generator
-  const randArgValueWrapper = !dimLength.length
+  const randArgValueWrapper: PublicRandFn = !dimLength.length
     ? randFnWrapper
     : () => nArray(prng, randFnWrapper, dimLength, options);
 
@@ -149,21 +161,21 @@ export function GeneratorFactory<T extends ArgType>(
  *
  * Throws an exception if min and max are not numbers
  */
-const getRandomNumber = <T extends ArgType>(
+const getRandomNumber = (
   prng: seedrandom.prng,
-  min: T,
-  max: T,
+  min: ArgValueType,
+  max: ArgValueType,
   options: ArgOptions
-): T => {
+): number => {
   if (typeof min !== "number" || typeof max !== "number")
     throw new Error("Min and max must be numbers");
 
   if (options.numInteger) {
     const minInt: number = Math.ceil(min);
     const maxInt: number = Math.floor(max) + 1;
-    return Math.floor(prng() * (maxInt - minInt) + minInt) as T; // Max and Min are inclusive
+    return Math.floor(prng() * (maxInt - minInt) + minInt); // Max and Min are inclusive
   } else {
-    return (prng() * (max - min) + min) as T; // Max and Min are inclusive
+    return prng() * (max - min) + min; // Max and Min are inclusive
   }
 }; // getRandomNumber()
 
@@ -178,17 +190,17 @@ const getRandomNumber = <T extends ArgType>(
  *
  * Throws an exception if min and max are not booleans
  */
-const getRandomBool = <T extends ArgType>(
+const getRandomBool: PrivateRandFn = (
   prng: seedrandom.prng,
-  min: T,
-  max: T,
+  min: ArgValueType,
+  max: ArgValueType,
   options: ArgOptions
-): T => {
+): boolean => {
   if (typeof min !== "boolean" || typeof max !== "boolean")
     throw new Error("Min and max must be booleans");
-  if (min && max) return true as T;
-  if (!min && !max) return false as T;
-  return (prng() >= 0.5) as T;
+  if (min && max) return true;
+  if (!min && !max) return false;
+  return prng() >= 0.5;
 }; // getRandomBool()
 
 /**
@@ -202,13 +214,13 @@ const getRandomBool = <T extends ArgType>(
  *
  * Throws an exception if min and max are not the same
  */
-const getLiteral = <T extends ArgType>(
+const getLiteral: PrivateRandFn = (
   prng: seedrandom.prng,
-  min: T,
-  max: T,
+  min: ArgValueType,
+  max: ArgValueType,
   options: ArgOptions
-): T => {
-  if (min === max) return min as T;
+): ArgValueType => {
+  if (min === max) return min;
   throw new Error("Min and max must be the same for literals");
 }; // getLiteral()
 
@@ -231,12 +243,12 @@ const getLiteral = <T extends ArgType>(
  *
  * TODO: Min and max may cause a non-uniform distribution of inputs.
  */
-const getRandomString = <T extends ArgType>(
+const getRandomString: PrivateRandFn = (
   prng: seedrandom.prng,
-  min: T,
-  max: T,
+  min: ArgValueType,
+  max: ArgValueType,
   options: ArgOptions
-): T => {
+): string => {
   if (typeof min !== "string" || typeof max !== "string")
     throw new Error("Min and max must be strings");
 
@@ -262,7 +274,7 @@ const getRandomString = <T extends ArgType>(
     outStr += charSet[getRandomNumber(prng, 0, charSetLen, intOptions)];
   }
 
-  return outStr as T;
+  return outStr;
 }; // getRandomString()
 
 /**
@@ -281,13 +293,13 @@ const getRandomString = <T extends ArgType>(
  */
 const nArray = (
   prng: seedrandom.prng,
-  genFn: () => ArgType | undefined,
+  genFn: PublicRandFn,
   dimLength: Interval<number>[],
   options: ArgOptions
-): any => {
+): ArgValueType => {
   if (dimLength.length) {
     const [dim, ...rest] = dimLength; // split the array: head, tail
-    const newArray = []; // output array
+    const newArray: ArgValueType[] = []; // output array
     const thisDim = getRandomNumber(
       prng,
       dim.min,

--- a/src/telemetry/Telemetry.ts
+++ b/src/telemetry/Telemetry.ts
@@ -124,7 +124,7 @@ export const listeners: Listener<any>[] = [
 
   {
     event: vscode.workspace.onDidChangeConfiguration,
-    fn: (e: vscode.ConfigurationChangeEvent): void => {
+    fn: (): void => {
       // If the config is active, we need to log the change and re-load
       if (config.active) {
         logger.push(new LoggerEntry("onDidChangeConfiguration"));

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1626,8 +1626,11 @@ ${inArgConsts}
          ${typeString}${dimString}${sep}
       </div>`;
 
-    // Give the option of suppressing generation of union members
-    if (parentTag === fuzzer.ArgTag.UNION) {
+    // Give the option of suppressing generation of optional members
+    if (
+      parentTag === fuzzer.ArgTag.UNION ||
+      (parentTag === fuzzer.ArgTag.OBJECT && arg.isOptional())
+    ) {
       // prettier-ignore
       html += /*html*/ `
         <div class="isNoInput tooltipped tooltipped-nw" aria-label="Generate inputs of this type?">

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -72,7 +72,7 @@ export class FuzzPanel {
         FuzzPanel.viewType, // FuzzPanel view type
         `Test: ${env.function.getName()}()`, // webview title
         vscode.ViewColumn.Beside, // open beside the editor
-        FuzzPanel.getWebviewOptions(extensionUri) // options
+        FuzzPanel.getWebviewOptions() // options
       );
       panel.iconPath = vscode.Uri.joinPath(
         extensionUri,
@@ -163,9 +163,8 @@ export class FuzzPanel {
    * @param extensionUri The Uri of the extension
    * @returns The options to use when creating the FuzzPanel WebView
    */
-  public static getWebviewOptions(
-    extensionUri: vscode.Uri
-  ): vscode.WebviewPanelOptions & vscode.WebviewOptions {
+  public static getWebviewOptions(): vscode.WebviewPanelOptions &
+    vscode.WebviewOptions {
     return {
       // Enable javascript in the webview
       enableScripts: true,
@@ -1896,8 +1895,7 @@ export async function handleFuzzCommand(match?: FunctionMatch): Promise<void> {
  * @returns array of CodeLens objects
  */
 export function provideCodeLenses(
-  document: vscode.TextDocument,
-  token: vscode.CancellationToken
+  document: vscode.TextDocument
 ): vscode.CodeLens[] {
   // Use the TypeScript analyzer to find all fn declarations in the module
   const matches: FunctionMatch[] = [];


### PR DESCRIPTION
Closes #206 by adding the ability to set `isNoInput` for optional object members, similar to how we currently handle union members. This feature is exposed via the checkboxes in `FuzzPanel`. 