### PR TITLE
fix: dims inconsistently redetermined (#162)

### DIFF
--- a/src/fuzzer/analysis/typescript/ArgDef.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.ts
@@ -377,7 +377,7 @@ export class ArgDef<T extends ArgType> {
    * @param options the argument's option set
    */
   public setOptions(inOptions: ArgOptions | ArgOptionOverride): void {
-    const options = { ...inOptions };
+    const options = { dimLength: this.options.dimLength, ...inOptions };
 
     // Cascade child options to child arguments
     if ("children" in options) {
@@ -400,6 +400,14 @@ export class ArgDef<T extends ArgType> {
 
     // Merge the two option sets; incoming has precedence
     const newOptions: ArgOptions = { ...this.options, ...options };
+
+    // Ensure this.dims-1 === dimLength.length
+    while (newOptions.dimLength.length < this.dims) {
+      newOptions.dimLength.push({ ...ArgDef.getDefaultOptions().dftDimLength });
+    }
+    newOptions.dimLength = this.dims
+      ? newOptions.dimLength.slice(0, this.dims)
+      : [];
 
     // Handle isNoInput
     if (options.isNoInput === false) {


### PR DESCRIPTION
This PR fixes #162 by, upon ingestion into `ArgDef`'s `setOptions()`, removing any `options.dimLength` entries beyond the bounds of `this.dims` so that the generator does not attempt to generate these additional dimensions.