### PR TITLE
fix: fuzzgrid border color for src/no input cols

### DIFF
--- a/assets/ui/FuzzPanelMain.css
+++ b/assets/ui/FuzzPanelMain.css
@@ -70,10 +70,14 @@ body {
 }
 .fuzzGrid td {
   word-break: break-word;
-  padding: 4px 6px;
+  padding: 2px 6px;
+}
+.fuzzGrid tbody tr:first-child td {
+  padding-top: 4px;
 }
 .fuzzGrid tbody tr:last-child td {
   border-bottom: 1px solid;
+  padding-bottom: 4px;
 }
 .editorFont {
   font-family: var(--vscode-editor-font-family);
@@ -83,8 +87,8 @@ body {
 .preWrap {
   white-space: pre-wrap;
 }
-.fuzzGrid td.tableCol-src,
-.fuzzGrid td.noInput {
+.fuzzGrid td.tableCol-src span,
+.fuzzGrid td.noInput span {
   color: rgb(from var(--vscode-foreground) r g b / 0.5);
 }
 .fuzzGrid th.tableCol-src,

--- a/assets/ui/FuzzPanelMain.ts
+++ b/assets/ui/FuzzPanelMain.ts
@@ -1725,6 +1725,7 @@ function drawTableBody({
         cell2.classList.add("colGroupEnd", "clickable");
       } else {
         const cell = row.appendChild(document.createElement("td"));
+        const span = cell.appendChild(document.createElement("span"));
         cell.classList.add(
           `tableCol-${k.replace(" ", "")}`,
           `editorFont`,
@@ -1733,7 +1734,7 @@ function drawTableBody({
         if (e[k] === "(no input)") {
           cell.classList.add("noInput");
         }
-        cell.textContent = e[k];
+        span.textContent = e[k];
       }
     });
   });


### PR DESCRIPTION
Fix the incorrect coloring of the bottom FuzzGrid table border for the source column as well as for `(no input)` cells when they are adjacent to the table border. The border color should be consistent regardless of the column or table cell contents.