### PR TITLE
fix: pin button can throw exception (#224)

### DIFF
--- a/assets/ui/FuzzPanelMain.ts
+++ b/assets/ui/FuzzPanelMain.ts
@@ -1016,7 +1016,7 @@ function drawTableBody({
             throw new Error("Invalid event target");
           }
           const idStr = currentTarget.parentElement.getAttribute("id");
-          if (idStr === null || parseInt(idStr)) {
+          if (idStr === null || isNaN(parseInt(idStr))) {
             throw new Error("Invalid event target");
           }
           handlePinToggle(parseInt(idStr), type);


### PR DESCRIPTION
This PR implements the fix that we discussed in PR #222 to avoid the exception than can otherwise happen when clicking the pin button. Fixes #224.