### PR TITLE
fix: jasmine test explorer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,6 @@
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
   "typescript.tsc.autoDetect": "off",
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "jasmineExplorer.nodeArgv": ["--no-experimental-strip-types"]
 }


### PR DESCRIPTION
Apply the node arg `--no-experimental-strip-types` to Jasmine Test Explorer so that VS Code's testing pane works with the experimental strip type feature that Node turns on by default now.