### PR TITLE
fix: ignore unsupported types while processing imports

### DIFF
--- a/src/fuzzer/analysis/typescript/TypescriptProgram.test.ts
+++ b/src/fuzzer/analysis/typescript/TypescriptProgram.test.ts
@@ -96,4 +96,25 @@ describe("fuzzer/analysis/typescript/ProgramDef:", () => {
       exportedFunctions["test2b"].getArgDefs().map((a) => a.getTypeAnnotation())
     ).toEqual(["{ b: number | string }"]);
   });
+
+  it("Issue 387: unsupport types do not affect other types", () => {
+    const exportedTypes = TypescriptProgram.fromSource(
+      () => 'export type a = "a";export type b = bigint;'
+    ).getExportedTypes();
+    expect(exportedTypes["a"]).toEqual({
+      isExported: true,
+      optional: false,
+      dims: 0,
+      module: "",
+      name: "a",
+      type: {
+        dims: 0,
+        type: ArgTag.LITERAL,
+        children: [],
+        value: "a",
+        resolved: true,
+      },
+    });
+    expect(exportedTypes).not.toContain("b");
+  });
 });

--- a/src/fuzzer/analysis/typescript/TypescriptProgram.ts
+++ b/src/fuzzer/analysis/typescript/TypescriptProgram.ts
@@ -689,10 +689,18 @@ export class TypescriptProgram {
                 `Duplicate type alias '${path.node.id.name}' found in module '${module}'`
               );
             } else {
-              types[path.node.id.name] = this._getTypeRefFromAstNode(
-                path.node,
-                path.parent
-              );
+              const name = path.node.id.name;
+              try {
+                types[name] = this._getTypeRefFromAstNode(
+                  path.node,
+                  path.parent
+                );
+              } catch (e) {
+                console.debug(
+                  `Error getting TypeRef from the AST node for ${name} in module ${this._module}, ignoring.
+                   Reason: ${e}`
+                );
+              }
             }
           }
         }


### PR DESCRIPTION
For #387.

This simply ignores any unsupported types while processing imports.

It doesn't set up tracking similar to `_unsupportedFunctions` but since that field seems unused I'm not sure if it is actually worth it?