### PR TITLE
chore: use local ts in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,7 @@
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
   "js/ts.tsc.autoDetect": "off",
+  "js/ts.tsdk.path": "./node_modules/typescript/lib",
   "editor.formatOnSave": true,
   "jasmineExplorer.nodeArgv": ["--no-experimental-strip-types"],
   "eslint.validate": ["javascript", "typescript"],


### PR DESCRIPTION
We need more stability inside the IDE across developers w.r.t. TypeScript errors and warnings, particularly considering that vscode is now shipping weekly updates. This PR configures our vscode workspace to use the local project's version of TypeScript rather than the default, which is whichever version vscode shipped this week.