### PR TITLE
fix: pinning for puts w/no inputs

### DIFF
--- a/assets/ui/FuzzPanelMain.ts
+++ b/assets/ui/FuzzPanelMain.ts
@@ -620,7 +620,9 @@ function main() {
         // Render the header row
         const hRow = thead.appendChild(document.createElement("tr"));
         Object.keys(data[type][0]).forEach((k) => {
-          if (k === pinnedLabel) {
+          if (hiddenColumns.indexOf(k) !== -1) {
+            // noop (hidden)
+          } else if (k === pinnedLabel) {
             const cell = hRow.appendChild(document.createElement("th"));
             cell.classList.add(
               "colorColumn",
@@ -635,8 +637,6 @@ function main() {
             cell.addEventListener("click", () => {
               handleColumnSort(type, k, tbody, true);
             });
-          } else if (hiddenColumns.indexOf(k) !== -1) {
-            // noop (hidden)
           } else if (k === implicitLabel) {
             if (resultsData.env.options.useImplicit) {
               const heuristicValidatorDescription =
@@ -1556,7 +1556,12 @@ function drawTableBody({
     let id = -1;
     const row = tbody.appendChild(document.createElement("tr"));
     Object.keys(e).forEach((k) => {
-      if (k === pinnedLabel) {
+      if (k === idLabel) {
+        id = parseInt(e[k]);
+        row.setAttribute("id", `${id}`);
+      } else if (hiddenColumns.indexOf(k) !== -1) {
+        // noop (hidden)
+      } else if (k === pinnedLabel) {
         const cell = row.appendChild(document.createElement("td"));
         // Add pin icon
         cell.className = e[k] ? pinState.classPinned : pinState.classPin;
@@ -1580,11 +1585,6 @@ function drawTableBody({
           }
           handlePinToggle(parseInt(idStr), type);
         });
-      } else if (k === idLabel) {
-        id = parseInt(e[k]);
-        row.setAttribute("id", `${id}`);
-      } else if (hiddenColumns.indexOf(k) !== -1) {
-        // noop (hidden)
       } else if (k === implicitLabel) {
         if (resultsData.env.options.useImplicit) {
           const cell = row.appendChild(document.createElement("td"));

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -2679,6 +2679,19 @@ ${inArgConsts}
         `;
       }
 
+      // Columns to hide on the front-end
+      const hiddenColumns = vscode.workspace
+        .getConfiguration("nanofuzz.ui")
+        .get<boolean>("showSourceColumn", false)
+        ? ["id"] // Always hide the id column
+        : ["id", "src"];
+
+      // Pinning and human validators are not relevant for
+      // PUTs with no inputs so hide those columns
+      if (!this._fuzzEnv.function.getArgDefs().length) {
+        hiddenColumns.push("pinned", "correct output?");
+      }
+
       // Hidden data for the client script to process
       html += /*html*/ `
             <!-- Fuzzer Result Payload: for the client script to process -->
@@ -2705,15 +2718,7 @@ ${inArgConsts}
 
             <!-- Fuzzer Sort Columns: for the client script to process -->
             <div id="fuzzHideColumns" class="hidden">
-              ${htmlEscape(
-                JSON5.stringify(
-                  vscode.workspace
-                    .getConfiguration("nanofuzz.ui")
-                    .get<boolean>("showSourceColumn", false)
-                    ? ["id"]
-                    : ["id", "src"]
-                )
-              )}
+              ${htmlEscape(JSON5.stringify(hiddenColumns))}
             </div>
 
             <!-- Validator Functions: for the client script to process -->


### PR DESCRIPTION
Resolves #247 by hiding the pinned and human validator columns, which are input-specific, for PUTs that have no inputs.