### PR TITLE
fix: fuzzpanel input has x but the function has y (#181)

### DIFF
--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1978,7 +1978,7 @@ function _applyArgOverrides(
   // Make the user aware if it appears that the function arguments changed
   if (argOverrides.length && argOverrides.length !== argsFlat.length) {
     vscode.window.showInformationMessage(
-      `Check the testing config: '${fn.getName()}()' changed`
+      `Check the testing config: '${fn.getName()}()' may have changed`
     );
   }
 

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1979,12 +1979,16 @@ function _applyArgOverrides(
   for (const i in argOverrides) {
     const thisOverride = argOverrides[i];
     const thisArg: fuzzer.ArgDef<fuzzer.ArgType> = argsFlat[i];
-    if (Number(i) + 1 > argsFlat.length)
-      throw new Error(
+    if (Number(i) + 1 > argsFlat.length) {
+      console.warn(
         `FuzzPanel input has ${
           Object.entries(argOverrides).length
-        } but the function has ${argsFlat.length}`
+        } argument(s), but the function has ${
+          argsFlat.length
+        } argument(s). Ignoring the extra argument(s).`
       );
+      break; // exit the for loop
+    }
 
     // Min and max values
     switch (thisArg.getType()) {

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1975,18 +1975,18 @@ function _applyArgOverrides(
   // Get the flattened list of function arguments
   const argsFlat = fn.getArgDefsFlat();
 
+  // Make the user aware if it appears that the function arguments changed
+  if (argOverrides.length && argOverrides.length !== argsFlat.length) {
+    vscode.window.showInformationMessage(
+      `Check the testing config: '${fn.getName()}()' changed`
+    );
+  }
+
   // Apply argument option changes
   for (const i in argOverrides) {
     const thisOverride = argOverrides[i];
     const thisArg: fuzzer.ArgDef<fuzzer.ArgType> = argsFlat[i];
     if (Number(i) + 1 > argsFlat.length) {
-      console.warn(
-        `FuzzPanel input has ${
-          Object.entries(argOverrides).length
-        } argument(s), but the function has ${
-          argsFlat.length
-        } argument(s). Ignoring the extra argument(s).`
-      );
       break; // exit the for loop
     }
 


### PR DESCRIPTION
Rather than blocking the user when a function's argument was deleted, this PR discards any extra arguments on load and issues an informational message so that the user may continue testing.