### PR TITLE
fix: narrow fuzzgrid left margin (#232)

### DIFF
--- a/assets/ui/FuzzPanelMain.css
+++ b/assets/ui/FuzzPanelMain.css
@@ -6,10 +6,11 @@ body {
 /** Grid Styles **/
 vscode-panel-view.fuzzGridPanel {
   padding-top: 5px;
+  padding-left: 3px;
 }
 .fuzzGrid {
   width: 100%;
-  padding-left: 4px;
+  padding-left: 0;
   border-spacing: 0;
 }
 .fuzzGrid td {
@@ -22,9 +23,16 @@ vscode-panel-view.fuzzGridPanel {
   border-bottom: 1px solid;
   vertical-align: bottom;
 }
+.fuzzGrid td:first-child,
+.fuzzGrid th:first-child {
+  padding-left: 0;
+}
 .fuzzGrid th.colorColumn {
   padding: 2px 8px;
   text-align: center;
+}
+.fuzzGrid tr.classGetExpectedOutputRow td:first-child {
+  padding-left: 6px;
 }
 td.fuzzGridCellPinned,
 td.fuzzGridCellPin {


### PR DESCRIPTION
Narrows the left margin of `fuzzGrid`, `fuzzGridPanel`, and first column of `fuzzGrid`.

![image](https://github.com/user-attachments/assets/cd7d6869-a9f3-4cea-bab4-18cc0fffbf5a)
