### PR TITLE
fix: upgrade msg typo

### DIFF
--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -375,7 +375,7 @@ export class FuzzPanel {
           testSet.functions[fnName].tests = inputTests[fnName];
         }
         console.info(
-          `Upgraded test set in file ${jsonFile} to ${testSet.version} to current version`
+          `Upgraded test set in file ${jsonFile} from ${testSet.version} to current version`
         );
         inputTests = testSet;
       } else {
@@ -390,7 +390,7 @@ export class FuzzPanel {
               testSet.functions[fn].options.useImplicit = true;
             }
             console.info(
-              `Upgraded test set in file ${jsonFile} to ${inputTests.version} to ${testSet.version}`
+              `Upgraded test set in file ${jsonFile} from ${inputTests.version} to ${testSet.version}`
             );
             inputTests = testSet;
             break;
@@ -405,7 +405,7 @@ export class FuzzPanel {
               testSet.functions[fn].options.useHuman = true;
             }
             console.info(
-              `Upgraded test set in file ${jsonFile} to ${inputTests.version} to ${testSet.version}`
+              `Upgraded test set in file ${jsonFile} from ${inputTests.version} to ${testSet.version}`
             );
             inputTests = testSet;
             break;
@@ -428,7 +428,7 @@ export class FuzzPanel {
               break;
             }
             console.info(
-              `Upgraded test set in file ${jsonFile} to ${inputTests.version} to ${testSet.version}`
+              `Upgraded test set in file ${jsonFile} from ${inputTests.version} to ${testSet.version}`
             );
             inputTests = testSet;
             break;
@@ -452,7 +452,7 @@ export class FuzzPanel {
               }
             }
             console.info(
-              `Upgraded test set in file ${jsonFile} to ${inputTests.version} to ${testSet.version}`
+              `Upgraded test set in file ${jsonFile} from ${inputTests.version} to ${testSet.version}`
             );
             inputTests = testSet;
             break;


### PR DESCRIPTION
Correct the typo in the upgrade log message.

E.g., `Upgraded test set in file ${jsonFile} to ${inputTests.version} to ${testSet.version}` --> `Upgraded test set in file ${jsonFile} from ${inputTests.version} to ${testSet.version}`