### PR TITLE
fix: `tree-sitter` on codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,9 @@
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
   "image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
 
+  // Install build tools for native addons (e.g., node-gyp)
+  "updateContentCommand": "sudo apt-get update && sudo apt-get install -y build-essential python3",
+
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
     "ghcr.io/devcontainers/features/node:1": {


### PR DESCRIPTION
Fix `tree-sitter` on Codespaces by adapting the dev container to include the necessary build tools