### PR TITLE
feat: get structured output working with Anthropic models

### DIFF
--- a/src/fuzzer/adapters/AnthropicUtils.ts
+++ b/src/fuzzer/adapters/AnthropicUtils.ts
@@ -1,0 +1,162 @@
+import * as z from "zod/v4";
+
+// Gets a value from an object, deletes the key, and returns the value (or undefined if not found)
+const pop = <T extends Record<string, any>, K extends string>(
+  obj: T,
+  key: K
+): T[K] => {
+  const value = obj[key];
+  delete obj[key];
+  return value;
+};
+
+// Supported string formats
+const SUPPORTED_STRING_FORMATS = new Set([
+  "date-time",
+  "time",
+  "date",
+  "duration",
+  "email",
+  "hostname",
+  "uri",
+  "ipv4",
+  "ipv6",
+  "uuid",
+]);
+
+type JSONSchema = Record<string, any>;
+
+function deepClone<T>(obj: T): T {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+function transformJSONSchema(jsonSchema: JSONSchema): JSONSchema {
+  const workingCopy = deepClone(jsonSchema);
+  return _transformJSONSchema(workingCopy);
+}
+
+function _transformJSONSchema(jsonSchema: JSONSchema): JSONSchema {
+  const strictSchema: JSONSchema = {};
+
+  const ref = pop(jsonSchema, "$ref");
+  if (ref !== undefined) {
+    strictSchema["$ref"] = ref;
+    return strictSchema;
+  }
+
+  const defs = pop(jsonSchema, "$defs");
+  if (defs !== undefined) {
+    const strictDefs: Record<string, any> = {};
+    strictSchema["$defs"] = strictDefs;
+    for (const [name, defSchema] of Object.entries(defs)) {
+      strictDefs[name] = _transformJSONSchema(defSchema as JSONSchema);
+    }
+  }
+
+  const type = pop(jsonSchema, "type");
+  const anyOf = pop(jsonSchema, "anyOf");
+  const oneOf = pop(jsonSchema, "oneOf");
+  const allOf = pop(jsonSchema, "allOf");
+
+  if (Array.isArray(anyOf)) {
+    strictSchema["anyOf"] = anyOf.map((variant) =>
+      _transformJSONSchema(variant as JSONSchema)
+    );
+  } else if (Array.isArray(oneOf)) {
+    strictSchema["anyOf"] = oneOf.map((variant) =>
+      _transformJSONSchema(variant as JSONSchema)
+    );
+  } else if (Array.isArray(allOf)) {
+    strictSchema["allOf"] = allOf.map((entry) =>
+      _transformJSONSchema(entry as JSONSchema)
+    );
+  } else {
+    if (type === undefined) {
+      throw new Error(
+        "JSON schema must have a type defined if anyOf/oneOf/allOf are not used"
+      );
+    }
+    strictSchema["type"] = type;
+  }
+
+  const description = pop(jsonSchema, "description");
+  if (description !== undefined) {
+    strictSchema["description"] = description;
+  }
+
+  const title = pop(jsonSchema, "title");
+  if (title !== undefined) {
+    strictSchema["title"] = title;
+  }
+
+  if (type === "object") {
+    const properties = pop(jsonSchema, "properties") || {};
+
+    strictSchema["properties"] = Object.fromEntries(
+      Object.entries(properties).map(([key, propSchema]) => [
+        key,
+        _transformJSONSchema(propSchema as JSONSchema),
+      ])
+    );
+
+    pop(jsonSchema, "additionalProperties");
+    strictSchema["additionalProperties"] = false;
+
+    const required = pop(jsonSchema, "required");
+    if (required !== undefined) {
+      strictSchema["required"] = required;
+    }
+  } else if (type === "string") {
+    const format = pop(jsonSchema, "format");
+    if (format !== undefined && SUPPORTED_STRING_FORMATS.has(format)) {
+      strictSchema["format"] = format;
+    } else if (format !== undefined) {
+      jsonSchema["format"] = format;
+    }
+  } else if (type === "array") {
+    const items = pop(jsonSchema, "items");
+    if (items !== undefined) {
+      strictSchema["items"] = _transformJSONSchema(items as JSONSchema);
+    }
+
+    const minItems = pop(jsonSchema, "minItems");
+    if (minItems !== undefined && (minItems === 0 || minItems === 1)) {
+      strictSchema["minItems"] = minItems;
+    } else if (minItems !== undefined) {
+      jsonSchema["minItems"] = minItems;
+    }
+  }
+
+  if (Object.keys(jsonSchema).length > 0) {
+    const existingDescription = strictSchema["description"];
+    strictSchema["description"] =
+      (existingDescription ? existingDescription + "\n\n" : "") +
+      "{" +
+      Object.entries(jsonSchema)
+        .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
+        .join(", ") +
+      "}";
+  }
+
+  return strictSchema;
+}
+
+/**
+ * Creates a JSON schema output format object for Anthropic models from the given Zod schema.
+ *
+ * Adapted from https://github.com/anthropics/anthropic-sdk-typescript/blob/main/src/helpers/zod.ts.
+ */
+export function zodOutputFormat<ZodInput extends z.ZodType>(
+  zodObject: ZodInput
+) {
+  let jsonSchema: JSONSchema = z.toJSONSchema(zodObject, { reused: "ref" });
+
+  jsonSchema = transformJSONSchema(jsonSchema);
+
+  return {
+    type: "json_schema",
+    schema: {
+      ...jsonSchema,
+    },
+  };
+}

--- a/src/fuzzer/adapters/LlmAdapter.ts
+++ b/src/fuzzer/adapters/LlmAdapter.ts
@@ -182,16 +182,14 @@ export class LlmAdapter {
         text: e,
       });
     });
+
+    const provider = LlmAdapter._getConfig().provider;
     vscode.commands.executeCommand(
       telemetry.commands.logTelemetry.name,
       new telemetry.LoggerEntry(
         "LlmAdapter.query.send",
         "Sending query to LLM (v=%s;m=%s). Query: %s.",
-        [
-          LlmAdapter._getConfig().provider,
-          LlmAdapter._getConfig().modelName,
-          prompt.join("\n"),
-        ]
+        [provider, LlmAdapter._getConfig().modelName, prompt.join("\n")]
       )
     );
 
@@ -201,12 +199,16 @@ export class LlmAdapter {
       responseFormat: { type: "json_object" },
     });
 
-    if (schema) {
-      chat = chat.withParams({
-        output_config: {
-          format: zodOutputFormat(schema),
-        },
-      });
+    // Provider specific settings
+    if (provider === "anthropic") {
+      if (schema) {
+        // Anthropic doesn't always respect responseFormat
+        chat = chat.withParams({
+          output_config: {
+            format: zodOutputFormat(schema),
+          },
+        });
+      }
     }
 
     const response = await chat.ask(promptParts);

--- a/src/fuzzer/adapters/LlmAdapter.ts
+++ b/src/fuzzer/adapters/LlmAdapter.ts
@@ -5,6 +5,8 @@ import { FunctionDef } from "../analysis/typescript/FunctionDef";
 import * as nodellm from "@node-llm/core";
 import { isError } from "../Util";
 import * as telemetry from "../../telemetry/Telemetry";
+import * as zod from "zod";
+import { zodOutputFormat } from "./AnthropicUtils";
 
 /**
  * An adapter for chatting with an LLM about the program under test
@@ -74,7 +76,7 @@ export class LlmAdapter {
    */
   public async genInputs(
     fn: FunctionDef,
-    schema?: [Parameters<typeof this._chat.withSchema>[0], string[]]
+    schema?: [zod.ZodObject, string[]]
   ): Promise<{
     programInputs: { [k: string]: ArgValueType }[];
     stats?: Awaited<ReturnType<LlmAdapter["_query"]>>["stats"];
@@ -161,7 +163,7 @@ export class LlmAdapter {
    */
   private async _query(
     prompt: string[],
-    schema?: Parameters<typeof this._chat.withSchema>[0]
+    schema?: zod.ZodObject
   ): Promise<{
     response: string;
     stats: {
@@ -193,11 +195,21 @@ export class LlmAdapter {
       )
     );
 
-    const response = await (schema ? this._chat.withSchema(schema) : this._chat)
-      .withRequestOptions({
-        responseFormat: { type: "json_object" },
-      })
-      .ask(promptParts);
+    let chat = (
+      schema ? this._chat.withSchema(schema.toJSONSchema()) : this._chat
+    ).withRequestOptions({
+      responseFormat: { type: "json_object" },
+    });
+
+    if (schema) {
+      chat = chat.withParams({
+        output_config: {
+          format: zodOutputFormat(schema),
+        },
+      });
+    }
+
+    const response = await chat.ask(promptParts);
 
     vscode.commands.executeCommand(
       telemetry.commands.logTelemetry.name,

--- a/src/fuzzer/generators/AiInputGenerator.ts
+++ b/src/fuzzer/generators/AiInputGenerator.ts
@@ -228,10 +228,7 @@ export class AiInputGenerator extends AbstractInputGenerator {
    *
    * @returns JSON schema
    */
-  protected _getInputsSchema(): [
-    ReturnType<zod.ZodType["toJSONSchema"]>,
-    string[],
-  ] {
+  protected _getInputsSchema(): [zod.ZodObject, string[]] {
     const zodObj: { [k: string]: zod.ZodType } = {};
     const directives: string[] = [];
     this._specs.forEach((arg) => {
@@ -254,9 +251,7 @@ export class AiInputGenerator extends AbstractInputGenerator {
       `${NANOFUZZ_FALSE} is a placeholder for the actual value \`false\``
     );
     return [
-      zod
-        .strictObject({ programInputs: zod.array(zod.strictObject(zodObj)) })
-        .toJSONSchema(),
+      zod.strictObject({ programInputs: zod.array(zod.strictObject(zodObj)) }),
       directives,
     ];
   } // fn: _getInputsSchema


### PR DESCRIPTION
As mentioned [before](https://github.com/nanofuzz/nanofuzz/issues/366#issuecomment-4756080738) `node-llm` doesn't really support structured output for Anthropic - this adapts a bunch of stuff from the Anthropic SDK and pass the config as an extra param, and as a result structured output seems to be working.

Before the fix the response frequently contains formatting directives like "```json", and after the fix this has stopped happening.