### PR TITLE
chore: bump `checkout` and `setup-node` actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
     steps:
       # Visual Studio Code Extension
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+        uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: yarn


### PR DESCRIPTION
Bump `checkout` and `setup-node` actions to v7