### PR TITLE
chore: enable switch-exhaustiveness-check

### DIFF
--- a/assets/ui/FuzzPanelMain.ts
+++ b/assets/ui/FuzzPanelMain.ts
@@ -1475,7 +1475,7 @@ function updateSortOrders(type: FuzzResultCategory, thisCol: string) {
     case FuzzSortOrder.desc:
       delete columnSortOrders[type][thisCol]; // not present, meaning "none"
       break;
-    default:
+    case FuzzSortOrder.none:
       columnSortOrders[type][thisCol] = FuzzSortOrder.asc;
   }
 } // fn: updateSortOrders

--- a/assets/ui/utils.ts
+++ b/assets/ui/utils.ts
@@ -21,7 +21,3 @@ export function getElementByIdWithTypeOrThrow<T extends HTMLElement>(
   }
   return element;
 }
-
-export function assertNonreachable(x: never): never {
-  throw new Error(`Non-reachable code executed: ${x}`);
-}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,7 @@ export default defineConfig(
         1,
         { assertionStyle: "never" },
       ],
+      "@typescript-eslint/switch-exhaustiveness-check": "error",
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -262,6 +262,7 @@
     "build": "node build.mjs",
     "test": "node --no-experimental-strip-types ./node_modules/jasmine/bin/jasmine.js",
     "lint": "eslint src assets/ui",
+    "lint:errors": "eslint --quiet src assets/ui",
     "vscode:prepublish": "yarn build",
     "publish": "vsce publish --yarn",
     "package": "vsce package --yarn",

--- a/src/fuzzer/analysis/typescript/ArgDef.test.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.test.ts
@@ -742,6 +742,11 @@ function getRandomArgDef(
     case ArgTag.UNION: {
       break;
     }
+    case ArgTag.UNRESOLVED: {
+      throw new Error(
+        "ArgTag.UNRESOLVED is not a valid type for getRandomArgDef"
+      );
+    }
   }
   return new ArgDef<ArgType>(
     name,

--- a/src/fuzzer/analysis/typescript/ArgDef.ts
+++ b/src/fuzzer/analysis/typescript/ArgDef.ts
@@ -199,7 +199,7 @@ export class ArgDef<T extends ArgType> {
       case ArgTag.LITERAL:
       case ArgTag.UNION:
         return [];
-      default:
+      case ArgTag.UNRESOLVED:
         throw new Error(`Unsupported type: ${type}`);
     }
   } // fn: getDefaultIntervals()
@@ -480,6 +480,7 @@ export class ArgDef<T extends ArgType> {
       return this.typeRef;
     }
 
+    // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
     switch (this.type) {
       case ArgTag.OBJECT: {
         // Literal object, no type. Recursively walk

--- a/src/fuzzer/analysis/typescript/ArgDefGenerator.ts
+++ b/src/fuzzer/analysis/typescript/ArgDefGenerator.ts
@@ -92,20 +92,21 @@ function generateRandomInputFn<T extends ArgType>(
   //if (arg.isConstant() && arg.getDim() === 0 && !arg.isNoInput())
   //  return () => arg.getConstantValue();
 
-  switch (arg.getType()) {
-    case "number":
+  const argType = arg.getType();
+  switch (argType) {
+    case ArgTag.NUMBER:
       randFn = getRandomNumber;
       break;
-    case "boolean":
+    case ArgTag.BOOLEAN:
       randFn = getRandomBool;
       break;
-    case "string":
+    case ArgTag.STRING:
       randFn = getRandomString;
       break;
-    case "literal":
+    case ArgTag.LITERAL:
       randFn = getLiteral;
       break;
-    case "union":
+    case ArgTag.UNION:
       // We generate this here using arg
       randFn = (
         prng: seedrandom.prng,
@@ -127,7 +128,7 @@ function generateRandomInputFn<T extends ArgType>(
         return generateRandomInputFn(children[rn], prng)();
       };
       break;
-    case "object":
+    case ArgTag.OBJECT:
       // We generate this here using arg
       randFn = (
         prng: seedrandom.prng,
@@ -149,8 +150,8 @@ function generateRandomInputFn<T extends ArgType>(
         return outObj;
       };
       break;
-    default:
-      throw new Error(`Unsupported argument type: ${arg.getType()[0]}`);
+    case ArgTag.UNRESOLVED:
+      throw new Error(`Unsupported argument type: ${argType[0]}`);
   }
 
   // Setup environment for callback

--- a/src/fuzzer/analysis/typescript/ProgramDef.ts
+++ b/src/fuzzer/analysis/typescript/ProgramDef.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/switch-exhaustiveness-check */
 import * as JSON5 from "json5";
 import { ArgDef } from "./ArgDef";
 import { FunctionDef } from "./FunctionDef";

--- a/src/fuzzer/generators/AiInputGenerator.ts
+++ b/src/fuzzer/generators/AiInputGenerator.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/switch-exhaustiveness-check */
 import { AbstractInputGenerator } from "./AbstractInputGenerator";
 import {
   ArgTag,

--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -2793,6 +2793,8 @@ ${inArgConsts}
       );
     } else {
       typeString = htmlEscape(argType.toLowerCase());
+
+      // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
       switch (argType) {
         case fuzzer.ArgTag.OBJECT:
           typeString = "Object";
@@ -2824,6 +2826,7 @@ ${inArgConsts}
     }
 
     let sep: string;
+    // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
     switch (argType) {
       case fuzzer.ArgTag.LITERAL:
         sep = endSep;
@@ -2977,6 +2980,15 @@ ${inArgConsts}
         html += `</div>`;
         break;
       }
+
+      case fuzzer.ArgTag.LITERAL:
+        // A literal typed input has only one possible value
+        break;
+
+      case fuzzer.ArgTag.UNRESOLVED:
+        throw new Error(
+          `Cannot render an unresolved argument definition as an HTML form.`
+        );
     }
 
     // For objects & unions: output the array settings
@@ -3392,6 +3404,7 @@ function _applyArgOverrides(
     }
 
     // Min and max values
+    // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
     switch (thisArg.getType()) {
       case fuzzer.ArgTag.NUMBER:
         if (thisOverride.number) {


### PR DESCRIPTION
Enable `switch-exhaustiveness-check` so adding new enum values could be safer, e.g., I am trying to add one for #64.