### PR TITLE
chore: improve typing

### DIFF
--- a/src/fuzzer/analysis/typescript/ProgramDef.ts
+++ b/src/fuzzer/analysis/typescript/ProgramDef.ts
@@ -159,16 +159,17 @@ export class ProgramDef {
               }
             }
           }
-        } catch (e: any) {
+        } catch (e: unknown) {
+          const msg = e instanceof Error ? e.message : JSON.stringify(e);
           console.debug(
             `Error resolving types for function '${fnRef.name}' argument '${
               lastArgName ?? "(unknown)"
-            }'; marking fn as unsupported. Reason: ${e.message}`
+            }'; marking fn as unsupported. Reason: ${msg}`
           );
 
           // Remove functions that we couldn't resolve
           this._unsupportedFunctions[fnRef.name] = {
-            reason: e.message,
+            reason: msg,
             argument: lastArgName,
             function: fnRef,
           };
@@ -182,9 +183,11 @@ export class ProgramDef {
             lastArgName = "return";
             this._resolveTypeRef(fnRef.returnType);
           }
-        } catch (e: any) {
+        } catch (e: unknown) {
           console.debug(
-            `Error resolving return type for function '${fnRef.name}'; Reason: ${e.message}`
+            `Error resolving return type for function '${
+              fnRef.name
+            }'; Reason: ${e instanceof Error ? e.message : JSON.stringify(e)}`
           );
         }
       }
@@ -1159,15 +1162,16 @@ export class ProgramDef {
             if (maybeFunction) {
               supported[name] = maybeFunction;
             }
-          } catch (e: any) {
+          } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : JSON.stringify(e);
             console.debug(
               `Error processing function '${this._src.substring(
                 node.range[0],
                 node.range[1]
-              )}' in module '${this._module}': ${e.message}`
+              )}' in module '${this._module}': ${msg}`
             );
             unsupported[name] = {
-              reason: e.message,
+              reason: msg,
               node: node,
             };
           }

--- a/src/telemetry/Telemetry.ts
+++ b/src/telemetry/Telemetry.ts
@@ -275,7 +275,7 @@ export const listeners: Listener<any>[] = [
 /**
  * Associates a callback function with an vscode event.
  */
-type Listener<T extends any> = {
+type Listener<T extends unknown> = {
   event: vscode.Event<T>;
   fn: (e: T) => void;
 };

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -135,11 +135,12 @@ export class FuzzPanel {
             )
           );
         });
-      } catch (e: any) {
+      } catch (e: unknown) {
         // It's possible the source code changed between restarting;
         // just log the exception and continue. Restoring these panels
         // is best effort anyway.
-        console.error(`Unable to revive FuzzPanel: ${e.message}`);
+        const msg = e instanceof Error ? e.message : JSON5.stringify(e);
+        console.error(`Unable to revive FuzzPanel: ${msg}`);
       }
     }
     // Dispose of any panels we can't revive
@@ -360,7 +361,7 @@ export class FuzzPanel {
     try {
       inputTests = JSON5.parse(fs.readFileSync(jsonFile).toString());
       testSet = inputTests;
-    } catch (e: any) {
+    } catch (e: unknown) {
       return this._initFuzzTestsForThisFn();
     }
 
@@ -529,9 +530,10 @@ export class FuzzPanel {
     // Persist the test set
     try {
       fs.writeFileSync(jsonFile, JSON5.stringify(fullSet)); // Update the file
-    } catch (e: any) {
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : JSON5.stringify(e);
       vscode.window.showErrorMessage(
-        `Unable to update json file: ${jsonFile} (${e.message})`
+        `Unable to update json file: ${jsonFile} (${msg})`
       );
     }
 
@@ -551,18 +553,21 @@ export class FuzzPanel {
       // Persist the Jest tests for CI
       try {
         fs.writeFileSync(jestFile, jestTests);
-      } catch (e: any) {
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : JSON5.stringify(e);
+
         vscode.window.showErrorMessage(
-          `Unable to update Jest test file: ${jestFile} (${e.message})`
+          `Unable to update Jest test file: ${jestFile} (${msg})`
         );
       }
     } else if (fs.existsSync(jestFile)) {
       // Delete the test file: it would contain no tests
       try {
         fs.rmSync(jestFile);
-      } catch (e: any) {
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : JSON5.stringify(e);
         vscode.window.showErrorMessage(
-          `Unable to remove Jest test file: ${jestFile} (${e.message})`
+          `Unable to remove Jest test file: ${jestFile} (${msg})`
         );
       }
     }
@@ -679,8 +684,8 @@ export class FuzzPanel {
 
     try {
       program = ProgramDef.fromModule(module);
-    } catch (e: any) {
-      this._errorMessage = e.message ?? "Unknown error";
+    } catch (e: unknown) {
+      this._errorMessage = e instanceof Error ? e.message : "Unknown error";
       vscode.window.showErrorMessage(
         `Unable to add the validator. TypeScript source file cannot be parsed. ${this._fuzzEnv.function.getModule()}`
       );
@@ -782,8 +787,8 @@ ${inArgConsts}
       try {
         const fn = ProgramDef.fromModule(module).getFunctions()[validatorName];
         this._navigateToSource(fn.getModule(), fn.getStartOffset());
-      } catch (e: any) {
-        this._errorMessage = e.message ?? "Unknown error";
+      } catch (e: unknown) {
+        this._errorMessage = e instanceof Error ? e.message : "Unknown error";
         vscode.window.showErrorMessage(
           `Unable to navigate to the created validator '${validatorName}' in '${fn.getModule()}'`
         );
@@ -901,14 +906,14 @@ ${inArgConsts}
     let program: ProgramDef;
     try {
       program = ProgramDef.fromModule(this._fuzzEnv.function.getModule());
-    } catch (e: any) {
-      this._errorMessage = e.message ?? "Unknown error";
+    } catch (e: unknown) {
+      this._errorMessage = e instanceof Error ? e.message : "Unknown error";
       vscode.commands.executeCommand(
         telemetry.commands.logTelemetry.name,
         new telemetry.LoggerEntry(
           "FuzzPanel.parse.error",
           "Parsing program failed. Target: %s. Message: %s",
-          [this.getFnRefKey(), this._errorMessage ?? "Unknown error"]
+          [this.getFnRefKey(), this._errorMessage]
         )
       );
       return;
@@ -1043,15 +1048,15 @@ ${inArgConsts}
         testSet.sortColumns = this._sortColumns;
         testSet.isVoid = this._fuzzEnv.function.isVoid();
         this._putFuzzTestsForThisFn(testSet);
-      } catch (e: any) {
+      } catch (e: unknown) {
         this._state = FuzzPanelState.error;
-        this._errorMessage = e.message ?? "Unknown error";
+        this._errorMessage = e instanceof Error ? e.message : "Unknown error";
         vscode.commands.executeCommand(
           telemetry.commands.logTelemetry.name,
           new telemetry.LoggerEntry(
             "FuzzPanel.fuzz.error",
             "Fuzzing failed. Target: %s. Message: %s",
-            [this.getFnRefKey(), this._errorMessage ?? "Unknown error"]
+            [this.getFnRefKey(), this._errorMessage]
           )
         );
       }
@@ -1615,18 +1620,18 @@ ${inArgConsts}
           </body>
         </html>
       `;
-    } catch (e: any) {
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Unknown error";
+      const stack = e instanceof Error ? e.stack : "<no stack>>";
       html = /*html*/ `
       <head></head>
       <body>
         <h1>:-(</h1>
         <p>Unable to render this panel due to an internal error in FuzzPanel.updateHtml().</p>
         <p>Stack trace:</p>
-        <pre>${e.stack}</pre>
+        <pre>${stack}</pre>
       <body>`;
-      console.debug(
-        `Exception in updateHtml(): ${e.message} stack: ${e.stack}`
-      );
+      console.debug(`Exception in updateHtml(): ${msg} stack: ${stack}`);
     }
 
     // Update the webview with the new HTML
@@ -1976,9 +1981,10 @@ export async function handleFuzzCommand(match?: FunctionMatch): Promise<void> {
   let fuzzSetup: fuzzer.FuzzEnv;
   try {
     fuzzSetup = fuzzer.setup(fuzzOptions, srcFile, fnName);
-  } catch (e: any) {
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : JSON.stringify(e);
     vscode.window.showErrorMessage(
-      `${toolName} could not find or does not support this function. Message: "${e.message}"`
+      `${toolName} could not find or does not support this function. Message: "${msg}"`
     );
     return;
   }
@@ -2031,9 +2037,10 @@ export function provideCodeLenses(
         ref: fn.getRef(),
       });
     }
-  } catch (e: any) {
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : JSON.stringify(e);
     console.error(
-      `Error parsing typescript file: ${document.fileName} error: ${e.message}`
+      `Error parsing typescript file: ${document.fileName} error: ${msg}`
     );
   }
 


### PR DESCRIPTION
This PR further shortens the list of type warnings that remain in the code base. This change primarily addresses explicit `any`types previously present in exception handlers.