### PR TITLE
chore: delete the obsolete numSigned option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To use NaNofuzz in your own projects:
 NaNofuzz is an **experimental** testing platform developed by the Accelerated Testing Research Program at Carnegie Mellon University's School of Computer Science. While NaNofuzz is **not** intended for production use, contributions are welcome to address the limitations below. 
 
 NaNofuzz supports exported standard and arrow functions with any mixture of the following parameter types:
- - Numbers (integers and floats, signed and unsigned)
+ - Numbers (integers and floats)
  - Strings
  - Booleans
  - Literal object types

--- a/package.json
+++ b/package.json
@@ -178,12 +178,6 @@
             "default": true,
             "description": "Generate integers as numeric inputs by default?"
           },
-          "nanofuzz.argdef.numSigned": {
-            "title": "Generate signed inputs?",
-            "type": "boolean",
-            "default": false,
-            "description": "Generate signed values as numeric inputs by default?"
-          },
           "nanofuzz.argdef.dftDimLength.min": {
             "title": "Minimum array length",
             "type": "number",

--- a/src/fuzzer/Fuzzer.test.ts
+++ b/src/fuzzer/Fuzzer.test.ts
@@ -63,7 +63,10 @@ const intOptions: FuzzOptions = {
  */
 const floatOptions: FuzzOptions = {
   ...intOptions,
-  argDefaults: ArgDef.getDefaultFloatOptions(),
+  argDefaults: {
+    ...ArgDef.getDefaultOptions(),
+    numInteger: false,
+  },
 };
 
 /**

--- a/src/fuzzer/adapters/JestAdapter.test.ts
+++ b/src/fuzzer/adapters/JestAdapter.test.ts
@@ -6,7 +6,6 @@ const argDefaults: ArgOptions = {
   strCharset: "abc",
   strLength: { min: 0, max: 3 },
   numInteger: true,
-  numSigned: false,
   anyType: ArgTag.NUMBER,
   anyDims: 0,
   dftDimLength: { min: 0, max: 1 },

--- a/src/fuzzer/analysis/typescript/ArgDef.test.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.test.ts
@@ -584,8 +584,6 @@ function abbrSpec(spec: ArgDef<ArgType>, indents = 0): string[] {
   line.push(`dims: ${JSON5.stringify(spec.getOptions().dimLength)}`);
   if (spec.isNoInput()) line.push(`NOINPUT`);
   if (spec.isOptional()) line.push(`OPTIONAL`);
-  if (spec.getType() === ArgTag.NUMBER && spec.getOptions().numSigned)
-    line.push(`SIGNED`);
   if (spec.getType() === ArgTag.NUMBER && spec.getOptions().numInteger)
     line.push(`INTEGER`);
   if (
@@ -702,24 +700,13 @@ function getRandomArgDef(
       options = {
         ...options,
         numInteger: prng() < 0.5,
-        numSigned: prng() < 0.5,
       };
       if (options.numInteger) {
-        if (options.numSigned) {
-          const min = Math.floor(prng() * 200) - 100;
-          interval = [{ min, max: min + Math.floor(prng() * 200) }];
-        } else {
-          const min = Math.floor(prng() * 100);
-          interval = [{ min, max: min + Math.floor(prng() * 100) }];
-        }
+        const min = Math.floor(prng() * 100);
+        interval = [{ min, max: min + Math.floor(prng() * 100) }];
       } else {
-        if (options.numSigned) {
-          const min = prng() * 200 - 100;
-          interval = [{ min, max: min + prng() * 200 }];
-        } else {
-          const min = prng() * 100;
-          interval = [{ min, max: min + prng() * 100 }];
-        }
+        const min = prng() * 100;
+        interval = [{ min, max: min + prng() * 100 }];
       }
       break;
     }

--- a/src/fuzzer/analysis/typescript/ArgDef.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.ts
@@ -182,7 +182,7 @@ export class ArgDef<T extends ArgType> {
       case ArgTag.NUMBER:
         return [
           {
-            min: options.numSigned ? -100 : 0,
+            min: 0,
             max: 100,
           },
         ];
@@ -548,9 +548,9 @@ export class ArgDef<T extends ArgType> {
   } // fn: getTypeAnnotation()
 
   /**
-   * Returns the default option set for signed integer values.
+   * Returns the default option set.
    *
-   * @returns the default option set for signed integer values
+   * @returns the default option set
    */
   public static getDefaultOptions(): ArgOptions {
     return {
@@ -571,9 +571,6 @@ export class ArgDef<T extends ArgType> {
       numInteger: vscode.workspace
         .getConfiguration("nanofuzz.argdef")
         .get("numInteger", true),
-      numSigned: vscode.workspace
-        .getConfiguration("nanofuzz.argdef")
-        .get("numSigned", false),
 
       // `Any` defaults
       anyType: vscode.workspace
@@ -595,18 +592,6 @@ export class ArgDef<T extends ArgType> {
       dimLength: [],
     };
   } // fn: getDefaultOptions()
-
-  /**
-   * Returns the default option set for signed float values.
-   *
-   * @returns the default option set for signed float values
-   */
-  public static getDefaultFloatOptions(): ArgOptions {
-    return {
-      ...ArgDef.getDefaultOptions(),
-      numInteger: false,
-    };
-  } // fn: getDefaultFloatOptions()
 
   /**
    * Accepts an option set and returns true if it is valid; false otherwise.

--- a/src/fuzzer/analysis/typescript/Types.ts
+++ b/src/fuzzer/analysis/typescript/Types.ts
@@ -107,7 +107,6 @@ export type ArgOptions = {
 
   // For type number
   numInteger: boolean; // true if the numeric argument input is an integer
-  numSigned: boolean; // true if the numeric argument input is signed
 
   // For type any
   anyType: ArgTag; // the type to interpret for 'any' types
@@ -135,7 +134,6 @@ export type ArgOptionOverrides = {
  */
 export type ArgOptionOverride = {
   numInteger?: boolean;
-  numSigned?: boolean;
   numIntervals?: Interval<number>[];
   dimLength?: Interval<number>[];
   strLength?: Interval<number>;


### PR DESCRIPTION
Delete the `numSigned` option as discussed in the thread here: https://github.com/nanofuzz/nanofuzz/issues/117#issuecomment-4336486156

`getDefaultFloatOptions` seems to be called only once and is for tests, so it is also inlined here. LMK if it should be reverted!