### PR TITLE
feat: support development via Nix and direnv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,5 +118,6 @@ dist
 # Telemetry data
 /telemetry
 
-# Extension bundles
-*.vsix
+# direnv files
+/.direnv/
+/.envrc

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,12 @@
 {
+  "[css]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[html]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[javascript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[json]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[jsonc]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[markdown]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[typescript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[yaml]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
   "files.exclude": {
     "out": false // set this to true to hide the "out" folder with the compiled JS files
   },
@@ -7,7 +15,5 @@
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
   "typescript.tsc.autoDetect": "off",
-
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,8 @@ Be sure you have these tools installed:
 - [Node.js][] v16+ (if using Linux or Mac, we recommend installing via [nvm][])
 - [Yarn][] v1.x
 
+If you're using [Nix][], all dependencies other than Git will be automatically provided by the `flake.nix` file in this repo once you've cloned it.
+
 ### Developing in Windows WSL
 
 Here are some WSL-specific guides:
@@ -183,6 +185,7 @@ Our repo uses [semantic versioning][] and maintains the same version number for 
 [homebrew]: https://brew.sh/
 [install dependencies]: https://classic.yarnpkg.com/en/docs/installing-dependencies
 [merge conflicts]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line
+[nix]: https://nixos.org/
 [node.js]: https://nodejs.org/en/download/
 [npm]: https://www.npmjs.com/
 [nvm]: https://github.com/nvm-sh/nvm

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1742707865,
+        "narHash": "sha256-RVQQZy38O3Zb8yoRJhuFgWo/iDIDj0hEdRTVfhOtzRk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "dd613136ee91f67e5dba3f3f41ac99ae89c5406b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,28 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        devShell =
+          with pkgs;
+          mkShell {
+            buildInputs = [
+              nixfmt-rfc-style
+              yarn
+            ];
+          };
+      }
+    );
+}


### PR DESCRIPTION
This PR makes it easy for developers using [Nix](https://nixos.org/) and [direnv](https://direnv.net/) to build NaNofuzz locally, so now (instead of having to have Node.js and Yarn already installed), they just need to clone it and then create a one-line `.envrc` file telling direnv to use the Nix config:

```sh
gh repo clone nanofuzz/nanofuzz
cd nanofuzz
echo 'use flake' > .envrc
direnv allow
```

I added this `.envrc` file (along with direnv's generated `.direnv` folder) to `.gitignore` because not everyone will want to use direnv with `flake.nix`. Also, I modified `.vscode/settings.json` so VS Code doesn't try to apply Prettier to _every_ file, only the ones it should actually be trying to format.