### PR TITLE
fix: fill maxDupeInputs on upgrade from v0.3.3 if missing

### DIFF
--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -434,8 +434,22 @@ export class FuzzPanel {
           }
           case "0.3.3": {
             // v0.3.3 format -- only additions such as isVoid and literal types that
-            // older versions of NaNofuzz will not interpret
+            // older versions of NaNofuzz will not interpret. Also check for missing
+            // maxDupeInputs value
             testSet = { ...inputTests, version: "0.3.6" };
+            for (const fn in testSet.functions) {
+              const thisFn = testSet.functions[fn];
+              const thisOpt: Partial<fuzzer.FuzzOptions> = thisFn.options;
+              if (
+                !("maxDupeInputs" in thisOpt) ||
+                thisOpt.maxDupeInputs === undefined ||
+                isNaN(thisOpt.maxDupeInputs)
+              ) {
+                thisOpt.maxDupeInputs = vscode.workspace
+                  .getConfiguration("nanofuzz.fuzzer")
+                  .get("maxDupeInputs", 1000);
+              }
+            }
             console.info(
               `Upgraded test set in file ${jsonFile} to ${inputTests.version} to ${testSet.version}`
             );


### PR DESCRIPTION
Users should not encounter this situation, but in the interim NaNofuzz releases, it was possible to end up with a `nano.json` file that is missing a `maxDupeInputs` option. Upon upgrade of the `nano.json` file from `v0.3.3` to `v0.3.6`, check for the missing `maxDupeInputs` value and fill the user's default value if it is missing.