### PR TITLE
feat: link from FuzzPanel to put (#107)

### DIFF
--- a/assets/ui/FuzzPanelMain.css
+++ b/assets/ui/FuzzPanelMain.css
@@ -101,11 +101,6 @@ td.classErrorOn:active {
   opacity: 80%;
 }
 
-/* Clickable cells (e.g., pin buttons) */
-td.clickable {
-  cursor: pointer;
-}
-
 .classAddRefreshValidator:active {
   /* background-color: var(--vscode-list-inactiveSelectionBackground); */
   opacity: 50%;
@@ -323,8 +318,8 @@ tr.classErrorExpectedOutputRow td div.slightFade {
   border-right-color: var(--vscode-focus-border);
 }
 
-/* Clickable columns (e.g., sorting) */
-th.clickable {
+/* Clickable items (e.g., sorting) */
+.clickable {
   cursor: pointer;
 }
 .columnSortDesc::after {

--- a/assets/ui/FuzzPanelMain.js
+++ b/assets/ui/FuzzPanelMain.js
@@ -98,6 +98,11 @@ function main() {
     .getElementById("fuzz.options")
     .addEventListener("click", (e) => toggleFuzzOptions(e));
 
+  // Add event listener for opening the function source code
+  document
+    .getElementById("openSourceLink")
+    .addEventListener("click", (e) => handleOpenSource(e));
+
   // Add event listener for the fuzz.options close button
   document
     .getElementById("fuzzOptions-close")
@@ -1495,6 +1500,19 @@ function refreshValidators(validatorList) {
 function handleAddValidator(e) {
   vscode.postMessage({
     command: "validator.add",
+    json: JSON5.stringify(""),
+  });
+} // fn: handleAddValidator()
+
+/**
+ * Send message to back-end to add code skeleton to source code (because the
+ * user clicked the customValidator button)
+ *
+ * @param e on-click event
+ */
+function handleOpenSource(e) {
+  vscode.postMessage({
+    command: "open.source",
     json: JSON5.stringify(""),
   });
 } // fn: handleAddValidator()


### PR DESCRIPTION
This PR resolves #107 by adding a hyperlink from the `FuzzPanel` back to the PUT's source code. This hyperlink is in the form of a VS Code text document icon to the right of the function name at the top of the `FuzzPanel`:

![image](https://github.com/user-attachments/assets/585daf4a-bde7-432d-9133-d825a0d482b9)


