### PR TITLE
fix: tsc v5.9.2 `tsc` shim require failure

### DIFF
--- a/src/fuzzer/Compiler.ts
+++ b/src/fuzzer/Compiler.ts
@@ -11,7 +11,7 @@ import path from "path";
 import os from "os";
 
 // Load the TypeScript compiler script
-const tsc = path.join(path.dirname(require.resolve("typescript")), "tsc.js");
+const tsc = path.join(path.dirname(require.resolve("typescript")), "_tsc.js");
 const tscScript = new vm.Script(fs.readFileSync(tsc, "utf8"));
 
 // Place to store previous ts hooks
@@ -229,6 +229,7 @@ function compileTS(module: NodeJS.Module) {
     setTimeout: setTimeout,
     clearTimeout: clearTimeout,
     __filename: tsc,
+    __dirname: path.dirname(tsc),
   };
 
   // Execute the module script


### PR DESCRIPTION
Typescript v5.9.2 and many other versions subsequent to v4.9.2 use a shim to load `tsc`. 

When called from `Compiler`, this shim is unable to `require` `tsc`. My guess is that a path in the `script.runInContext()` context is set incorrectly, which prevents the shim's `require` from resolving the relative module path of the real `tsc`.

Calling the actual `tsc` directly also fixes the problem, which is the strategy adopted by this change.