### PR TITLE
fix: add brackets to tuple ui

### DIFF
--- a/src/ui/FuzzPanel.ts
+++ b/src/ui/FuzzPanel.ts
@@ -2837,6 +2837,9 @@ ${inArgConsts}
       case fuzzer.ArgTag.OBJECT:
         sep = ` = {` + htmlEllipsis;
         break;
+      case fuzzer.ArgTag.TUPLE:
+        sep = ` = [` + htmlEllipsis;
+        break;
       default:
         sep = " = " + htmlEllipsis;
     }
@@ -2998,7 +3001,7 @@ ${inArgConsts}
               (html += this._argDefToHtmlForm(
                 child,
                 counter,
-                ", ",
+                "",
                 "",
                 arg.getType()
               ))
@@ -3020,8 +3023,8 @@ ${inArgConsts}
 
     html += `</div>`;
     // For objects: output the end of object character ("}") here
-    if (argType === fuzzer.ArgTag.OBJECT) {
-      html += /*html*/ `<div class="argDef-preClose"></div><div class="argDef-close">}${endSep}</div>`;
+    if (argType === fuzzer.ArgTag.OBJECT || argType === fuzzer.ArgTag.TUPLE) {
+      html += /*html*/ `<div class="argDef-preClose"></div><div class="argDef-close">${argType === fuzzer.ArgTag.OBJECT ? "}" : "]"}${endSep}</div>`;
     }
     html += `</div>`;
 


### PR DESCRIPTION
Minor change to the new tuple UI so that tuple inputs are surrounded by brackets similar to how objects are currently surrounded by curly braces.

<img width="590" height="650" alt="image" src="https://github.com/user-attachments/assets/b3d5429a-911b-47b8-a97c-d4c91cfd73e1" />
