### PR TITLE
chore: separate property oracle from the fuzzer

### DIFF
--- a/assets/ui/FuzzPanelMain.ts
+++ b/assets/ui/FuzzPanelMain.ts
@@ -10,18 +10,18 @@ import {
   FuzzValueOrigin,
   isFuzzResultTab,
   Judgment,
-} from "fuzzer/Types";
+} from "../../src/fuzzer/Types";
 import {
   ArgValueType,
   ArgValueTypeWrapped,
   FuzzTestResults,
-} from "fuzzer/Fuzzer";
+} from "../../src/fuzzer/Fuzzer";
 import {
   FuzzPanelFuzzRunMessage,
   FuzzPanelMessageToWebView,
   FuzzPanelMessageFromWebView,
   FuzzPanelPinMessage,
-} from "ui/FuzzPanel";
+} from "../../src/ui/FuzzPanel";
 
 const vscode = acquireVsCodeApi();
 

--- a/src/fuzzer/Fuzzer.test.ts
+++ b/src/fuzzer/Fuzzer.test.ts
@@ -239,7 +239,7 @@ describe("fuzzer:", () => {
       fuzzResult.results.some((e) => e.input[0].value === "bugs")
     ).toBeTruthy();
 
-    // Expect that most of the validtor tests will pass
+    // Expect that some of the validtor tests will pass
     expect(
       fuzzResult.results.some((e) =>
         e.passedValidators.some((v) => v === "pass")

--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -11,12 +11,10 @@ import {
   FuzzIoElement,
   FuzzPinnedTest,
   FuzzTestResult,
-  Result,
   FuzzResultCategory,
   FuzzStopReason,
   FuzzBusyStatusMessage,
   BaseMeasureConfig,
-  Judgment,
 } from "./Types";
 import { InputAndSource, FuzzOptions } from "./Types";
 import { MeasureFactory } from "./measures/MeasureFactory";
@@ -474,6 +472,13 @@ export class Tester {
     // Build a test runner for executing tests
     const runner = RunnerFactory(this.env, mod, this._function.getName());
 
+    // Build runners for the property validators
+    const propertyOracle = new PropertyOracle(
+      this._validators.map((vFnRef) =>
+        RunnerFactory(this.env, mod, vFnRef.name)
+      )
+    );
+
     // Are we currently injecting inputs?
     let stillInjecting = !!injectTests.length;
 
@@ -716,7 +721,7 @@ export class Tester {
         pct: typeof stopCondition === "number" ? stopCondition : 100,
       });
 
-      // Call the function via the wrapper
+      // Call the function via the runner
       const startRunTime = performance.now(); // start timer
       try {
         const inputValues = result.input.map((e) => e.value);
@@ -770,80 +775,32 @@ export class Tester {
         );
       }
 
-      // PROPERTY VALIDATOR ------------------------------------------
+      // PROPERTY ORACLE --------------------------------------------
       // If a property validator is selected, call it to evaluate the result
-      // TODO: Refactor this out of the fuzzer similar to the other oracles
-      if (this._validators.length && this._options.useProperty) {
-        for (const valFn in this._validators) {
-          const valFnName = this._validators[valFn].name;
-          // Build the validator function wrapper
-          const validatorFnWrapper = functionTimeout(
-            (result: FuzzTestResult): FuzzTestResult => {
-              // Simplified data structure for validator function input
-              const validatorIn: Result = {
-                in: result.input.map((i) => i.value), // inputs
-                out:
-                  result.output.length === 0
-                    ? "timeout or exception"
-                    : result.output[0].value,
-                exception: result.exception,
-                timeout: result.timeout,
-              };
-              try {
-                // Map v0.3 judgments to v0.4 judgments
-                const validatorOut: boolean | undefined | Judgment =
-                  mod[valFnName](validatorIn);
-                let judgment: Judgment;
-                switch (validatorOut) {
-                  case undefined:
-                    judgment = "unknown";
-                    break;
-                  case true:
-                    judgment = "pass";
-                    break;
-                  case false:
-                    judgment = "fail";
-                    break;
-                  default:
-                    judgment = validatorOut;
-                }
-                return {
-                  ...result,
-                  passedValidator: judgment,
-                };
-              } catch (e: unknown) {
-                const msg = isError(e) ? e.message : JSON.stringify(e);
-                const stack = isError(e) ? e.stack : "<no stack>";
-                return {
-                  ...result,
-                  validatorException: true,
-                  validatorExceptionMessage: msg,
-                  validatorExceptionFunction: valFnName,
-                  validatorExceptionStack: stack,
-                };
-              }
-            },
-            this._options.fnTimeout
-          );
-
-          // Categorize the result (so it's not stale)
-          result.category = categorizeResult(result);
-
-          // Call the validator function wrapper
-          const validatorResult: typeof result = validatorFnWrapper(
-            JSON5.parse<typeof result>(JSON5.stringify(result))
-          ); // <-- Wrapper (protect the input)
-
-          // Store the validator results
-          result.passedValidators.push(validatorResult.passedValidator);
-          result.validatorException = validatorResult.validatorException;
-          result.validatorExceptionFunction =
-            validatorResult.validatorExceptionFunction;
-          result.validatorExceptionMessage =
-            validatorResult.validatorExceptionMessage;
-          result.validatorExceptionStack =
-            validatorResult.validatorExceptionStack;
-        } // for: valFn in env.validators
+      if (this._options.useProperty) {
+        propertyOracle
+          .judge(
+            Object.freeze({
+              in: result.input.map((i) => i.value), // inputs
+              out:
+                result.output.length === 0
+                  ? "timeout or exception"
+                  : result.output[0].value,
+              exception: result.exception,
+              timeout: result.timeout,
+            })
+          )
+          .forEach((j, i) => {
+            if (isError(j)) {
+              result.passedValidators.push("unknown");
+              result.validatorException = true;
+              result.validatorExceptionMessage = j.message;
+              result.validatorExceptionFunction = this._validators[i].name;
+              result.validatorExceptionStack = j.stack;
+            } else {
+              result.passedValidators.push(j);
+            }
+          });
 
         // Summarize propert judgments.
         result.passedValidator = PropertyOracle.summarize(

--- a/src/fuzzer/oracles/ExampleOracle.ts
+++ b/src/fuzzer/oracles/ExampleOracle.ts
@@ -1,4 +1,4 @@
-import { FuzzIoElement } from "fuzzer/Types";
+import { FuzzIoElement } from "../Types";
 import { Judgment } from "./Types";
 import * as JSON5 from "json5";
 

--- a/src/fuzzer/oracles/ImplicitOracle.ts
+++ b/src/fuzzer/oracles/ImplicitOracle.ts
@@ -1,4 +1,4 @@
-import { FuzzIoElement } from "fuzzer/Types";
+import { FuzzIoElement } from "../Types";
 import { Judgment } from "./Types";
 
 /**

--- a/src/fuzzer/oracles/PropertyOracle.ts
+++ b/src/fuzzer/oracles/PropertyOracle.ts
@@ -1,6 +1,60 @@
 import { Judgment } from "./Types";
+import { Result } from "../Types";
+import { isError } from "../Util";
+import { AbstractRunner } from "../runners/AbstractRunner";
 
 export class PropertyOracle {
+  protected _propRunners: AbstractRunner[] = [];
+
+  constructor(propRunners: AbstractRunner[]) {
+    this._propRunners = [...propRunners];
+  }
+
+  /**
+   * Judge an execution result of a program using property validators
+   *
+   * @param `result` result of executing the program
+   * @returns one judgment or one exception for each property validator
+   */
+  public judge(result: Result): (Judgment | Error)[] {
+    const jj: (Judgment | Error)[] = [];
+    for (const r of this._propRunners) {
+      try {
+        const validatorOut = r.run([result])[0];
+        switch (validatorOut) {
+          case true: // v0.3
+          case "pass": // v0.4
+            jj.push("pass");
+            break;
+          case false: // v0.3
+          case "fail": // v0.4
+            jj.push("fail");
+            break;
+          case undefined: // v0.3
+          case "unknown": // v0.4
+            jj.push("unknown");
+            break;
+          default:
+            jj.push(
+              new Error(
+                `Property validator did not return: "pass" | "fail" | "unknown"`
+              )
+            );
+        }
+      } catch (e: unknown) {
+        jj.push(
+          isError(e)
+            ? e
+            : new Error(
+                `Property validator threw exception that is not an Error`,
+                { cause: e }
+              )
+        );
+      }
+    }
+    return jj;
+  } // fn: judge
+
   /**
    * Summarizes a judgment from multiple propert-based judgments.
    *
@@ -22,5 +76,5 @@ export class PropertyOracle {
       }
     }
     return summary;
-  }
+  } // fn: summarize
 }

--- a/src/fuzzer/runners/JSRunner.ts
+++ b/src/fuzzer/runners/JSRunner.ts
@@ -69,7 +69,7 @@ export class JSRunner extends AbstractRunner {
     const script = new vm.Script(`returnValue = function_();`);
 
     const wrappedFunction = (
-      timeout: number,
+      timeout: number | undefined,
       ...arguments_: unknown[]
     ): [unknown, VmGlobals] => {
       // `function_` resides in the context of the original
@@ -79,7 +79,7 @@ export class JSRunner extends AbstractRunner {
         function_: () => function_(...arguments_),
       };
 
-      script.runInNewContext(context, { timeout: timeout });
+      script.runInNewContext(context, timeout ? { timeout: timeout } : {});
 
       return [context.returnValue, context];
     };

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -14,7 +14,7 @@ import {
   clearCoverageHeatmapFromEditor,
 } from "./CoverageHeatmap";
 import { normalizePathForKey } from "../fuzzer/Util";
-import { CodeCoverageMeasureStats } from "fuzzer/measures/CoverageMeasure";
+import { CodeCoverageMeasureStats } from "../fuzzer/measures/CoverageMeasure";
 
 // Consts for validator result arg name generation
 const resultArgCandidateNames = ["r", "result", "_r", "_result"];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,11 +22,7 @@
     "isolatedModules": false,
     "strict": true,
     "declaration": true,
-    "declarationMap": true,
-    "paths": {
-      "fuzzer/*": ["./src/fuzzer/*"],
-      "ui/*": ["./src/ui/*"]
-    }
+    "declarationMap": true
   },
   "formatCodeOptions": {
     "baseIndentSize": 0,


### PR DESCRIPTION
This PR finishes separating the property-based oracle from the fuzzer.

Resolves #216 by allowing the particular Composite Oracle to be programmatically defined in various ways.