### PR TITLE
fix: dims of type refs w/arrays (#205)

### DIFF
--- a/src/fuzzer/analysis/typescript/ArgDef.test.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.test.ts
@@ -49,8 +49,9 @@ function makeTypeRef(
     module: module,
     typeRefName,
     optional: optional ?? false,
-    dims: dims,
+    dims: 0,
     type: {
+      dims: dims,
       type: type,
       children: children,
       value: literalValue,

--- a/src/fuzzer/analysis/typescript/ArgDef.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.ts
@@ -157,7 +157,7 @@ export class ArgDef<T extends ArgType> {
       offset, // offset
       ref.type.type, // type
       options, // options
-      ref.dims, // dims
+      ref.dims + ref.type.dims, // type reference dims + concrete type dims
       ref.optional, // optional
       intervals, // intervals
       ref.type.children.map((child) => ArgDef.fromTypeRef(child, options, i++)), // children

--- a/src/fuzzer/analysis/typescript/FunctionDef.test.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.test.ts
@@ -63,8 +63,9 @@ function makeTypeRef(
     module: module,
     typeRefName,
     optional: optional ?? false,
-    dims: dims,
+    dims: 0,
     type: {
+      dims: dims,
       type: type,
       children: children,
       value: literalValue,
@@ -245,12 +246,13 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         isVoid: false,
         args: [
           {
-            dims: 1,
+            dims: 0,
             isExported: false,
             module: thisProgram.getModule(),
             name: "array",
             optional: false,
             type: {
+              dims: 1,
               children: [],
               resolved: true,
               type: ArgTag.STRING,
@@ -263,6 +265,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
           module: "dummy.ts",
           optional: false,
           type: {
+            dims: 0,
             children: [],
             resolved: true,
             type: "string",
@@ -318,12 +321,13 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
       isVoid: false,
       args: [
         {
-          dims: 1,
+          dims: 0,
           isExported: false,
           module: thisProgram.getModule(),
           name: "array",
           optional: false,
           type: {
+            dims: 1,
             children: [],
             resolved: true,
             type: ArgTag.STRING,
@@ -336,6 +340,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         module: "dummy.ts",
         optional: false,
         type: {
+          dims: 0,
           children: [],
           resolved: true,
           type: "string",
@@ -355,12 +360,13 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
       isVoid: false,
       args: [
         {
-          dims: 1,
+          dims: 0,
           isExported: false,
           module: thisProgram.getModule(),
           name: "array",
           optional: false,
           type: {
+            dims: 1,
             children: [],
             resolved: true,
             type: ArgTag.STRING,
@@ -373,6 +379,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
         module: "dummy.ts",
         optional: false,
         type: {
+          dims: 0,
           children: [],
           resolved: true,
           type: "string",
@@ -420,6 +427,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
           module: "dummy.ts",
           optional: false,
           type: {
+            dims: 0,
             children: [],
             resolved: true,
             type: "number",
@@ -512,6 +520,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
           module: "dummy.ts",
           optional: false,
           type: {
+            dims: 0,
             children: [],
             resolved: true,
             type: "number",
@@ -733,6 +742,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
             name: "n",
             optional: false,
             type: {
+              dims: 0,
               children: [],
               resolved: true,
               value: 3,
@@ -747,6 +757,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
             name: "a",
             optional: false,
             type: {
+              dims: 0,
               children: [],
               resolved: true,
               value: "a",
@@ -761,6 +772,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
             name: "b",
             optional: false,
             type: {
+              dims: 0,
               children: [],
               resolved: true,
               type: "literal",
@@ -801,6 +813,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
             name: "a",
             optional: false,
             type: {
+              dims: 0,
               children: [
                 {
                   dims: 0,
@@ -808,6 +821,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
                   module: "dummy.ts",
                   optional: false,
                   type: {
+                    dims: 0,
                     children: [],
                     resolved: true,
                     type: "string",
@@ -819,6 +833,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
                   module: "dummy.ts",
                   optional: false,
                   type: {
+                    dims: 0,
                     children: [],
                     resolved: true,
                     type: "number",
@@ -837,6 +852,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
             name: "b",
             optional: false,
             type: {
+              dims: 0,
               children: [
                 {
                   dims: 0,
@@ -844,6 +860,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
                   module: "dummy.ts",
                   optional: false,
                   type: {
+                    dims: 0,
                     children: [],
                     resolved: true,
                     type: "string",
@@ -855,6 +872,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
                   module: "dummy.ts",
                   optional: false,
                   type: {
+                    dims: 0,
                     children: [],
                     resolved: true,
                     type: "literal",
@@ -873,6 +891,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
           module: "dummy.ts",
           optional: false,
           type: {
+            dims: 0,
             resolved: true,
             type: "union",
             children: [
@@ -882,6 +901,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
                 module: "dummy.ts",
                 optional: false,
                 type: {
+                  dims: 0,
                   children: [],
                   resolved: true,
                   type: "boolean",
@@ -893,6 +913,7 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
                 module: "dummy.ts",
                 optional: false,
                 type: {
+                  dims: 0,
                   children: [],
                   resolved: true,
                   type: "literal",
@@ -902,6 +923,125 @@ describe("fuzzer/analysis/typescript/FunctionDef", () => {
             ],
           },
         },
+      },
+    ]);
+  });
+
+  test("findFnInSource: type references w/arrays", () => {
+    const src = `
+    type onlyNumbers = number[];
+    type onlyNumber = number;
+    export function test5(a: onlyNumbers): void {return;}
+    export function test6(a: onlyNumbers[]): void {return;}
+    export function test7(a: onlyNumber): void {return;}
+    export function test8(a: onlyNumber[]): void {return;}`;
+    const thisProgram = dummyProgram.setSrc(() => src);
+    expect(
+      Object.values(thisProgram.getFunctions()).map((e) => e.getRef())
+    ).toStrictEqual([
+      {
+        name: "test5",
+        module: "dummy.ts",
+        src: "function test5(a: onlyNumbers): void {return;}",
+        startOffset: 75,
+        endOffset: 121,
+        isExported: true,
+        isVoid: true,
+        args: [
+          {
+            dims: 0,
+            isExported: false,
+            module: "dummy.ts",
+            name: "a",
+            optional: false,
+            type: {
+              dims: 1,
+              children: [],
+              resolved: true,
+              type: "number",
+            },
+            typeRefName: "onlyNumbers",
+          },
+        ],
+        returnType: undefined,
+      },
+      {
+        name: "test6",
+        module: "dummy.ts",
+        src: "function test6(a: onlyNumbers[]): void {return;}",
+        startOffset: 133,
+        endOffset: 181,
+        isExported: true,
+        isVoid: true,
+        args: [
+          {
+            dims: 1,
+            isExported: false,
+            module: "dummy.ts",
+            name: "a",
+            optional: false,
+            type: {
+              dims: 1,
+              children: [],
+              resolved: true,
+              type: "number",
+            },
+            typeRefName: "onlyNumbers",
+          },
+        ],
+        returnType: undefined,
+      },
+      {
+        name: "test7",
+        module: "dummy.ts",
+        src: "function test7(a: onlyNumber): void {return;}",
+        startOffset: 193,
+        endOffset: 238,
+        isExported: true,
+        isVoid: true,
+        args: [
+          {
+            dims: 0,
+            isExported: false,
+            module: "dummy.ts",
+            name: "a",
+            optional: false,
+            type: {
+              dims: 0,
+              children: [],
+              resolved: true,
+              type: "number",
+            },
+            typeRefName: "onlyNumber",
+          },
+        ],
+        returnType: undefined,
+      },
+      {
+        name: "test8",
+        module: "dummy.ts",
+        src: "function test8(a: onlyNumber[]): void {return;}",
+        startOffset: 250,
+        endOffset: 297,
+        isExported: true,
+        isVoid: true,
+        args: [
+          {
+            dims: 1,
+            isExported: false,
+            module: "dummy.ts",
+            name: "a",
+            optional: false,
+            type: {
+              dims: 0,
+              children: [],
+              resolved: true,
+              type: "number",
+            },
+            typeRefName: "onlyNumber",
+          },
+        ],
+        returnType: undefined,
       },
     ]);
   });

--- a/src/fuzzer/analysis/typescript/ProgramDef.ts
+++ b/src/fuzzer/analysis/typescript/ProgramDef.ts
@@ -923,7 +923,6 @@ export class ProgramDef {
         typeNode,
         this._options
       );
-      thisType.dims = dims;
 
       // Create the TypeRef data structure
       switch (type) {
@@ -931,6 +930,7 @@ export class ProgramDef {
         case ArgTag.BOOLEAN:
         case ArgTag.NUMBER: {
           thisType.type = {
+            dims: dims,
             type: type,
             children: [],
             resolved: true,
@@ -939,6 +939,7 @@ export class ProgramDef {
         }
         case ArgTag.LITERAL: {
           thisType.type = {
+            dims: dims,
             type: type,
             children: [],
             value: literalValue,
@@ -949,12 +950,14 @@ export class ProgramDef {
         case ArgTag.UNION:
         case ArgTag.OBJECT: {
           thisType.type = {
+            dims: dims,
             type: type,
             children: this._getChildrenFromNode(typeNode),
           };
           break;
         }
         case ArgTag.UNRESOLVED: {
+          thisType.dims = dims;
           thisType.typeRefName = typeRefNode; // Unresolved type reference
           break;
         }

--- a/src/fuzzer/analysis/typescript/Types.ts
+++ b/src/fuzzer/analysis/typescript/Types.ts
@@ -53,6 +53,7 @@ export type TypeRef = {
   dims: number; // Number of dimensions for the type (0 for non-array types)
   type?: {
     type: ArgTag; // Concrete type of the type
+    dims: number; // Concrete type dims (the concrete type may have its own dimensions)
     children: TypeRef[]; // Array of child types
     value?: ArgType; // Value if a literal type
     resolved?: boolean; // True if the type's children have been resolved; false, otherwise

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1784,10 +1784,20 @@ ${inArgConsts}
     disabledFlag: string
   ): string {
     let html = "";
+    const argOptions = arg.getOptions();
 
     // Array dimensions
     for (let dim = 0; dim < arg.getDim(); dim++) {
       const arrayBase = `${idBase}-array-${dim}`;
+      const arrayDimOptions = argOptions.dimLength;
+      const minValue =
+        arrayDimOptions.length > dim
+          ? arrayDimOptions[dim].min
+          : argOptions.dftDimLength.min;
+      const maxValue =
+        arrayDimOptions.length > dim
+          ? arrayDimOptions[dim].max
+          : argOptions.dftDimLength.max;
 
       // TODO: validate for ints > 0 !!!
       html += /*html*/ ``;
@@ -1795,11 +1805,11 @@ ${inArgConsts}
         /*html*/
         `<div class="argDef-array">
           <vscode-text-field size="3" ${disabledFlag} id="${arrayBase}-min" name="${arrayBase}-min" value="${htmlEscape(
-          arg.getOptions().dimLength[dim].min.toString()
+          minValue.toString()
         )}">Array${"[]".repeat(dim + 1)}: Min 
           </vscode-text-field>
           <vscode-text-field size="3" ${disabledFlag} id="${arrayBase}-max" name="${arrayBase}-max" value="${htmlEscape(
-          arg.getOptions().dimLength[dim].max.toString()
+          maxValue.toString()
         )}">Max length
           </vscode-text-field>
         </div>`;


### PR DESCRIPTION
This PR resolves #205 by adding a `dims` attribute to the concrete type definition (`TypeRef.type.dims`), which we now populate instead of `TypeRef.dims` when building a new concrete `TypeRef`. 

In the case of building a `TypeRef` with a type reference that must be resolved, then the previous (non-concrete) `TypeRef.dims` is filled with the type reference's dimensions such that the subsequently resolved `TypeRef` will have two `dims`: one for the type reference (`TypeRef.dims`) and one for the concrete type definition (`TypeRef.type.dims`).

`ArgDef.fromTypeRef()` has been modified to sum both `dims` properties when constructing a new `ArgDef` and determining its dimensions. The example from the original issues has been expanded into a test case.