### PR TITLE
feat: human-guided input generator

### DIFF
--- a/assets/ui/FuzzPanelMain.css
+++ b/assets/ui/FuzzPanelMain.css
@@ -57,12 +57,10 @@ th.expandCollapseColumn {
   padding-bottom: 0px;
 }
 .fuzzGrid tbody tr {
-  transition: font-weight 1s ease, box-shadow 3s 3s ease,
-    background-color 3s 3s ease;
+  transition: box-shadow 3s 3s ease, background-color 3s 3s ease;
 }
 .fuzzGrid tbody tr.focus {
   transition: none;
-  font-weight: bold;
   background-color: var(--vscode-editor-hoverHighlightBackground);
   box-shadow: 0px 0px 1px 1px
     rgb(from var(--vscode-editor-hoverHighlightBackground) r g b / 1);

--- a/assets/ui/FuzzPanelMain.css
+++ b/assets/ui/FuzzPanelMain.css
@@ -456,9 +456,12 @@ div.fuzzInputControlGroup {
   color: var(--vscode-notifications-foreground);
   text-align: center;
   border-radius: 2px;
+  border-style: solid;
   border-width: 2px;
-  border-color: var(--vscode-notifications-border);
-  padding: 0.5em;
+  border-color: rgb(
+    from var(--vscode-editor-hoverHighlightBackground) r g b / 1
+  );
+  padding: 0.25em;
   position: absolute;
   left: 50%;
   font-size: var(--vscode-font-size);

--- a/assets/ui/FuzzPanelMain.css
+++ b/assets/ui/FuzzPanelMain.css
@@ -56,6 +56,17 @@ th.expandCollapseColumn {
   padding-right: 0px;
   padding-bottom: 0px;
 }
+.fuzzGrid tbody tr {
+  transition: font-weight 1s ease, box-shadow 3s 3s ease,
+    background-color 3s 3s ease;
+}
+.fuzzGrid tbody tr.focus {
+  transition: none;
+  font-weight: bold;
+  background-color: var(--vscode-editor-hoverHighlightBackground);
+  box-shadow: 0px 0px 1px 1px
+    rgb(from var(--vscode-editor-hoverHighlightBackground) r g b / 1);
+}
 
 /* Validator icons */
 td.classCheckOff,
@@ -434,4 +445,42 @@ div.fuzzInputControlGroup {
   font-size: var(--vscode-font-size);
   line-height: normal;
   margin-bottom: 2px;
+}
+
+/** Snackbar: adapted from https://www.w3schools.com/howto/howto_js_snackbar.asp **/
+.snackbar {
+  visibility: hidden;
+  min-width: 18em;
+  margin-left: -9.25em;
+  background-color: var(--vscode-notifications-background);
+  color: var(--vscode-notifications-foreground);
+  text-align: center;
+  border-radius: 2px;
+  border-width: 2px;
+  border-color: var(--vscode-notifications-border);
+  padding: 0.5em;
+  position: absolute;
+  left: 50%;
+  font-size: var(--vscode-font-size);
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+}
+.snackbarShow {
+  visibility: visible;
+  animation: fadein 0.5s, fadeout 0.5s 3.6s;
+}
+@keyframes fadein {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes fadeout {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
 }

--- a/assets/ui/FuzzPanelMain.css
+++ b/assets/ui/FuzzPanelMain.css
@@ -149,13 +149,13 @@ td.classErrorOn:active {
 
 /* Expected output panel */
 td.classErrorCell {
-  text-decoration: red underline wavy;
+  text-decoration: var(--vscode-editorError-foreground) underline wavy;
 }
 vscode-text-field.classErrorCell {
   opacity: 100%;
   outline-style: solid;
   outline-width: 0.05cm;
-  outline-color: red;
+  outline-color: var(--vscode-editorError-foreground);
 }
 tr.classGetExpectedOutputRow td,
 tr.classErrorExpectedOutputRow td {
@@ -172,7 +172,7 @@ tr.classErrorExpectedOutputRow td div.slightFade {
   opacity: 80%;
 }
 .expectedOutputErrorMessage {
-  color: red;
+  color: var(--vscode-editorError-foreground);
   margin-left: 0.5em;
   font-weight: bold;
 }

--- a/assets/ui/FuzzPanelMain.ts
+++ b/assets/ui/FuzzPanelMain.ts
@@ -14,7 +14,11 @@ import {
   FuzzSortColumns,
   FuzzSortOrder,
 } from "fuzzer/Types";
-import { ArgValueType, FuzzTestResults } from "fuzzer/Fuzzer";
+import {
+  ArgValueType,
+  ArgValueTypeWrapped,
+  FuzzTestResults,
+} from "fuzzer/Fuzzer";
 
 const vscode = acquireVsCodeApi();
 
@@ -626,14 +630,14 @@ function handleAddTestInput() {
       }
     }
 
-    overrides.input.push(value);
+    overrides.input.push({ value: value });
   }
 
   // Only call the fuzzer if the input is not already in the grid
   const tick = resultsData.results.findIndex(
     (r) =>
       JSON5.stringify(r.input.map((i) => i.value)) ===
-      JSON5.stringify(overrides.input)
+      JSON5.stringify(overrides.input?.map((i) => i.value))
   );
   if (tick === -1) {
     // Call the extension to test this one input
@@ -2183,5 +2187,5 @@ export type FuzzPanelFuzzStartMessage = {
   fuzzer: Partial<FuzzOptions>;
   args: DeepPartial<FuzzArgOverride>[];
   lastTab?: string;
-  input?: ArgValueType[];
+  input?: ArgValueTypeWrapped[];
 };

--- a/assets/ui/FuzzPanelMain.ts
+++ b/assets/ui/FuzzPanelMain.ts
@@ -135,6 +135,12 @@ function main() {
     toggleAddTestInputOptions
   );
 
+  // Add event listener for the fuzz.addTestInput.cancel button
+  getElementByIdOrThrow("fuzz.addTestInput.cancel").addEventListener(
+    "click",
+    toggleAddTestInputOptions
+  );
+
   // Add event listener for the fuzz.addTestInput button
   getElementByIdOrThrow("fuzz.addTestInput").addEventListener(
     "click",
@@ -550,10 +556,13 @@ function toggleAddTestInputOptions() {
   );
   if (isHidden(fuzzAddTestInputOptionsPane)) {
     toggleHidden(fuzzAddTestInputOptionsPane);
-    fuzzAddTestInputOptionsButton.innerHTML = "Cancel Add Input";
+    hide(fuzzAddTestInputOptionsButton);
+    getElementByIdOrThrow("customArgDef-0-exact").focus();
+    getElementByIdOrThrow("fuzz.start").setAttribute("appearance", "secondary");
   } else {
     toggleHidden(fuzzAddTestInputOptionsPane);
-    fuzzAddTestInputOptionsButton.innerHTML = "Add Input...";
+    show(fuzzAddTestInputOptionsButton);
+    getElementByIdOrThrow("fuzz.start").setAttribute("appearance", "primary");
   }
 } // fn: toggleAddTestInputOptions
 

--- a/assets/ui/FuzzPanelMain.ts
+++ b/assets/ui/FuzzPanelMain.ts
@@ -578,6 +578,13 @@ function handleAddTestInput() {
     const argType = argDef.querySelector(".argDef-type")?.id.split("-")[2];
     const argIsArray =
       argDef.querySelector(".argDef-isArray")?.id.split("-")[2] === "true";
+    const argIsNoInput = document.getElementById(`customArgDef-${i}-isNoInput`);
+    const argIsNoInputValue =
+      argIsNoInput === null
+        ? false
+        : (argIsNoInput.getAttribute("value") ??
+            argIsNoInput.getAttribute("current-checked")) !== "true";
+
     // !!!!!!!! Figure out what the array logic is for
 
     const unparsedValue =
@@ -586,7 +593,9 @@ function handleAddTestInput() {
       ) || "";
 
     let value: ArgValueType;
-    if (argIsArray) {
+    if (argIsNoInputValue) {
+      value = undefined;
+    } else if (argIsArray) {
       try {
         value = JSON5.parse(unparsedValue);
         if (!Array.isArray(value)) {
@@ -601,10 +610,11 @@ function handleAddTestInput() {
           value = Number(unparsedValue);
           break;
         case "boolean":
-          value =
+          value = !!(
             getElementByIdOrThrow(`customArgDef-${i}-true`).getAttribute(
               "current-checked"
-            ) === "true";
+            ) === "true"
+          );
           break;
         default:
           // For string or any other type, try parsing; fallback to raw string

--- a/assets/ui/FuzzPanelMain.ts
+++ b/assets/ui/FuzzPanelMain.ts
@@ -1706,10 +1706,19 @@ export type DeepPartial<T> = {
  * @param eCurrTarget current target of onClick() event
  */
 function handleFuzzStart(eCurrTarget: EventTarget) {
+  // Fuzzer option overrides (from UI)
   const overrides: {
     fuzzer: Partial<FuzzOptions>;
     args: DeepPartial<FuzzArgOverride>[];
-  } = { fuzzer: {}, args: [] }; // Fuzzer option overrides (from UI)
+    lastTab: string | undefined;
+  } = {
+    fuzzer: {},
+    args: [],
+    lastTab:
+      document
+        .getElementById("fuzzResultsTabStrip")
+        ?.getAttribute("activeId") ?? undefined,
+  };
   const disableArr = [eCurrTarget]; // List of controls to disable while fuzzer is busy
   const fuzzBase = "fuzz"; // Base html id name
 

--- a/assets/ui/FuzzPanelMain.ts
+++ b/assets/ui/FuzzPanelMain.ts
@@ -12,6 +12,7 @@ import {
   FuzzResultCategory,
   FuzzSortColumns,
   FuzzSortOrder,
+  FuzzTestResult,
 } from "fuzzer/Types";
 import { FuzzTestResults } from "fuzzer/Fuzzer";
 
@@ -120,6 +121,23 @@ function main() {
   getElementByIdOrThrow("fuzz.options").addEventListener(
     "click",
     toggleFuzzOptions
+  );
+
+  // Add event listener for the fuzz.options button
+  getElementByIdOrThrow("fuzz.addCustomTestOptions").addEventListener(
+    "click",
+    toggleAddCustomTestOptions
+  );
+
+  // Add event listener for the fuzz.options close button
+  getElementByIdOrThrow("fuzzAddCustomTestOptions-close").addEventListener(
+    "click",
+    toggleAddCustomTestOptions
+  );
+
+  getElementByIdOrThrow("fuzz.addCustomTest").addEventListener(
+    "click",
+    handleAddCustomTestCase
   );
 
   // Add event listener for opening the function source code
@@ -495,6 +513,107 @@ function toggleFuzzOptions() {
 } // fn: toggleFuzzOptions()
 
 /**
+ * Toggles whether add test case options are shown.
+ */
+function toggleAddCustomTestOptions() {
+  const fuzzAddCustomTestOptions = getElementByIdOrThrow(
+    "fuzzAddCustomTestOptions"
+  );
+  const fuzzAddCustomTestOptionsButton = getElementByIdOrThrow(
+    "fuzz.addCustomTestOptions"
+  );
+  if (isHidden(fuzzAddCustomTestOptions)) {
+    toggleHidden(fuzzAddCustomTestOptions);
+    fuzzAddCustomTestOptionsButton.innerHTML = "Close custom test options";
+  } else {
+    toggleHidden(fuzzAddCustomTestOptions);
+    fuzzAddCustomTestOptionsButton.innerHTML = "Add custom test...";
+  }
+
+  // Refresh the list of validators !!!!!!!
+  // handleGetListOfValidators(); !!!!!!!!
+} // fn: toggleAddCustomTestOptions
+
+/**
+ * Add custom test to the test results table.
+ */
+function handleAddCustomTestCase() {
+  const input: FuzzIoElement[] = [];
+  const output: FuzzIoElement[] = [];
+
+  for (let i = 0; document.getElementById(`customArgDef-${i}`) !== null; i++) {
+    const argDef = getElementByIdOrThrow(`customArgDef-${i}`);
+    const argType = argDef.querySelector(".argDef-type")?.id.split("-")[2];
+    const argIsArray =
+      argDef.querySelector(".argDef-isArray")?.id.split("-")[2] === "true";
+    const name = argDef.querySelector(".argDef-name")?.textContent || "";
+
+    const unparsedValue =
+      getElementByIdOrThrow(`customArgDef-${i}-exact`).getAttribute(
+        "current-value"
+      ) || "";
+
+    let value: any;
+    if (argIsArray) {
+      try {
+        value = JSON5.parse(unparsedValue);
+        if (!Array.isArray(value)) {
+          throw new Error("Expected an array input.");
+        }
+      } catch (error) {
+        throw new Error(`Invalid array input: ${unparsedValue}`);
+      }
+    } else {
+      switch (argType) {
+        case "number":
+          value = Number(unparsedValue);
+          break;
+        case "boolean":
+          value =
+            getElementByIdOrThrow(`customArgDef-${i}-true`).getAttribute(
+              "current-checked"
+            ) === "true";
+          break;
+        default:
+          // For string or any other type, try parsing; fallback to raw string
+          try {
+            value = JSON5.parse(unparsedValue);
+          } catch {
+            value = unparsedValue;
+          }
+      }
+    }
+
+    input.push({ name, value, offset: 0 });
+  }
+
+  // Build the custom test object.
+  const customTest: FuzzTestResult = {
+    input,
+    output,
+    pinned: true,
+    category: "ok", // default category; may be changed based on the result
+    exception: false,
+    timeout: false,
+    validatorException: false,
+    elapsedTime: 0,
+    passedImplicit: true,
+  };
+
+  // Pin the new test case
+  vscode.postMessage({
+    command: "test.pin",
+    json: JSON5.stringify(customTest),
+  });
+
+  // Request the extension to run just this custom test.
+  vscode.postMessage({
+    command: "fuzz.customTest",
+    json: JSON5.stringify(customTest),
+  });
+} // fn: handleAddCustomTestCase
+
+/**
  * Toggles whether interesting inputs are shown
  */
 function toggleInterestingInputs(): void {
@@ -695,7 +814,7 @@ function handleCorrectToggle(
     input: resultsData.results[id].input,
     output: resultsData.results[id].output,
     pinned: isPinned,
-    expectedOutput: data[type][index][expectedLabel],
+    implicit: true,
   };
 
   // Send the request to the extension

--- a/package.json
+++ b/package.json
@@ -198,15 +198,11 @@
     "build": "node build.mjs",
     "test": "node --no-experimental-strip-types ./node_modules/jasmine/bin/jasmine.js",
     "docs": "typedoc --plugin none --out docs",
-    "coverage": "yarn test --coverage --watchAll=false",
     "lint": "eslint --ext js,ts,tsx src",
-    "build-decls": "tsc --declaration --outDir build/dist && tsc-alias -p tsconfig.json",
-    "vscode:prepublish": "yarn run compile",
+    "vscode:prepublish": "yarn build",
     "publish": "vsce publish --yarn",
     "package": "vsce package --yarn",
-    "compile": "yarn build",
-    "watch": "tsc -watch -p ./",
-    "pretest": "yarn run compile && yarn run lint"
+    "pretest": "yarn build && yarn run lint"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -96,12 +96,6 @@
           "minimum": 0,
           "description": "Maximum time (in ms) to allow a test function to run before making it as a timeout."
         },
-        "nanofuzz.fuzzer.onlyFailures": {
-          "title": "Report only test failures?",
-          "type": "boolean",
-          "default": false,
-          "description": "Report only failing tests?"
-        },
         "nanofuzz.ui.hideMoreOptionsButton": {
           "title": "Hide the 'More options' button?",
           "type": "boolean",

--- a/src/fuzzer/Fuzzer.test.ts
+++ b/src/fuzzer/Fuzzer.test.ts
@@ -29,6 +29,7 @@ const allGenerators = {
     enabled: true,
   },
 };
+
 /**
  * Fuzzer option for integer arguments and a seed for deterministic test execution.
  */

--- a/src/fuzzer/Fuzzer.test.ts
+++ b/src/fuzzer/Fuzzer.test.ts
@@ -1,5 +1,6 @@
 import { ArgDef, setup, fuzz, implicitOracle } from "./Fuzzer";
 import { FuzzOptions } from "./Types";
+import * as JSON5 from "json5";
 
 // Extend default test timeout to 45s
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 45000;
@@ -528,5 +529,40 @@ describe("fuzzer:", () => {
     );
     expect(fuzzResult.results.length).toBe(3);
     expect(fuzzResult.results.every((e) => e.passedImplicit)).toBeTruthy();
+
+    // Run the following tests on the raw and JSON5-cloned results
+    [
+      fuzzResult.results,
+      JSON5.parse(JSON5.stringify(fuzzResult.results)),
+    ].forEach((r) => {
+      // Every input should be true, false, or undefined
+      expect(
+        fuzzResult.results.every(
+          (e) =>
+            e.input.length &&
+            (e.input[0].value === undefined ||
+              e.input[0].value === true ||
+              e.input[0].value === false)
+        )
+      ).toBeTruthy();
+      // Some inputs should be undefined
+      expect(
+        fuzzResult.results.some(
+          (e) => e.input.length && e.input[0].value === undefined
+        )
+      ).toBeTruthy();
+      // Some inputs should be true
+      expect(
+        fuzzResult.results.some(
+          (e) => e.input.length && e.input[0].value === true
+        )
+      ).toBeTruthy();
+      // Some inputs should be false
+      expect(
+        fuzzResult.results.some(
+          (e) => e.input.length && e.input[0].value === false
+        )
+      ).toBeTruthy();
+    });
   });
 });

--- a/src/fuzzer/Fuzzer.test.ts
+++ b/src/fuzzer/Fuzzer.test.ts
@@ -41,7 +41,6 @@ const intOptions: FuzzOptions = {
   seed: "qwertyuiop",
   maxDupeInputs: 1000,
   maxFailures: 0,
-  onlyFailures: false,
   useImplicit: true,
   useHuman: true,
   useProperty: false,
@@ -55,15 +54,6 @@ const intOptions: FuzzOptions = {
 const floatOptions: FuzzOptions = {
   ...intOptions,
   argDefaults: ArgDef.getDefaultFloatOptions(),
-};
-
-/**
- * Fuzzer options for counter-example mode
- */
-const counterExampleOptions: FuzzOptions = {
-  ...intOptions,
-  maxFailures: 1,
-  onlyFailures: true,
 };
 
 /**
@@ -390,14 +380,6 @@ describe("fuzzer:", () => {
         fuzzResult.stats.measures.CodeCoverageMeasure.counters.branchesCovered
       ).toBeGreaterThan(0);
     }
-  });
-
-  it("Counter-example mode 01", function () {
-    const fuzzResult = fuzz(
-      setup(counterExampleOptions, "nanofuzz-study/examples/14.ts", "modInv")
-    );
-    expect(fuzzResult.results.length).toBe(1);
-    expect(fuzzResult.results[0].category).not.toBe("ok");
   });
 
   /**

--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -441,9 +441,7 @@ export const fuzz = (
     }
 
     // Store the result for this iteration
-    if (!env.options.onlyFailures || result.category !== "ok") {
-      results.results.push(result);
-    }
+    results.results.push(result);
 
     // Take measurements for this test run
     {

--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -134,7 +134,11 @@ export const fuzz = (
   // first: we want the composite generator to know about these inputs so that
   // any "interesting" inputs might be further mutated by other generators.
   compositeInputGenerator.inject(
-    pinnedTests.map((t) => t.input.map((i) => i.value))
+    pinnedTests.map((t) =>
+      t.input.map((i) => {
+        return { value: i.value };
+      })
+    )
   );
 
   // The module that includes the function to fuzz will
@@ -219,7 +223,7 @@ export const fuzz = (
       return {
         name: argDefs[i].getName(),
         offset: i,
-        value: e,
+        value: e.value,
       };
     });
     result.source = genInput.source.subgen;

--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -777,8 +777,7 @@ export function mergeTestResults(
   const c: FuzzTestResults = JSON5.parse(JSON5.stringify(a));
   c.env.function = b.env.function;
   c.stopReason = b.stopReason;
-  // !!!!!!!! merge interesting inputs after we retain measure
-  // context across fuzzer runs.
+  // !!!!!!!! merge interesting inputs when we retain measure context across runs.
 
   // Merge results
   c.results.push(...b.results);

--- a/src/fuzzer/Types.ts
+++ b/src/fuzzer/Types.ts
@@ -165,6 +165,7 @@ export enum FuzzStopReason {
   MAXFAILURES = "maxFailures",
   MAXTIME = "maxTime",
   MAXDUPES = "maxDupes",
+  NOMOREINPUTS = "noMoreInputs",
 }
 
 /**

--- a/src/fuzzer/Types.ts
+++ b/src/fuzzer/Types.ts
@@ -98,7 +98,6 @@ export type FuzzOptions = {
   maxTests: number; // number of fuzzing tests to execute (>= 0)
   maxDupeInputs: number; // maximum number of duplicate inputs before stopping (>=0)
   maxFailures: number; // maximum number of failures to report (>=0)
-  onlyFailures: boolean; // only report tests that do not pass
   fnTimeout: number; // timeout threshold in ms per test
   suiteTimeout: number; // timeout for the entire test suite
   useImplicit: boolean; // use implicit oracle

--- a/src/fuzzer/analysis/typescript/ArgDef.test.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.test.ts
@@ -487,7 +487,11 @@ describe("fuzzer/analysis/typescript/ArgDef: getTypeAnnotation", () => {
           let k = 100;
           while (k--) {
             const inputStringBefore = JSON5.stringify(input);
-            const muts = ArgDefMutator.getMutators(spec, input, prng);
+            const muts = ArgDefMutator.getMutators(
+              spec,
+              input.map((i) => i.value),
+              prng
+            );
             if (muts.length) {
               const index = Math.floor(prng() * (muts.length - 1));
               const mut = muts[index];

--- a/src/fuzzer/analysis/typescript/ArgDef.test.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.test.ts
@@ -487,11 +487,7 @@ describe("fuzzer/analysis/typescript/ArgDef: getTypeAnnotation", () => {
           let k = 100;
           while (k--) {
             const inputStringBefore = JSON5.stringify(input);
-            const muts = ArgDefMutator.getMutators(
-              spec,
-              input.map((i) => i.value),
-              prng
-            );
+            const muts = ArgDefMutator.getMutators(spec, input, prng);
             if (muts.length) {
               const index = Math.floor(prng() * (muts.length - 1));
               const mut = muts[index];

--- a/src/fuzzer/analysis/typescript/ArgDefGenerator.ts
+++ b/src/fuzzer/analysis/typescript/ArgDefGenerator.ts
@@ -1,6 +1,13 @@
 import seedrandom from "seedrandom";
 import { ArgDef } from "./ArgDef";
-import { ArgTag, ArgType, ArgValueType, ArgOptions, Interval } from "./Types";
+import {
+  ArgTag,
+  ArgType,
+  ArgValueType,
+  ArgOptions,
+  Interval,
+  ArgValueTypeWrapped,
+} from "./Types";
 
 /**
  * Pseudo-randomly generates example values that conform to an ArgDef spec.
@@ -27,8 +34,10 @@ export class ArgDefGenerator {
    *
    * @returns value that conforms to the ArgDef specs
    */
-  public next(): ArgValueType[] {
-    return this._gens.map((e) => e());
+  public next(): ArgValueTypeWrapped[] {
+    return this._gens.map((e) => {
+      return { value: e() };
+    });
   } // fn: next
 
   /**

--- a/src/fuzzer/analysis/typescript/ArgDefValidator.ts
+++ b/src/fuzzer/analysis/typescript/ArgDefValidator.ts
@@ -1,5 +1,5 @@
 import { ArgDef } from "./ArgDef";
-import { ArgTag, ArgType, ArgValueType } from "./Types";
+import { ArgTag, ArgType, ArgValueType, ArgValueTypeWrapped } from "./Types";
 import * as JSON5 from "json5";
 
 /**
@@ -23,11 +23,11 @@ export class ArgDefValidator {
    * @param `values` array of values to validate against the specs.
    * @returns true if the values conform to the ArgDef specs, false otherwise
    */
-  public validate(values: ArgValueType[]): boolean {
+  public validate(values: ArgValueTypeWrapped[]): boolean {
     let i = 0;
     return (
       values.length <= this._specs.length &&
-      values.every((e) => ArgDefValidator.validate(e, this._specs[i++]))
+      values.every((e) => ArgDefValidator.validate(e.value, this._specs[i++]))
     );
   } // fn: validate
 

--- a/src/fuzzer/analysis/typescript/FunctionDef.ts
+++ b/src/fuzzer/analysis/typescript/FunctionDef.ts
@@ -190,10 +190,9 @@ export class FunctionDef {
    * @param overrides
    */
   public applyOverrides(overrides: ArgOptionOverrides): void {
-    // Apply argument overrides
-    for (const argName of Object.keys(overrides.argOptions)) {
+    for (const argName of Object.keys(overrides)) {
       const arg = this._argDefs.find((arg) => arg.getName() === argName);
-      if (arg !== undefined) arg.setOptions(overrides.argOptions[argName]);
+      if (arg !== undefined) arg.setOptions(overrides[argName]);
     }
   } // fn: applyOverrides()
 

--- a/src/fuzzer/analysis/typescript/Types.ts
+++ b/src/fuzzer/analysis/typescript/Types.ts
@@ -89,6 +89,7 @@ export type ArgValueType =
     }
   | ArgValueType[]
   | undefined;
+export type ArgValueTypeWrapped = { value: ArgValueType }; // Use for arrays
 
 /**
  * The set of options for an argument.  This option set is used to "fill in" information

--- a/src/fuzzer/generators/CompositeInputGenerator.ts
+++ b/src/fuzzer/generators/CompositeInputGenerator.ts
@@ -1,5 +1,5 @@
 import { AbstractInputGenerator } from "./AbstractInputGenerator";
-import { ArgType, ArgValueType } from "../analysis/typescript/Types";
+import { ArgType, ArgValueTypeWrapped } from "../analysis/typescript/Types";
 import { ArgDef } from "../analysis/typescript/ArgDef";
 import { AbstractMeasure, BaseMeasurement } from "../measures/AbstractMeasure";
 import { Leaderboard } from "./Leaderboard";
@@ -36,7 +36,7 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
     currentIndex: number; // current index (of L) into last dimension of progress and cost
   }[]; // history for each input generator
   private _scoredInputs: ScoredInput[] = []; // List of scored inputs
-  private _injectedInputs: ArgValueType[][] = []; // Inputs to force generate first
+  private _injectedInputs: ArgValueTypeWrapped[][] = []; // Inputs to force generate first
   private _selectedSubgenIndex = -1; // Selected subordinate input generator (e.g., by efficiency)
   private _leaderboard; // Interesting inputs
   private _lastInput?: InputAndSource; // Last input generated
@@ -93,8 +93,8 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
    *
    * @param `inputs` array of input values to produce first
    */
-  public inject(inputs: ArgValueType[][]): void {
-    this._injectedInputs = JSON5.parse(JSON5.stringify(inputs.reverse()));
+  public inject(inputs: ArgValueTypeWrapped[][]): void {
+    this._injectedInputs = [...inputs].reverse();
   } // fn: inject
 
   /**

--- a/src/fuzzer/generators/MutationInputGenerator.ts
+++ b/src/fuzzer/generators/MutationInputGenerator.ts
@@ -68,7 +68,7 @@ export class MutationInputGenerator extends AbstractInputGenerator {
         return {
           tick: 0,
           value: input,
-          source: { subgen: this.name, tick: sourceTick },
+          source: { subgen: "MutationInputGenerator", tick: sourceTick },
         };
       }
 
@@ -81,7 +81,7 @@ export class MutationInputGenerator extends AbstractInputGenerator {
     return {
       tick: 0,
       value: input,
-      source: { subgen: this.name, tick: sourceTick },
+      source: { subgen: "MutationInputGenerator", tick: sourceTick },
     };
   } // fn: next
 } // class: MutationInputGenerator

--- a/src/fuzzer/generators/MutationInputGenerator.ts
+++ b/src/fuzzer/generators/MutationInputGenerator.ts
@@ -59,7 +59,7 @@ export class MutationInputGenerator extends AbstractInputGenerator {
       // Calculate possible mutations for the input
       const mutators = ArgDefMutator.getMutators(
         this._specs,
-        input.map((i) => i.value),
+        input,
         this._prng
       );
 

--- a/src/fuzzer/generators/MutationInputGenerator.ts
+++ b/src/fuzzer/generators/MutationInputGenerator.ts
@@ -59,7 +59,7 @@ export class MutationInputGenerator extends AbstractInputGenerator {
       // Calculate possible mutations for the input
       const mutators = ArgDefMutator.getMutators(
         this._specs,
-        input,
+        input.map((i) => i.value),
         this._prng
       );
 

--- a/src/fuzzer/generators/RandomInputGenerator.test.ts
+++ b/src/fuzzer/generators/RandomInputGenerator.test.ts
@@ -124,7 +124,7 @@ const testRandomInt = (intMin: number, intMax: number): void => {
   const gen = new RandomInputGenerator(arg, seed);
   for (let i = 0; i < 1000; i++) {
     const { value: inputs } = gen.next();
-    const input = inputs[0];
+    const input = inputs[0].value;
     expect(typeof input === "number" && Number.isInteger(input)).toBeTruthy();
     expect(input).toBeGreaterThanOrEqual(intMin);
     expect(input).toBeLessThanOrEqual(intMax);
@@ -156,7 +156,7 @@ const testRandomFloat = (floatMin: number, floatMax: number): void => {
   const gen = new RandomInputGenerator(arg, seed);
   for (let i = 0; i < 1000; i++) {
     const { value: inputs } = gen.next();
-    const input = inputs[0];
+    const input = inputs[0].value;
     expect(typeof input === "number").toBeTruthy();
     expect(input).toBeGreaterThanOrEqual(floatMin);
     expect(input).toBeLessThanOrEqual(floatMax);
@@ -190,10 +190,8 @@ const testRandomBool = (boolMin: boolean, boolMax: boolean): void => {
 
   // Test that the generator generates booleans within the bounds
   const inputs: ArgValueType[][] = [];
-  let input: ArgValueType;
   for (let i = 0; i < 1000; i++) {
-    ({ value: inputs[i] } = gen.next());
-    input = inputs[i];
+    inputs.push(gen.next().value.map((i) => i.value));
   }
   expect(inputs.every((e) => typeof e[0] === "boolean")).toBeTruthy();
   expect(inputs.some((e) => e[0] === boolMin)).toBeTruthy();
@@ -232,7 +230,7 @@ const testRandomString = (
   // Test that the generator generates strings within the bounds
   const inputs: ArgValueType[][] = [];
   for (let i = 0; i < 1000; i++) {
-    ({ value: inputs[i] } = gen.next());
+    inputs.push(gen.next().value.map((i) => i.value));
     const input = inputs[i][0];
     expect(typeof input === "string").toBeTruthy();
     if (typeof input === "string") {

--- a/src/fuzzer/generators/RandomInputGenerator.ts
+++ b/src/fuzzer/generators/RandomInputGenerator.ts
@@ -27,6 +27,10 @@ export class RandomInputGenerator extends AbstractInputGenerator {
    * @returns next randomly-generated input
    */
   public next(): InputAndSource {
-    return { tick: 0, value: this._gen.next(), source: { subgen: this.name } };
+    return {
+      tick: 0,
+      value: this._gen.next(),
+      source: { subgen: "RandomInputGenerator" },
+    };
   } // fn: next
 } // class: RandomInputGenerator

--- a/src/fuzzer/generators/Types.ts
+++ b/src/fuzzer/generators/Types.ts
@@ -1,5 +1,5 @@
 import { BaseMeasurement } from "../measures/AbstractMeasure";
-import { ArgValueType } from "../analysis/typescript/Types";
+import { ArgValueTypeWrapped } from "../analysis/typescript/Types";
 import { SupportedInputGenerators } from "fuzzer/Types";
 
 /**
@@ -7,7 +7,7 @@ import { SupportedInputGenerators } from "fuzzer/Types";
  */
 export type InputAndSource = {
   tick: number;
-  value: ArgValueType[];
+  value: ArgValueTypeWrapped[];
   source: {
     subgen: SupportedInputGenerators | "injected";
     tick?: number;

--- a/src/telemetry/Telemetry.ts
+++ b/src/telemetry/Telemetry.ts
@@ -5,7 +5,7 @@ let currentWindow = ""; // Current editor window filename / uri
 let currentTerm = ""; // Current terminal window name
 let logger: Logger; // Telemetry logger
 let context: vscode.ExtensionContext; // Context of this extension
-let config: PurseConfig; // Configuration settings
+let config: PurseConfig | undefined; // Configuration settings
 let logFlusher: NodeJS.Timeout | undefined; // Interval to flush log data
 
 /**
@@ -37,7 +37,7 @@ function loadConfig(): void {
   };
 
   // Handle change in logging config
-  if (oldConfig.active !== config.active) {
+  if (!oldConfig || oldConfig.active !== config.active) {
     if (config.active) {
       console.info("Telemetry is active");
       logger.setActive(true);
@@ -126,7 +126,7 @@ export const listeners: Listener<any>[] = [
     event: vscode.workspace.onDidChangeConfiguration,
     fn: (): void => {
       // If the config is active, we need to log the change and re-load
-      if (config.active) {
+      if (config && config.active) {
         logger.push(new LoggerEntry("onDidChangeConfiguration"));
         loadConfig(); // Re-load config due to config change
       } else {

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1658,7 +1658,7 @@ ${inArgConsts}
             }. This is the maximum number configured.`,
           [fuzzer.FuzzStopReason.MAXTESTS]: `because it reached the maximum number of new tests configured (${
               this._results.env.options.maxTests
-            }). This is in addition to the ${this._results.stats.counters.inputsInjected} prior input${
+            }). This is in addition to the ${this._results.stats.counters.inputsInjected} interesting input${
               this._results.stats.counters.inputsInjected !== 1 ? "s" : ""
             } ${toolName} also tested.`,
           [fuzzer.FuzzStopReason.MAXDUPES]: `because it reached the maximum number of sequentially-generated duplicate inputs configured (${
@@ -1790,9 +1790,9 @@ ${inArgConsts}
           <p>
             ${toolName} ran for ${Math.round(
             this._results.stats.timers.run
-          )} ms, re-tested ${
+          )} ms, tested ${
             this._results.stats.counters.inputsInjected
-          } prior input${
+          } interesting input${
             this._results.stats.counters.inputsInjected !== 1 ? "s" : ""
           }, generated ${
             this._results.stats.counters.inputsGenerated
@@ -2007,6 +2007,7 @@ ${inArgConsts}
               ${htmlEscape(JSON5.stringify(this.getState()))}
             </div>
           </div>
+          <div id="snackbarRoot" class="hidden" />
           </body>
         </html>
       `;

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1660,7 +1660,7 @@ ${inArgConsts}
               this._results.env.options.maxTests
             }). This is in addition to the ${this._results.stats.counters.inputsInjected} prior input${
               this._results.stats.counters.inputsInjected !== 1 ? "s" : ""
-            } ${toolName} also executed.`,
+            } ${toolName} also tested.`,
           [fuzzer.FuzzStopReason.MAXDUPES]: `because it reached the maximum number of sequentially-generated duplicate inputs configured (${
               this._results.env.options.maxDupeInputs
             }). This can mean that NaNofuzz is having difficulty generating further new inputs: the function's input space might be small or near exhaustion. You can change this setting in More Options.`,
@@ -1976,7 +1976,8 @@ ${inArgConsts}
             <!-- Fuzzer Result Payload: for the client script to process -->
             <div id="fuzzResultsData" style="display:none">
               ${
-                this._results === undefined
+                this._results === undefined ||
+                this._state !== FuzzPanelState.done
                   ? "{}"
                   : htmlEscape(JSON5.stringify(this._results))
               }

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1585,7 +1585,7 @@ ${inArgConsts}
                 ? ""
                 : /*html*/ `style="display:none;"`
             }>
-              <vscode-panels aria-label="Test result tabs" class="fuzzTabStrip">`;
+              <vscode-panels aria-label="Test result tabs" class="fuzzTabStrip"${this._focusInput ? `activeId="tab-${this._focusInput[0]}"`:``}>`;
 
       // If we have results, render the output tabs to display the results.
       const tabs: (

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -278,6 +278,9 @@ export class FuzzPanel {
             this._doGetValidators();
             this._doFuzzStartCmd(json);
             break;
+          case "fuzz.customTest":
+            await this._doCustomTestCmd(json);
+            break;
           case "test.pin":
             this._doTestPinnedCmd(json, true);
             break;
@@ -1118,6 +1121,22 @@ ${inArgConsts}
     });
   } // fn: _doFuzzStartCmd()
 
+  private async _doCustomTestCmd(json: string): Promise<void> {
+    const customTest: fuzzer.FuzzTestResult = JSON5.parse(json);
+    try {
+      // Run just the custom test
+      const results = await fuzzer.fuzz(this._fuzzEnv, [customTest]);
+      const testOutcome = results.results[0];
+
+      this._results?.results.push(testOutcome);
+      this._state = FuzzPanelState.done;
+    } catch (e: unknown) {
+      this._state = FuzzPanelState.error;
+      this._errorMessage = e instanceof Error ? e.message : "Unknown error";
+    }
+
+    this._updateHtml();
+  }
   /**
    * Disposes all objects used by this instance
    */
@@ -1188,8 +1207,10 @@ ${inArgConsts}
       ]); // URI to client-side panel script
       const env = this._fuzzEnv; // Fuzzer environment
       const fn = env.function; // Function under test
-      const counter = { id: 0 }; // Unique counter for argument ids
+      const counterArgDef = { id: 0 }; // Unique counter for argument ids
+      const counterCustomArgDef = { id: 0 }; // Unique counter for argument ids
       let argDefHtml = ""; // HTML representing argument definitions
+      let customArgDefHtml = ""; // HTML representing custom test case argument definitions.
       const heuristicValidatorDescription = fn.isVoid()
         ? "Heuristic validator (for void functions). Fails: timeout, exception, values !==undefined"
         : "Heuristic validator. Fails: timeout, exception, null, undefined, Infinity, NaN";
@@ -1201,16 +1222,26 @@ ${inArgConsts}
         });
       } // if: results are available
 
-      // Render the HTML for each argument
-      fn.getArgDefs().forEach(
-        (arg, i) =>
-          (argDefHtml += this._argDefToHtmlForm(
-            arg,
-            counter,
-            "",
-            i === fn.getArgDefs().length - 1 ? "" : ","
-          ))
-      );
+      // Render the HTML for each argument and custom test case argument
+      fn.getArgDefs().forEach((arg, i) => {
+        argDefHtml += this._argDefToHtmlForm(
+          arg,
+          counterArgDef,
+          "",
+          i === fn.getArgDefs().length - 1 ? "" : ",",
+          undefined,
+          false
+        );
+
+        customArgDefHtml += this._argDefToHtmlForm(
+          arg,
+          counterCustomArgDef,
+          "",
+          i === fn.getArgDefs().length - 1 ? "" : ",",
+          undefined,
+          true
+        );
+      });
 
       // Prettier abhorrently butchers this HTML, so disable prettier here
       // prettier-ignore
@@ -1376,6 +1407,22 @@ ${inArgConsts}
               <vscode-divider></vscode-divider>
             </div>
 
+            <!-- Add New Test Case Options -->
+            <div id="fuzzAddCustomTestOptions" class="hidden">
+              <div class="panelButton">
+                <span class="codicon codicon-close" id="fuzzAddCustomTestOptions-close"></span>
+              </div>
+              <h2>Custom test case options</h2>
+
+              <div id="pane-nanofuzz"
+                <div id="argDefs">${customArgDefHtml}</div>
+                <br></br>
+                <vscode-button ${disabledFlag} id="fuzz.addCustomTest" appearance="primary">
+                  Add custom test
+                </vscode-button>
+              </div>
+            </div>
+
             <!-- Button Bar -->
             <div style="padding-top: .25em;">
               <vscode-button ${disabledFlag} id="fuzz.start" appearance="primary">
@@ -1392,7 +1439,14 @@ ${inArgConsts}
                     : ``
                 } id="fuzz.options" appearance="secondary" aria-label="Fuzzer Options">
                 More options...
-                </vscode-button>
+              </vscode-button>
+              <vscode-button ${disabledFlag} ${ 
+                (this._state === FuzzPanelState.done && this._results !== undefined)
+                    ? ``
+                    : `class="hidden" ` 
+                } id="fuzz.addCustomTestOptions" appearance="secondary" aria-label="Fuzzer Options">
+                Add custom test...
+              </vscode-button>
             </div>
 
             <!-- Fuzzer Errors -->
@@ -1887,10 +1941,11 @@ ${inArgConsts}
     counter: { id: number }, // pass counter by reference
     beginSep: string,
     endSep: string,
-    parentTag?: fuzzer.ArgTag
+    parentTag?: fuzzer.ArgTag,
+    isCustomArgDef?: boolean
   ): string {
     const id = counter.id++; // unique id for each argument
-    const idBase = `argDef-${id}`; // base HTML id for this argument
+    const idBase = isCustomArgDef ? `customArgDef-${id}` : `argDef-${id}`; // base HTML id for this argument
     const argType = arg.getType(); // type of argument
     const argName = arg.getName(); // name of the argument
     const disabledFlag =
@@ -1898,6 +1953,7 @@ ${inArgConsts}
     const dimString = "[]".repeat(arg.getDim()); // Text indicating array dimensions
     const optionalString = arg.isOptional() ? "?" : ""; // Text indication arg optionality
     const htmlEllipsis = `<span class="hidden argDef-ellipsis">...</span>`;
+    const isArgArray = arg.getDim() > 0; // Is this an array argument?
 
     let typeString: string; // Text indicating the type of argument
     const argTypeRef = arg.getTypeRef();
@@ -1954,6 +2010,9 @@ ${inArgConsts}
       default:
         sep = " = " + htmlEllipsis;
     }
+
+    if (isCustomArgDef) sep = " = " + htmlEllipsis; // Custom test case arguments do not have ellipsis
+
     // prettier-ignore
     html += /*html*/ `
          ${typeString}${dimString}${sep}
@@ -1972,6 +2031,14 @@ ${inArgConsts}
     }
 
     html += /*html*/ `
+      <!-- Argument isArray -->
+      <div class="argDef-isArray argDef-isArray-${htmlEscape(
+        isArgArray ? "true" : "false"
+      )}" id="${idBase}-${
+      isArgArray ? "true" : "false"
+    }" style="padding-left: 1em;"></div>`;
+
+    html += /*html*/ `
       <!-- Argument Type -->
       <div class="argDef-type argDef-type-${htmlEscape(
         arg.getType()
@@ -1982,120 +2049,170 @@ ${inArgConsts}
     switch (arg.getType()) {
       // Number-specific Options
       case fuzzer.ArgTag.NUMBER: {
-        // TODO: validate for ints and floats !!!
-        html += /*html*/ `<vscode-text-field size="3" ${disabledFlag} id="${idBase}-min" name="${idBase}-min" value="${htmlEscape(
-          Number(arg.getIntervals()[0].min).toString()
-        )}">Min value</vscode-text-field>`;
-        html += " ";
-        html += /*html*/ `<vscode-text-field size="3" ${disabledFlag} id="${idBase}-max" name="${idBase}-max" value="${htmlEscape(
-          Number(arg.getIntervals()[0].max).toString()
-        )}">Max value</vscode-text-field>`;
-        html += " ";
-        html +=
-          /*html*/
-          `<vscode-radio-group style="display: inline-block;">
+        if (isCustomArgDef) {
+          // TODO: validate that this is a number
+          html += /*html*/ `<vscode-text-field size="3" ${disabledFlag} id="${idBase}-exact" name="${idBase}-exact" value="${
+            isArgArray
+              ? "[]"
+              : htmlEscape(Number(arg.getIntervals()[0].min).toString())
+          }">Value</vscode-text-field>`;
+        } else {
+          // TODO: validate for ints and floats !!!
+          html += /*html*/ `<vscode-text-field size="3" ${disabledFlag} id="${idBase}-min" name="${idBase}-min" value="${htmlEscape(
+            Number(arg.getIntervals()[0].min).toString()
+          )}">Min value</vscode-text-field>`;
+          html += " ";
+          html += /*html*/ `<vscode-text-field size="3" ${disabledFlag} id="${idBase}-max" name="${idBase}-max" value="${htmlEscape(
+            Number(arg.getIntervals()[0].max).toString()
+          )}">Max value</vscode-text-field>`;
+          html += " ";
+          html +=
+            /*html*/
+            `<vscode-radio-group style="display: inline-block;">
             <vscode-radio ${disabledFlag} id="${idBase}-numInteger" name="${idBase}-numInteger" ${
-            arg.getOptions().numInteger ? " checked " : ""
-          }>Integer</vscode-radio>
+              arg.getOptions().numInteger ? " checked " : ""
+            }>Integer</vscode-radio>
             <vscode-radio ${disabledFlag} id="${idBase}-numInteger" name="${idBase}-numInteger" ${
-            !arg.getOptions().numInteger ? " checked " : ""
-          }>Float</vscode-radio>
+              !arg.getOptions().numInteger ? " checked " : ""
+            }>Float</vscode-radio>
           </vscode-radio-group>`;
+        }
+
         break;
       }
 
       // String-specific Options
       case fuzzer.ArgTag.STRING: {
-        // TODO: validate for ints > 0 !!!
-        html += /*html*/ `<vscode-text-field size="3" ${disabledFlag} id="${idBase}-minStrLen" name="${idBase}-min" value="${htmlEscape(
-          arg.getOptions().strLength.min.toString()
-        )}">Min length</vscode-text-field>`;
-        html += " ";
-        html += /*html*/ `<vscode-text-field size="3" ${disabledFlag} id="${idBase}-maxStrLen" name="${idBase}-max" value="${htmlEscape(
-          arg.getOptions().strLength.max.toString()
-        )}">Max length</vscode-text-field>`;
-        html += " ";
-        html += /*html*/ `<vscode-text-field size="10" ${disabledFlag} id="${idBase}-strCharset" name="${idBase}-strCharset" value="${htmlEscape(
-          arg.getOptions().strCharset
-        )}">Character set</vscode-text-field>`;
+        if (isCustomArgDef) {
+          // TODO: validate that this is a string
+          html += /*html*/ `<vscode-text-field size="3" ${disabledFlag} id="${idBase}-exact" name="${idBase}-exact" value="${
+            isArgArray ? "[]" : ""
+          }">Value</vscode-text-field>`;
+        } else {
+          // TODO: validate for ints > 0 !!!
+          html += /*html*/ `<vscode-text-field size="3" ${disabledFlag} id="${idBase}-minStrLen" name="${idBase}-min" value="${htmlEscape(
+            arg.getOptions().strLength.min.toString()
+          )}">Min length</vscode-text-field>`;
+          html += " ";
+          html += /*html*/ `<vscode-text-field size="3" ${disabledFlag} id="${idBase}-maxStrLen" name="${idBase}-max" value="${htmlEscape(
+            arg.getOptions().strLength.max.toString()
+          )}">Max length</vscode-text-field>`;
+          html += " ";
+          html += /*html*/ `<vscode-text-field size="10" ${disabledFlag} id="${idBase}-strCharset" name="${idBase}-strCharset" value="${htmlEscape(
+            arg.getOptions().strCharset
+          )}">Character set</vscode-text-field>`;
+        }
         break;
       }
 
       // Boolean-specific Options
       case fuzzer.ArgTag.BOOLEAN: {
-        let intervals = arg.getIntervals();
-        if (intervals.length === 0) {
-          intervals = [{ min: false, max: true }];
-        }
-        html +=
-          /*html*/
-          `<vscode-radio-group>
+        if (isCustomArgDef) {
+          html +=
+            /*html*/
+            isArgArray
+              ? `<vscode-text-field size="3" ${disabledFlag} id="${idBase}-exact" name="${idBase}-exact" value="[]">Value</vscode-text-field>`
+              : `<vscode-radio-group id="${idBase}-exact" ${disabledFlag}>
+            <vscode-radio id="${idBase}-true" name="${idBase}-exact" value="true" checked>True</vscode-radio>
+            <vscode-radio id="${idBase}-false" name="${idBase}-exact" value="false">False</vscode-radio>
+          </vscode-radio-group>`;
+        } else {
+          let intervals = arg.getIntervals();
+          if (intervals.length === 0) {
+            intervals = [{ min: false, max: true }];
+          }
+          html +=
+            /*html*/
+            `<vscode-radio-group>
             <!--<label slot="label">Values</label>-->
             <vscode-radio ${disabledFlag} id="${idBase}-trueFalse" name="${idBase}-trueFalse" ${
-            intervals[0].min !== intervals[0].max ? " checked " : ""
-          }>True and false</vscode-radio>
+              intervals[0].min !== intervals[0].max ? " checked " : ""
+            }>True and false</vscode-radio>
             <vscode-radio ${disabledFlag} id="${idBase}-trueOnly" name="${idBase}-trueOnly" ${
-            intervals[0].min && intervals[0].max ? " checked " : ""
-          }>True</vscode-radio>
+              intervals[0].min && intervals[0].max ? " checked " : ""
+            }>True</vscode-radio>
             <vscode-radio ${disabledFlag} id="${idBase}-falseOnly" name="${idBase}-falseOnly" ${
-            !intervals[0].min && !intervals[0].max ? " checked " : ""
-          }>False</vscode-radio>
+              !intervals[0].min && !intervals[0].max ? " checked " : ""
+            }>False</vscode-radio>
           </vscode-radio-group>`;
+        }
+
         break;
       }
 
       // Union-specific Options
       case fuzzer.ArgTag.UNION: {
-        // Output the array form prior to the child arguments.
-        // This seems odd, but the screen reads better to the user this way.
-        html += this._argDefArrayToHtmlForm(arg, idBase, disabledFlag);
-        html += `<div>`;
-        arg
-          .getChildren()
-          .forEach(
-            (child) =>
-              (html += this._argDefToHtmlForm(
-                child,
-                counter,
-                " | ",
-                "",
-                arg.getType()
-              ))
-          );
-        html += `</div>`;
+        if (isCustomArgDef) {
+          // TODO: validate
+          html += /*html*/ `<vscode-text-field size="3" ${disabledFlag} id="${idBase}-exact" name="${idBase}-exact" value="${
+            isArgArray ? "[]" : ""
+          }">Value</vscode-text-field>`;
+        } else {
+          // Output the array form prior to the child arguments.
+          // This seems odd, but the screen reads better to the user this way.
+          html += this._argDefArrayToHtmlForm(arg, idBase, disabledFlag);
+
+          html += `<div>`;
+          arg
+            .getChildren()
+            .forEach(
+              (child) =>
+                (html += this._argDefToHtmlForm(
+                  child,
+                  counter,
+                  " | ",
+                  "",
+                  arg.getType(),
+                  isCustomArgDef
+                ))
+            );
+          html += `</div>`;
+        }
         break;
       }
 
       // Object-specific Options
       case fuzzer.ArgTag.OBJECT: {
-        // Output the array form prior to the child arguments.
-        // This seems odd, but the screen reads better to the user this way.
-        html += this._argDefArrayToHtmlForm(arg, idBase, disabledFlag);
-        html += `<div>`;
-        const children = arg.getChildren();
-        children.forEach(
-          (child, i) =>
-            (html += this._argDefToHtmlForm(
-              child,
-              counter,
-              "",
-              i === children.length - 1 ? "" : ",",
-              arg.getType()
-            ))
-        );
-        html += `</div>`;
+        if (isCustomArgDef) {
+          // TODO: validate
+          html += /*html*/ `<vscode-text-field size="3" ${disabledFlag} id="${idBase}-exact" name="${idBase}-exact" value="${
+            isArgArray ? "[]" : "{}"
+          }">Value</vscode-text-field>`;
+        } else {
+          // Output the array form prior to the child arguments.
+          // This seems odd, but the screen reads better to the user this way.
+          html += this._argDefArrayToHtmlForm(arg, idBase, disabledFlag);
+          html += `<div>`;
+          const children = arg.getChildren();
+          children.forEach(
+            (child, i) =>
+              (html += this._argDefToHtmlForm(
+                child,
+                counter,
+                "",
+                i === children.length - 1 ? "" : ",",
+                arg.getType(),
+                isCustomArgDef
+              ))
+          );
+          html += `</div>`;
+        }
         break;
       }
     }
 
     // For objects & unions: output the array settings
-    if (argType !== fuzzer.ArgTag.OBJECT && argType !== fuzzer.ArgTag.UNION) {
+    if (
+      argType !== fuzzer.ArgTag.OBJECT &&
+      argType !== fuzzer.ArgTag.UNION &&
+      !isCustomArgDef
+    ) {
       html += this._argDefArrayToHtmlForm(arg, idBase, disabledFlag);
     }
 
     html += `</div>`;
     // For objects: output the end of object character ("}") here
-    if (argType === fuzzer.ArgTag.OBJECT) {
+    if (argType === fuzzer.ArgTag.OBJECT && !isCustomArgDef) {
       html += /*html*/ `<div class="argDef-preClose"></div><div class="argDef-close" style="font-size:1.25em;">}${endSep}</div>`;
     }
     html += `</div>`;

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1538,7 +1538,10 @@ ${inArgConsts}
               <div class="panelButton">
                 <span class="codicon codicon-close" id="fuzzAddTestInputOptions-close"></span>
               </div>
-              <h2 style="margin-bottom:.2em;">Add a test input manually</h2>
+              <h2 style="margin-bottom:.3em;">Add a test input</h2>
+              <p class="fuzzPanelDescription">
+                Enter an input below. Click <strong>Add input</strong> to test it.
+              </p>
               <table class="fuzzGrid">
                 <thead>
                   <tr>
@@ -1563,7 +1566,7 @@ ${inArgConsts}
                       )
                       .join("\r\n")}
                     <td>
-                      <vscode-button disabled ${disabledFlag} id="fuzz.addTestInput" appearance="primary">
+                      <vscode-button ${disabledFlag} id="fuzz.addTestInput" appearance="primary">
                         Add input
                       </vscode-button>
                     </td>

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1102,7 +1102,7 @@ ${inArgConsts}
         return {
           name: specs[i].getName(),
           offset: i,
-          value: v,
+          value: v.value,
         };
       }),
       output: [], // the fuzzer fills this
@@ -1868,9 +1868,9 @@ ${inArgConsts}
                         .map(
                           (i) =>
                             `<td>${
-                              i === undefined
+                              i.value === undefined
                                 ? "(no input)"
-                                : JSON5.stringify(i)
+                                : JSON5.stringify(i.value)
                             }</td>`
                         )
                         .join("\r\n")}
@@ -2787,5 +2787,5 @@ export type FuzzPanelFuzzStartMessage = {
   fuzzer: fuzzer.FuzzOptions;
   args: fuzzer.FuzzArgOverride[];
   lastTab?: string;
-  input?: fuzzer.ArgValueType[];
+  input?: fuzzer.ArgValueTypeWrapped[];
 };

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -43,6 +43,7 @@ export class FuzzPanel {
   private _argOverrides: fuzzer.FuzzArgOverride[]; // The current set of argument overrides
   private _focusInput?: [string, number]; // Newly-added input to receive UI focus
   private _lastFuzzRun: "none" | "one" | "gen" = "none"; // Type of last fuzzer run
+  private _lastTab: string | undefined; // Last tab that had focus
 
   // State-dependent instance variables
   private _results?: fuzzer.FuzzTestResults; // done state: the fuzzer output
@@ -1005,8 +1006,12 @@ ${inArgConsts}
     const panelInput: {
       fuzzer: fuzzer.FuzzOptions;
       args: fuzzer.FuzzArgOverride[];
+      lastTab: string | undefined;
     } = JSON5.parse(json);
     const fn = this._fuzzEnv.function;
+
+    // Remember the selected tab
+    this._lastTab = panelInput.lastTab;
 
     // Apply numeric fuzzer option changes
     const numericOptions = [
@@ -1594,7 +1599,7 @@ ${inArgConsts}
                 ? ""
                 : /*html*/ `style="display:none;"`
             }>
-              <vscode-panels aria-label="Test result tabs" class="fuzzTabStrip"${this._focusInput ? `activeId="tab-${this._focusInput[0]}"`:``}>`;
+              <vscode-panels aria-label="Test result tabs" id="fuzzResultsTabStrip" class="fuzzTabStrip"${this._focusInput ? ` activeId="tab-${this._focusInput[0]}"` : (this._lastTab ? ` activeId="${this._lastTab}"` : ``)}>`;
 
       // If we have results, render the output tabs to display the results.
       const tabs: (

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1514,6 +1514,9 @@ ${inArgConsts}
                 <vscode-button ${disabledFlag} id="fuzz.addTestInput" appearance="primary">
                   Test this input
                 </vscode-button>
+                <vscode-button ${disabledFlag} id="fuzz.addTestInput.cancel" appearance="secondary">
+                  Cancel
+                </vscode-button>
               </div>
               <vscode-divider />
             </div>
@@ -1521,7 +1524,7 @@ ${inArgConsts}
             <!-- Button Bar -->
             <div style="padding-top: .25em;">
               <vscode-button ${disabledFlag} id="fuzz.start" appearance="primary">
-                ${this._state === FuzzPanelState.busy ? "Testing..." : "Test"}
+                ${this._state === FuzzPanelState.busy ? "Testing..." : (this._state === FuzzPanelState.done ? "Re-test" : "Test")}
               </vscode-button>
               <vscode-button  ${disabledFlag} class="hidden" id="fuzz.changeMode" appearance="secondary" aria-label="Change Mode">
                 Change Mode
@@ -1540,7 +1543,7 @@ ${inArgConsts}
                 (this._state === FuzzPanelState.done && this._results !== undefined)
                     ? ``
                     : `class="hidden" ` 
-                } id="fuzz.addTestInputOptions" appearance="secondary" aria-label="Fuzzer Options">
+                } id="fuzz.addTestInputOptions" appearance="secondary" aria-label="Add a test input">
                 Add Input...
               </vscode-button>
             </div>

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -1522,9 +1522,9 @@ ${inArgConsts}
               <div class="panelButton">
                 <span class="codicon codicon-close" id="fuzzAddTestInputOptions-close"></span>
               </div>
-              <h2>Add a test input manually</h2>
-              <div style="margin-left: 0.5em; margin-bottom: 0.75em;" id="argDefs">${customArgDefHtml}</div>
-              <div style="margin-top: 0.5em">
+              <h2 style="margin-bottom:.2em;">Add a test input manually</h2>
+              <div style="padding-bottom: 0.2em;" id="argDefs">${customArgDefHtml}</div>
+              <div style="padding-top: 0.2em; clear: both;">
                 <vscode-button ${disabledFlag} id="fuzz.addTestInput" appearance="primary">
                   Test this input
                 </vscode-button>
@@ -2064,7 +2064,9 @@ ${inArgConsts}
       this._state === FuzzPanelState.busy ? ` disabled ` : ""; // Disable inputs if busy
     const dimString = "[]".repeat(arg.getDim()); // Text indicating array dimensions
     const optionalString = arg.isOptional() ? "?" : ""; // Text indication arg optionality
-    const htmlEllipsis = `<span class="hidden argDef-ellipsis">...</span>`;
+    const htmlEllipsis = `<span class="hidden argDef-ellipsis">${
+      isCustomArgDef ? "undefined;" : "..."
+    }</span>`;
     const isArgArray = arg.getDim() > 0; // Is this an array argument?
 
     let typeString: string; // Text indicating the type of argument
@@ -2133,11 +2135,12 @@ ${inArgConsts}
     // Give the option of suppressing generation of optional members
     if (
       parentTag === fuzzer.ArgTag.UNION ||
-      (parentTag === fuzzer.ArgTag.OBJECT && arg.isOptional())
+      (parentTag === fuzzer.ArgTag.OBJECT && arg.isOptional()) ||
+      (isCustomArgDef && arg.isOptional())
     ) {
       // prettier-ignore
       html += /*html*/ `
-        <div class="isNoInput tooltipped tooltipped-nw" aria-label="Generate inputs of this type?">
+        <div class="isNoInput tooltipped tooltipped-nw" aria-label="${isCustomArgDef ? "Include this optional parameter?" : "Generate inputs of this type?"}">
           <vscode-checkbox id="${idBase}-isNoInput" ${disabledFlag} ${arg.isNoInput() ? "" : "checked"} current-checked="${arg.isNoInput() ? "false" : "true"}"></vscode-checkbox>
         </div>`
     }
@@ -2167,7 +2170,7 @@ ${inArgConsts}
             isArgArray
               ? "[]"
               : htmlEscape(Number(arg.getIntervals()[0].min).toString())
-          }">Value</vscode-text-field>`;
+          }"></vscode-text-field>`;
         } else {
           // TODO: validate for ints and floats !!!
           html += /*html*/ `<vscode-text-field size="3" ${disabledFlag} id="${idBase}-min" name="${idBase}-min" value="${htmlEscape(
@@ -2199,7 +2202,7 @@ ${inArgConsts}
           // TODO: validate that this is a string
           html += /*html*/ `<vscode-text-field size="3" ${disabledFlag} id="${idBase}-exact" name="${idBase}-exact" value="${
             isArgArray ? "[]" : ""
-          }">Value</vscode-text-field>`;
+          }"></vscode-text-field>`;
         } else {
           // TODO: validate for ints > 0 !!!
           html += /*html*/ `<vscode-text-field size="3" ${disabledFlag} id="${idBase}-minStrLen" name="${idBase}-min" value="${htmlEscape(
@@ -2258,7 +2261,7 @@ ${inArgConsts}
           // TODO: validate
           html += /*html*/ `<vscode-text-field size="3" ${disabledFlag} id="${idBase}-exact" name="${idBase}-exact" value="${
             isArgArray ? "[]" : ""
-          }">Value</vscode-text-field>`;
+          }"></vscode-text-field>`;
         } else {
           // Output the array form prior to the child arguments.
           // This seems odd, but the screen reads better to the user this way.
@@ -2289,7 +2292,7 @@ ${inArgConsts}
           // TODO: validate
           html += /*html*/ `<vscode-text-field size="3" ${disabledFlag} id="${idBase}-exact" name="${idBase}-exact" value="${
             isArgArray ? "[]" : "{}"
-          }">Value</vscode-text-field>`;
+          }"></vscode-text-field>`;
         } else {
           // Output the array form prior to the child arguments.
           // This seems odd, but the screen reads better to the user this way.


### PR DESCRIPTION
Building upon PR #250, this PR resolves #127 by giving the user the ability to manually add test inputs. 

The execution of manual inputs is tracked by measures, such as code coverage. Manual inputs, if interesting according to those measures, might be mutated by other input generators in subsequent testing runs.

<img width="578" height="749" alt="image" src="https://github.com/user-attachments/assets/3f5cd3ea-5a92-4f2a-9540-cdf1c08141c8" />

Note: this PR removes counter-example mode.