### PR TITLE
fix: invalid array mutation

### DIFF
--- a/src/fuzzer/Fuzzer.test.ts
+++ b/src/fuzzer/Fuzzer.test.ts
@@ -2,6 +2,7 @@ import { ArgDef, Tester, implicitOracle } from "./Fuzzer";
 import { TypeScriptCompiler } from "./Compiler";
 import { FuzzOptions } from "./Types";
 import * as JSON5 from "json5";
+import { ArgDefValidator } from "./analysis/typescript/ArgDefValidator";
 
 // Extend default test timeout to 60s
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
@@ -448,13 +449,10 @@ describe("fuzzer:", () => {
     expect(args[1].getDim()).toBe(3);
 
     const fuzzResult = tester.testSync();
-    //const validator = new ArgDefValidator(args);
+    const validator = new ArgDefValidator(args);
     expect(fuzzResult.results.length).not.toBe(0); // Ensure we have results
     fuzzResult.results.forEach((result) => {
       const input = result.input.map((i) => i.value);
-      /* 
-      TODO: This part of the test is commented out pending resolution of Issue # 329
-      console.debug(JSON5.stringify(input)); // !!!!!!!!!!
       expect(
         validator.validate(
           result.input.map((i) => {
@@ -476,7 +474,6 @@ describe("fuzzer:", () => {
           JSON5.stringify(input[1])
         )
       ).toBeTrue();
-      */
     });
   });
 

--- a/src/fuzzer/analysis/typescript/ArgDefMutator.ts
+++ b/src/fuzzer/analysis/typescript/ArgDefMutator.ts
@@ -52,33 +52,51 @@ export class ArgDefMutator {
       level = 1
     ): void => {
       const options = spec.getOptions();
-      mutations.push(
-        ...[
-          {
-            name: "array-jumble",
-            value: [...a].sort(() => 0.5 - prng()),
-            path: [...path],
-          },
-          {
-            name: "array-reverse",
-            value: [...a].reverse(),
-            path: [...path],
-          },
-          {
-            name: "array-appendNewElement",
-            value: [
-              ...a,
-              ArgDefGenerator.gen(spec, prng, false /* w/o dimensions */),
-            ],
-            path: [...path],
-          },
-        ].filter(
-          (e) =>
-            JSON5.stringify(e.value) !== JSON5.stringify(a) &&
-            options.dimLength[level - 1].max >= e.value.length &&
-            options.dimLength[level - 1].min <= e.value.length
-        )
-      );
+
+      // Re-arrange elements if multiple elements are present
+      if (a.length > 1) {
+        mutations.push(
+          ...[
+            {
+              name: "array-jumble",
+              value: [...a].sort(() => 0.5 - prng()),
+              path: [...path],
+            },
+            {
+              name: "array-reverse",
+              value: [...a].reverse(),
+              path: [...path],
+            },
+          ].filter((e) => JSON5.stringify(e.value) !== JSON5.stringify(a))
+        );
+      } // if: array length > 1
+
+      // Add elements if the dimension is not yet full
+      if (options.dimLength[level - 1].max > a.length) {
+        // Append new non-array element on the terminal dimension
+        // when that terminal dimension is not full
+        if (level === spec.getDim()) {
+          // terminal dimension: add a value
+          mutations.push(
+            ...[
+              {
+                name: "array-appendNewElement",
+                value: [
+                  ...a,
+                  ArgDefGenerator.gen(spec, prng, false /* w/o dimensions */),
+                ],
+                path: [...path],
+              },
+            ].filter(
+              (e) =>
+                JSON5.stringify(e.value) !== JSON5.stringify(a) &&
+                options.dimLength[level - 1].max >= e.value.length &&
+                options.dimLength[level - 1].min <= e.value.length
+            ) // filter
+          ); // push
+        }
+        // TODO: non-terminal dimension: generate a dimensional element
+      } // if: dimension is not yet full
 
       // Process each element in this level of the array
       for (const i in a) {
@@ -107,7 +125,7 @@ export class ArgDefMutator {
           });
         }
       }
-    };
+    }; // fn: mutateArray
 
     // Create a subinput for each input
     const subInputs: {
@@ -122,7 +140,7 @@ export class ArgDefMutator {
         subSpec: specs[i],
         inArray: false,
       };
-    });
+    }); // fn: subInputs
 
     // Process each subinput
     for (let i = 0; i < subInputs.length; i++) {

--- a/src/fuzzer/analysis/typescript/ArgDefValidator.ts
+++ b/src/fuzzer/analysis/typescript/ArgDefValidator.ts
@@ -162,9 +162,15 @@ const traverse = (
   for (const i in a) {
     if (Array.isArray(a[i]) && currDepth < spec.getDim()) {
       if (!traverse(a[i], spec, currDepth + 1)) {
-        return false;
+        return false; // next level of array is invalid
       }
     } else {
+      if (currDepth + 1 < spec.getDim()) {
+        console.debug(
+          `${JSON5.stringify(a)} has non-array value at insufficient depth (${currDepth + 1} < ${spec.getDim()})`
+        ); // !!!!!!!!!!
+        return false; // value at insufficient depth
+      }
       if (!ArgDefValidator.validate(a[i], spec, true)) {
         return false;
       }


### PR DESCRIPTION
Resolves #329 by adding a check to `ArgDefMutator` and `ArgDefValidator` as well as an expanded end-to-end regression test, `Fuzz example 17 - dimensioned typerefs`.