### PR TITLE
fix: disambiguate validator exception msgs (#163)

### DIFF
--- a/assets/ui/FuzzPanelMain.js
+++ b/assets/ui/FuzzPanelMain.js
@@ -231,8 +231,9 @@ function main() {
           o.value === undefined ? "undefined" : JSON5.stringify(o.value);
       });
       if (e.validatorException) {
-        outputs[`output`] =
-          "(validator exception) " + e.validatorExceptionMessage;
+        outputs[
+          `output`
+        ] = `(${e.validatorExceptionFunction} exception) ${e.validatorExceptionMessage}`;
       } else if (e.exception) {
         outputs[`output`] = "(exception) " + e.exceptionMessage;
       }
@@ -402,9 +403,11 @@ function main() {
             });
           } else {
             const cell = hRow.appendChild(document.createElement("th"));
+            const label =
+              type === "failure" && k === "output" ? "exception" : k;
             cell.id = type + "-" + k;
             cell.classList.add("clickable");
-            cell.innerHTML = `<big>${htmlEscape(k)}</big>`;
+            cell.innerHTML = `<big>${htmlEscape(label)}</big>`;
             cell.addEventListener("click", () => {
               handleColumnSort(cell, hRow, type, k, tbody, true);
             });
@@ -1366,7 +1369,6 @@ function handleFuzzStart(eCurrTarget) {
     const maxStrLen = document.getElementById(idBase + "-maxStrLen");
     const strCharset = document.getElementById(idBase + "-strCharset");
     const isNoInput = document.getElementById(idBase + "-isNoInput");
-    console.debug(idBase + "-isNoInput"); // !!!!!
 
     // Process numeric overrides
     if (numInteger !== null) {

--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -293,6 +293,7 @@ export const fuzz = async (
                 ...result,
                 validatorException: true,
                 validatorExceptionMessage: e.message,
+                validatorExceptionFunction: valFnName,
                 validatorExceptionStack: e.stack,
               };
             }
@@ -311,6 +312,8 @@ export const fuzz = async (
         // Store the validator results
         result.passedValidators.push(validatorResult.passedValidator);
         result.validatorException = validatorResult.validatorException;
+        result.validatorExceptionFunction =
+          validatorResult.validatorExceptionFunction;
         result.validatorExceptionMessage =
           validatorResult.validatorExceptionMessage;
         result.validatorExceptionStack =

--- a/src/fuzzer/Types.ts
+++ b/src/fuzzer/Types.ts
@@ -17,6 +17,7 @@ export type FuzzTestResult = {
   passedValidators?: boolean[]; // for each custom validator, true if passed; false, otherwise
   validatorException: boolean; // true if validator threw an exception
   validatorExceptionMessage?: string; // validator exception message
+  validatorExceptionFunction?: string; // name of validator throwing exception
   validatorExceptionStack?: string; // validator stack trace if exception was thrown
   elapsedTime: number; // elapsed time of test
   expectedOutput?: FuzzIoElement[]; // the expected output, if any


### PR DESCRIPTION
This PR adds the validator function name to the exception message displayed in `FuzzPanel`'s results grid. 

![image](https://github.com/user-attachments/assets/a0428731-7d91-490a-af7a-a6c578eecd90)


## Limitations
- Currently the fuzzer returns 0-1 validator exceptions such that if multiple validators throw exceptions for a particular input example, the fuzzer only tells the user about one of them. This PR does not resolve that limitation, which we likely will want to resolve in the future.