### PR TITLE
fix: 372 ai input generator stack dump

### DIFF
--- a/src/fuzzer/generators/AiInputGenerator.ts
+++ b/src/fuzzer/generators/AiInputGenerator.ts
@@ -277,11 +277,8 @@ export class AiInputGenerator extends AbstractInputGenerator {
     path: string,
     directives: string[]
   ): zod.ZodType {
-    // !!! do we handle optionality or dimensions in all cases here?
     const argIntervals = inArg.getIntervals();
-    const argChildren = inArg
-      .getChildren()
-      .filter((child) => !child.isNoInput());
+    const argChildren = inArg.getChildren();
     const argOptions = inArg.getOptions();
 
     // Helper function that creates a Zod schema from an ArgDef


### PR DESCRIPTION
Fixes #372 where the AI input generator could stack dump with an error inside Zod, which would crash when `NoInput` flags resulted in, e.g., a single-element union. 