### PR TITLE
chore: tweak row spacing

### DIFF
--- a/assets/ui/FuzzPanelMain.css
+++ b/assets/ui/FuzzPanelMain.css
@@ -70,7 +70,7 @@ body {
 }
 .fuzzGrid td {
   word-break: break-word;
-  padding: 2px 6px;
+  padding: 3px 6px;
 }
 .fuzzGrid tbody tr:first-child td {
   padding-top: 4px;


### PR DESCRIPTION
Makes the gap between grid rows slightly larger because the prior smaller gap made it a little too hard to distinguish among rows containing a lot of data.