### PR TITLE
fix: python prop validator auto-import Literal

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,7 @@
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
   "js/ts.tsc.autoDetect": "off",
   "js/ts.tsdk.path": "./node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "editor.formatOnSave": true,
   "jasmineExplorer.nodeArgv": ["--no-experimental-strip-types"],
   "eslint.validate": ["javascript", "typescript"],

--- a/build.mjs
+++ b/build.mjs
@@ -36,7 +36,6 @@ if (!fs.existsSync(path.resolve(path.join(".", ".venv")))) {
 }
 [{ name: "json5" }].forEach((pkg) => {
   const libdir = findInDescendants("./.venv", pkg.name);
-  console.debug(libdir);
   if (libdir === undefined) {
     throw new Error(
       `Could not find Python package ${pkg.name}. Is it installed in the python virtual environment? (see ./CONTRIBUTING.md)`
@@ -47,6 +46,18 @@ if (!fs.existsSync(path.resolve(path.join(".", ".venv")))) {
   });
   rimraf.sync(`./build/extension/${pkg.name}/__pycache__`);
   console.log(`copied .py ${pkg.name}`);
+});
+
+// Copy wasm imports (web-tree-sitter)
+[
+  "./node_modules/web-tree-sitter/web-tree-sitter.wasm",
+  "./node_modules/tree-sitter-python/tree-sitter-python.wasm",
+  "./node_modules/tree-sitter-typescript/tree-sitter-typescript.wasm",
+  "./node_modules/tree-sitter-javascript/tree-sitter-javascript.wasm",
+].forEach((wasmFile) => {
+  copyfiles([wasmFile, "./build/ui"], true, () =>
+    console.log(`copied ${path.basename(wasmFile)}`)
+  );
 });
 
 // VSCode Web Extension Back-end
@@ -68,7 +79,10 @@ await esbuild.build({
     "typescript",
     "tree-sitter",
     "tree-sitter-python",
+    "tree-sitter-typescript",
+    "tree-sitter-javascript",
   ],
+  define: { "process.env.TARGET_WEB": "false" },
 });
 
 // VSCode Web Extension Front-end UI
@@ -80,9 +94,10 @@ await esbuild.build({
   platform: "browser",
   outfile: "./build/ui/FuzzPanelView.js",
   minify: true,
-  format: "iife", // IIFE format is suitable for browser-based UI
+  format: "esm", // for web-tree-sitter (was iife)
   sourcemap: "both",
-  external: [],
+  external: ["module", "fs/promises", "path"],
+  define: { "process.env.TARGET_WEB": "true" },
 });
 
 // CompilerWorker
@@ -97,6 +112,7 @@ await esbuild.build({
   sourcemap: "both",
   tsconfig: "./tsconfig.json",
   external: ["path", "fs", "typescript"],
+  define: { "process.env.TARGET_WEB": "false" },
 });
 
 /**

--- a/build.mjs
+++ b/build.mjs
@@ -51,7 +51,7 @@ if (!fs.existsSync(path.resolve(path.join(".", ".venv")))) {
 
 // VSCode Web Extension Back-end
 await esbuild.build({
-  entryPoints: ["./src/extension.ts"],
+  entryPoints: ["./src/Extension.ts"],
   outfile: "./build/extension/extension.js",
   bundle: true,
   platform: "node",

--- a/package.json
+++ b/package.json
@@ -296,6 +296,7 @@
     "seedrandom": "^3.0.5",
     "tree-sitter": "^0.25.0",
     "tree-sitter-python": "^0.25.0",
+    "tree-sitter-typescript": "^0.23.2",
     "typescript": "5.9.2",
     "zod": "^4.3.6"
   },

--- a/package.json
+++ b/package.json
@@ -298,6 +298,7 @@
     "tree-sitter-python": "^0.25.0",
     "tree-sitter-typescript": "^0.23.2",
     "typescript": "5.9.2",
+    "web-tree-sitter": "^0.26.11",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/Extension.ts
+++ b/src/Extension.ts
@@ -1,0 +1,84 @@
+import * as vscode from "vscode";
+import * as fp from "./ui/FuzzPanelController";
+import * as tm from "./telemetry/Telemetry";
+
+const disposables: vscode.Disposable[] = []; // Keep track of disposables
+
+/**
+ * Called by VS Code to activates the extension.
+ *
+ * @param context extension context provided by the VS Code extension host
+ */
+export function activate(context: vscode.ExtensionContext): void {
+  tm.init(context);
+  fp.init(context);
+
+  // --------------------------- Commands --------------------------- //
+
+  /**
+   * Push the commands to the VS Code command palette.
+   */
+  for (const cmd of Object.values({ ...fp.commands, ...tm.commands })) {
+    const reg = vscode.commands.registerCommand(cmd.name, cmd.fn);
+    context.subscriptions.push(reg);
+    disposables.push(reg);
+  }
+
+  // ---------------------------- Panels ---------------------------- //
+
+  /**
+   * Register a FuzzPanelSerializer so the FuzzPanel window persists
+   * across VS Code sessions.
+   */
+  vscode.window.registerWebviewPanelSerializer(fp.FuzzPanel.viewType, {
+    async deserializeWebviewPanel(
+      webviewPanel: vscode.WebviewPanel,
+      state: fp.FuzzPanelStateSerialized
+    ): Promise<void> {
+      // Restore content of the webview.
+      fp.FuzzPanel.revive(webviewPanel, context.extensionUri, state);
+    },
+  });
+
+  // --------------------------- CodeLens --------------------------- //
+
+  /**
+   * Push our CodeLens provider to the VS Code editor
+   */
+  fp.languages.forEach((lang) => {
+    const lens = vscode.languages.registerCodeLensProvider(lang, {
+      provideCodeLenses: fp.provideCodeLenses,
+    });
+    context.subscriptions.push(lens);
+    disposables.push(lens);
+  }); // push CodeLens provider
+
+  // --------------------------- Listeners -------------------------- //
+
+  /**
+   * Push event listeners to VS Code
+   */
+  tm.listeners.forEach((listener) => {
+    context.subscriptions.push(listener.event(listener.fn));
+  });
+  fp.listeners.forEach((listener) => {
+    context.subscriptions.push(listener.event(listener.fn));
+  });
+} // fn: activate()
+
+/**
+ * De-activaton logic for the extension
+ */
+export function deactivate(): void {
+  disposables.forEach((e) => e.dispose());
+  fp.deinit();
+  tm.deinit();
+} // fn: deactivate()
+
+/**
+ * Associates a callback function with an vscode event.
+ */
+export type Listener<T> = {
+  event: vscode.Event<T>;
+  fn: (e: T) => void;
+};

--- a/src/Jsonn.test.ts
+++ b/src/Jsonn.test.ts
@@ -5,6 +5,7 @@ describe("JSONN: ", () => {
   it("round-trip values", () => {
     [
       null,
+      NaN,
       undefined,
       true,
       false,
@@ -18,8 +19,10 @@ describe("JSONN: ", () => {
         trueValue: true,
         noValue: undefined,
         nullValue: null,
+        nanValue: NaN,
         arrayValue: [
           null,
+          NaN,
           undefined,
           true,
           false,
@@ -33,6 +36,7 @@ describe("JSONN: ", () => {
       },
       [
         null,
+        NaN,
         undefined,
         true,
         false,
@@ -42,7 +46,7 @@ describe("JSONN: ", () => {
         "hello",
         true,
         false,
-        { trueValue: true, noValue: undefined, nullValue: null },
+        { trueValue: true, noValue: undefined, nanValue: NaN, nullValue: null },
       ],
     ].forEach((value) => {
       const roundtripValue = JSONN.parse<typeof value>(JSONN.stringify(value));

--- a/src/Jsonn.test.ts
+++ b/src/Jsonn.test.ts
@@ -1,0 +1,78 @@
+import * as JSONN from "./Jsonn";
+import { isKeyedObject } from "./Util";
+
+describe("JSONN: ", () => {
+  it("round-trip values", () => {
+    [
+      null,
+      undefined,
+      true,
+      false,
+      Infinity,
+      -Infinity,
+      3,
+      "hello",
+      true,
+      false,
+      {
+        trueValue: true,
+        noValue: undefined,
+        nullValue: null,
+        arrayValue: [
+          null,
+          undefined,
+          true,
+          false,
+          Infinity,
+          -Infinity,
+          3,
+          "hello",
+          true,
+          false,
+        ],
+      },
+      [
+        null,
+        undefined,
+        true,
+        false,
+        Infinity,
+        -Infinity,
+        3,
+        "hello",
+        true,
+        false,
+        { trueValue: true, noValue: undefined, nullValue: null },
+      ],
+    ].forEach((value) => {
+      const roundtripValue = JSONN.parse<typeof value>(JSONN.stringify(value));
+      expect(roundtripValue).toEqual(value);
+
+      // Jasmine ignores keys with an unknown value, so we need an extra check here
+      // to ensure those are preserved by JSONN.
+      if (isKeyedObject(value)) {
+        let key: keyof typeof value;
+        for (key in value) {
+          if (value[key] === undefined && isKeyedObject(roundtripValue)) {
+            expect(key in roundtripValue).toBeTrue();
+            expect(roundtripValue[key]).toBeUndefined();
+          }
+        }
+      }
+    });
+  });
+
+  /* !!!!!!!!!!
+  it("Issue #301", () => {
+    const input = { a: undefined };
+    const serializedInput = JSONN.stringify(input);
+    const roundtripValue = JSONN.parse<object>(serializedInput);
+    expect(serializedInput).toEqual("{a: undefined}");
+    expect("a" in roundtripValue).toBeTrue();
+    expect(isKeyedObject(roundtripValue)).toBeTrue();
+    if (isKeyedObject(roundtripValue)) {
+      expect(roundtripValue["a"]).toBeUndefined();
+    }
+  });
+  */
+});

--- a/src/Jsonn.ts
+++ b/src/Jsonn.ts
@@ -59,7 +59,7 @@ export function stringify(
         },
     space
   );
-  return `${stats.replacements ? predicate : ""}${text}`;
+  return text;
 }
 
 /**
@@ -79,41 +79,37 @@ export function parse<T>(
     | undefined
 ): T {
   let result: unknown;
-  if (!text.startsWith(predicate)) {
-    result =
-      text.trim() === "undefined" ? undefined : JSON5.parse(text, reviver);
+  if (text.trim() === "undefined") {
+    result = undefined;
   } else {
-    if (text.slice(predicate.length).trim() === "undefined") {
-      result = undefined;
-    } else {
-      // Parse the data while keeping a list of any values we need to replace.
-      // We do this in two steps because JSON5 strips `undefined` AFTER revive.
-      const valuesToRevive: ReviveTarget[] = [];
-      result = JSON5.parse<T>(
-        text,
-        reviver
-          ? function (this: unknown, key: string, value: unknown): unknown {
-              return reviver.call(
-                this,
-                key,
-                jsonnReviver.call(this, key, value, valuesToRevive)
-              );
-            }
-          : function (this: unknown, key: string, value: unknown): unknown {
-              return jsonnReviver.call(this, key, value, valuesToRevive);
-            }
-      );
+    // Parse the data while keeping a list of any values we need to replace.
+    // We do this in two steps because JSON5 strips `undefined` AFTER revive.
+    const valuesToRevive: ReviveTarget[] = [];
+    result = JSON5.parse<T>(
+      text,
+      reviver
+        ? function (this: unknown, key: string, value: unknown): unknown {
+            return reviver.call(
+              this,
+              key,
+              jsonnReviver.call(this, key, value, valuesToRevive)
+            );
+          }
+        : function (this: unknown, key: string, value: unknown): unknown {
+            return jsonnReviver.call(this, key, value, valuesToRevive);
+          }
+    );
 
-      // Now replace the values we kept track of
-      valuesToRevive.forEach((t) => {
-        if ("obj" in t) {
-          t.obj[t.key] = t.value;
-        } else {
-          t.arr[Number(t.key)] = t.value;
-        }
-      });
-    }
+    // Now replace the values we kept track of
+    valuesToRevive.forEach((t) => {
+      if ("obj" in t) {
+        t.obj[t.key] = t.value;
+      } else {
+        t.arr[Number(t.key)] = t.value;
+      }
+    });
   }
+
   return result as T;
 }
 
@@ -127,9 +123,6 @@ export function getPlaceholder(_key: "undefined"): string {
   return `{${PlaceHolderKey}:'${UndefinedKey}'}`;
   //  return Undefined;
 }
-
-export const predicate = `/*JSONN:1.0.0*/`;
-//const Undefined = Symbol("____JSONN____61581952310____UNDEFINED____");
 
 /**
  * Replaces special values with a JSONN placeholder

--- a/src/Jsonn.ts
+++ b/src/Jsonn.ts
@@ -1,8 +1,6 @@
 import * as JSON5 from "json5";
 import { isKeyedObject } from "./Util";
 
-const JSONN_PREDICATE = `/*JSONN:1.0.0*/`;
-
 /**
  * JSONN: JavaScript Object Notation for NaNofuzz
  *
@@ -61,7 +59,7 @@ export function stringify(
         },
     space
   );
-  return `${stats.replacements ? JSONN_PREDICATE : ""}${text}`;
+  return `${stats.replacements ? predicate : ""}${text}`;
 }
 
 /**
@@ -81,11 +79,11 @@ export function parse<T>(
     | undefined
 ): T {
   let result: unknown;
-  if (!text.startsWith(JSONN_PREDICATE)) {
+  if (!text.startsWith(predicate)) {
     result =
       text.trim() === "undefined" ? undefined : JSON5.parse(text, reviver);
   } else {
-    if (text.slice(JSONN_PREDICATE.length).trim() === "undefined") {
+    if (text.slice(predicate.length).trim() === "undefined") {
       result = undefined;
     } else {
       // Parse the data while keeping a list of any values we need to replace.
@@ -118,6 +116,20 @@ export function parse<T>(
   }
   return result as T;
 }
+
+/**
+ * Returns the stringified placeholder for a particular special value.
+ *
+ * @param _key 'undefined'
+ * @returns stringified placeholder value
+ */
+export function getPlaceholder(_key: "undefined"): string {
+  return `{${PlaceHolderKey}:'${UndefinedKey}'}`;
+  //  return Undefined;
+}
+
+export const predicate = `/*JSONN:1.0.0*/`;
+//const Undefined = Symbol("____JSONN____61581952310____UNDEFINED____");
 
 /**
  * Replaces special values with a JSONN placeholder

--- a/src/Jsonn.ts
+++ b/src/Jsonn.ts
@@ -1,0 +1,188 @@
+import * as JSON5 from "json5";
+import { isKeyedObject } from "./Util";
+
+const JSONN_PREDICATE = `/*JSONN:1.0.0*/`;
+
+/**
+ * JSONN: JavaScript Object Notation for NaNofuzz
+ *
+ * Mostly a drop-in replacement for JSON5. Adds support for serializing
+ * and unserializing `undefined`, including in arrays and object members.
+ *
+ * While JSONN is valid JSON5 and might be parsed ok by JSON5, `undefined`
+ * values will be parsed inaccurately by the standard JSON5 library.
+ *
+ * JSONN output includes the predicate above.
+ */
+
+/**
+ * Converts a JavaScript value to a JSONN string.
+ *
+ * @param `value` The value to convert to a JSONN string.
+ * @param `replacer` A function that alters the behavior of the
+ *         stringification process. If this value is null or not
+ *         provided, all properties of the object are included in
+ *         the resulting JSONN string.
+ * @param `space` A String or Number object that's used to insert
+ *        white space into the output JSON5 string for readability
+ *        purposes. If this is a Number, it indicates the number of
+ *        space characters to use as white space; this number is
+ *        capped at 10 (if it is greater, the value is just 10).
+ *        Values less than 1 indicate that no space should be used.
+ *        If this is a String, the string (or the first 10 characters
+ *        of the string, if it's longer than that) is used as white
+ *        space. If this parameter is not provided (or is null), no
+ *        white space is used. If white space is used, trailing
+ *        commas will be used in objects and arrays.
+ * @returns The JSONN string converted from the JavaScript value.
+ */
+export function stringify(
+  value: unknown,
+  replacer?:
+    | ((this: unknown, key: string, value: unknown) => unknown)
+    | null
+    | undefined,
+  space?: string | number | null | undefined
+): string {
+  const stats: JsonnStats = { replacements: false };
+  const text = JSON5.stringify(
+    value,
+    replacer
+      ? function (this: unknown, key: string, value: unknown): unknown {
+          return jsonnReplacer.call(
+            this,
+            key,
+            replacer.call(this, key, value),
+            stats
+          );
+        }
+      : function (this: unknown, key: string, value: unknown): unknown {
+          return jsonnReplacer.call(this, key, value, stats);
+        },
+    space
+  );
+  return `${stats.replacements ? JSONN_PREDICATE : ""}${text}`;
+}
+
+/**
+ * Parses a JSONN string and constructing a JavaScript value or object
+ * described by the string.
+ *
+ * @param `text` The string to parse as JSONN
+ * @param `reviver` A function that prescribes how the value originally
+ *        produced by parsing is transformed before being returned.
+ * @returns The JavaScript value converted from the JSONN string
+ */
+export function parse<T>(
+  text: string,
+  reviver?:
+    | ((this: unknown, key: string, value: unknown) => unknown)
+    | null
+    | undefined
+): T {
+  let result: unknown;
+  if (!text.startsWith(JSONN_PREDICATE)) {
+    result =
+      text.trim() === "undefined" ? undefined : JSON5.parse(text, reviver);
+  } else {
+    if (text.slice(JSONN_PREDICATE.length).trim() === "undefined") {
+      result = undefined;
+    } else {
+      // Parse the data while keeping a list of any values we need to replace.
+      // We do this in two steps because JSON5 strips `undefined` AFTER revive.
+      const valuesToRevive: ReviveTarget[] = [];
+      result = JSON5.parse<T>(
+        text,
+        reviver
+          ? function (this: unknown, key: string, value: unknown): unknown {
+              return reviver.call(
+                this,
+                key,
+                jsonnReviver.call(this, key, value, valuesToRevive)
+              );
+            }
+          : function (this: unknown, key: string, value: unknown): unknown {
+              return jsonnReviver.call(this, key, value, valuesToRevive);
+            }
+      );
+
+      // Now replace the values we kept track of
+      valuesToRevive.forEach((t) => {
+        if ("obj" in t) {
+          t.obj[t.key] = t.value;
+        } else {
+          t.arr[Number(t.key)] = t.value;
+        }
+      });
+    }
+  }
+  return result as T;
+}
+
+/**
+ * Replaces special values with a JSONN placeholder
+ *
+ * @param `this` current object
+ * @param `key` key into object
+ * @param `value` value at object key
+ * @returns the replacement value
+ */
+function jsonnReplacer(
+  this: unknown,
+  key: string,
+  value: unknown,
+  stats: JsonnStats
+): unknown {
+  if (value === undefined) {
+    stats.replacements = true;
+    return {
+      [PlaceHolderKey]: UndefinedKey,
+    };
+  }
+  return value;
+}
+
+/**
+ * Makes a list of object keys that need values rerplaced.
+ * This second pass is required because JSON5 strips undefined
+ * values after the revive process.
+ *
+ * @param `this` current object
+ * @param `key` key into object
+ * @param `value` value at object key
+ * @param `targets` array of objects and keys to replace with values
+ * @returns the replacement value (but usually the input value)
+ */
+function jsonnReviver(
+  this: unknown,
+  key: string,
+  value: unknown,
+  targets: ReviveTarget[]
+): unknown {
+  if (
+    isKeyedObject(value) &&
+    PlaceHolderKey in value &&
+    value[PlaceHolderKey] === UndefinedKey
+  ) {
+    if (key === "") {
+      return undefined;
+    } else {
+      if (Array.isArray(this)) {
+        targets.push({ arr: this, key, value: undefined });
+      } else if (isKeyedObject(this)) {
+        targets.push({ obj: this, key, value: undefined });
+      }
+    }
+  }
+  return value;
+}
+
+type ReviveTarget = {
+  key: string;
+  value: unknown;
+} & ({ obj: Record<string, unknown> } | { arr: unknown[] });
+
+type JsonnStats = { replacements: boolean };
+
+const PlaceHolderKey = "____JSONN____61581952310____VALUE____";
+const UndefinedKey = "__undefined__";

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -1,0 +1,14 @@
+/**
+ * Type guard function that returns true if `obj` has keys
+ *
+ * @param `obj` the object to check
+ * @returns true if `obj` has keys, false otherwise
+ */
+export function isKeyedObject(obj: unknown): obj is Record<string, unknown> {
+  return (
+    obj !== null &&
+    typeof obj === "object" &&
+    !Array.isArray(obj) &&
+    Object.keys(obj).length > 0
+  );
+} // fn: isKeyedObject

--- a/src/fuzzer/Fuzzer.test.ts
+++ b/src/fuzzer/Fuzzer.test.ts
@@ -2,6 +2,7 @@ import { ArgDef, Tester } from "./Fuzzer";
 import { TypescriptCompiler } from "./compilers/TypescriptCompiler";
 import { FuzzOptions } from "./Types";
 import * as JSON5 from "json5";
+import * as ValueMapper from "./mappers/ValueMapper";
 import { ArgDefValidator } from "./analysis/ArgDefValidator";
 
 // Extend default test timeout to 60s
@@ -658,5 +659,57 @@ describe("fuzzer:", () => {
         intOptions
       ).testSync();
     }).toThrowError();
+  });
+
+  it("Issue #301 (Python) include object members if value is `None`", async () => {
+    const fuzzResult = await new Tester(
+      "./test_fixtures/Fuzzer.testfixtures.py",
+      "issue301",
+      intOptions
+    ).testSync();
+
+    const failures = fuzzResult.results.filter(
+      (r) => r.passedImplicit === "fail"
+    );
+
+    expect(fuzzResult.results.length).toBeGreaterThan(1);
+    expect(failures.length).toEqual(1);
+    expect(ValueMapper.toLang("python", failures[0].input[0].value)).toEqual(
+      "6"
+    );
+    expect(
+      typeof failures[0].output[0].value === "object" &&
+        "a" in failures[0].output[0].value &&
+        failures[0].output[0].value["a"] === null
+    ).toBeTrue();
+    expect(ValueMapper.toLang("python", failures[0].output[0].value)).toEqual(
+      `{"a": None}`
+    );
+  });
+
+  it("Issue #301 (Typescript) include object members if value is `undefined`", async () => {
+    const fuzzResult = await new Tester(
+      "./test_fixtures/Fuzzer.testfixtures.ts",
+      "issue301",
+      intOptions
+    ).testSync();
+
+    const failures = fuzzResult.results.filter(
+      (r) => r.passedImplicit === "fail"
+    );
+
+    expect(fuzzResult.results.length).toBeGreaterThan(1);
+    expect(failures.length).toEqual(1);
+    expect(
+      ValueMapper.toLang("typescript", failures[0].input[0].value)
+    ).toEqual("6");
+    expect(
+      typeof failures[0].output[0].value === "object" &&
+        "a" in failures[0].output[0].value &&
+        failures[0].output[0].value["a"] === undefined
+    ).toBeTrue();
+    expect(
+      ValueMapper.toLang("typescript", failures[0].output[0].value)
+    ).toEqual(`{a: undefined}`);
   });
 });

--- a/src/fuzzer/Fuzzer.test.ts
+++ b/src/fuzzer/Fuzzer.test.ts
@@ -1,7 +1,6 @@
 import { ArgDef, Tester } from "./Fuzzer";
 import { TypescriptCompiler } from "./compilers/TypescriptCompiler";
 import { FuzzOptions } from "./Types";
-import * as JSON5 from "json5";
 import * as ValueMapper from "./mappers/ValueMapper";
 import { ArgDefValidator } from "./analysis/ArgDefValidator";
 
@@ -353,13 +352,13 @@ describe("fuzzer:", () => {
       ).toBeTrue();
       expect(input.length).toBe(2);
       expect(
-        ["[]", "[[]]", "[[[]]]", "[[['hello']]]"].includes(
-          JSON5.stringify(input[0])
+        ["[]", "[[]]", "[[[]]]", `[[["hello"]]]`].includes(
+          ValueMapper.toLang("typescript", input[0])
         )
       ).toBeTrue();
       expect(
-        ["[]", "[[]]", "[[[]]]", "[[['goodbye']]]"].includes(
-          JSON5.stringify(input[1])
+        ["[]", "[[]]", "[[[]]]", `[[["goodbye"]]]`].includes(
+          ValueMapper.toLang("typescript", input[1])
         )
       ).toBeTrue();
     });
@@ -546,13 +545,8 @@ describe("fuzzer:", () => {
       fuzzResult.results.every((e) => e.passedImplicit === "pass")
     ).toBeTruthy();
 
-    // Run the following tests on the raw and JSON5-cloned results
-    [
-      fuzzResult.results,
-      JSON5.parse<typeof fuzzResult.results>(
-        JSON5.stringify(fuzzResult.results)
-      ),
-    ].forEach((r) => {
+    // Run the following tests on the raw and cloned results
+    [fuzzResult.results, structuredClone(fuzzResult.results)].forEach((r) => {
       // Every input should be true, false, or undefined
       expect(
         r.every(

--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -1,11 +1,12 @@
 import * as fs from "fs";
-import * as JSON5 from "json5";
+import * as JSONN from "../Jsonn";
 import { ArgDef } from "./analysis/ArgDef";
 import { ArgValueType, FunctionRef } from "./analysis/Types";
 import { CompositeInputGenerator } from "./generators/CompositeInputGenerator";
 import * as compiler from "./compilers/TypescriptCompiler";
 import * as CompilerFactory from "./compilers/CompilerFactory";
 import * as ProgramFactory from "./analysis/ProgramFactory";
+import * as ValueMapper from "./mappers/ValueMapper";
 import { FunctionDef } from "./analysis/FunctionDef";
 import {
   FuzzIoElement,
@@ -87,10 +88,10 @@ export class Tester {
     // Options
     if (!isOptionValid(options)) {
       throw new Error(
-        `Invalid options provided: ${JSON5.stringify(options, null, 2)}`
+        `Invalid options provided: ${JSONN.stringify(options, null, 2)}`
       );
     }
-    this._options = JSON5.parse<typeof options>(JSON5.stringify(options));
+    this._options = structuredClone(options);
 
     // Get the active measures, which will take various measurements
     // during execution that guide the composite generator
@@ -154,8 +155,8 @@ export class Tester {
 
     // Stale: options are stale
     if (
-      JSON5.stringify(retestRelevantOptions(options)) !==
-      JSON5.stringify(retestRelevantOptions(this._options))
+      JSONN.stringify(retestRelevantOptions(options)) !==
+      JSONN.stringify(retestRelevantOptions(this._options))
     ) {
       return "optionschanged";
     }
@@ -177,13 +178,9 @@ export class Tester {
   protected _getInitializedResults(): FuzzTestResults {
     return {
       env: {
-        options: JSON5.parse<typeof this._options>(
-          JSON5.stringify(this._options)
-        ),
+        options: structuredClone(this._options),
         function: this._function,
-        validators: JSON5.parse<typeof this._validators>(
-          JSON5.stringify(this._validators)
-        ),
+        validators: structuredClone(this._validators),
       },
       stopReason: FuzzStopReason.CRASH, // updated later
       stats: {
@@ -256,16 +253,15 @@ export class Tester {
     // Ensure we have a valid set of Fuzz options
     if (!isOptionValid(options)) {
       throw new Error(
-        `Invalid options provided: ${JSON5.stringify(options, null, 2)}`
+        `Invalid options provided: ${JSONN.stringify(options, null, 2)}`
       );
     }
 
     // If we already have an option set and it differs
     // from the new one, use the new options.
-    const strOptions = JSON5.stringify(options);
-    if (JSON5.stringify(this._options) !== strOptions) {
-      this._options = JSON5.parse<typeof options>(strOptions);
-      this._results.env.options = JSON5.parse<typeof options>(strOptions);
+    if (JSONN.stringify(this._options) !== JSONN.stringify(options)) {
+      this._options = structuredClone(options);
+      this._results.env.options = structuredClone(options);
       this._compositeInputGenerator.options = this._options.generators;
     }
   } // property: set options
@@ -276,13 +272,9 @@ export class Tester {
    */
   public get env(): FuzzEnv {
     return {
-      options: JSON5.parse<typeof this._options>(
-        JSON5.stringify(this._options)
-      ),
+      options: structuredClone(this._options),
       function: this._function,
-      validators: JSON5.parse<typeof this._validators>(
-        JSON5.stringify(this._validators)
-      ),
+      validators: structuredClone(this._validators),
     };
   } // property: get env
 
@@ -369,7 +361,7 @@ export class Tester {
         callbackFn(
           isError(e)
             ? e
-            : { name: "unknown error", message: JSON5.stringify(e) }
+            : { name: "unknown error", message: JSONN.stringify(e) }
         );
         return;
       }
@@ -440,6 +432,7 @@ export class Tester {
     });
 
     const argDefs = this._function.getArgDefs();
+    const lang = this._function.getLang();
 
     // Inject pinned tests into the composite generator so that they generate
     // first: we want the composite generator to know about these inputs so that
@@ -596,7 +589,7 @@ export class Tester {
         if (this._options.outputFile) {
           fs.writeFileSync(
             this._options.outputFile,
-            JSON5.stringify(this._results)
+            JSONN.stringify(this._results)
           );
           update({
             msg: `Wrote results to: ${this._options.outputFile}`,
@@ -654,14 +647,14 @@ export class Tester {
       // we need to retain any saved details for injected tests.
       if (genInput.injected) {
         // Ensure the injected inputs are in the expected order
-        const expectedInput = JSON5.stringify(
+        const expectedInput = JSONN.stringify(
           injectTests[runStats.counters.inputsInjected].input
         );
-        const returnedInput = JSON5.stringify(result.input);
+        const returnedInput = JSONN.stringify(result.input);
         if (expectedInput !== returnedInput) {
           throw new Error(
             `Injected inputs in unexpected order at injected input# ${runStats.counters.inputsInjected}. Expected: "${expectedInput}". Got: "${returnedInput}".` +
-              JSON5.stringify(injectTests, null, 3)
+              JSONN.stringify(injectTests, null, 3)
           );
         }
 
@@ -731,7 +724,7 @@ export class Tester {
         msg: `${cancelFn && cancelFn() && stillInjecting ? "Pause pending retest of prior inputs.\r\n" : ""}${stillInjecting ? "Retesting prior" : "Generating new test"} input# ${
           runStats.counters.passedTests + runStats.counters.failedTests + 1
         }: ${this._function.getName()}(${result.input
-          .map((i) => JSON5.stringify(i.value))
+          .map((i) => ValueMapper.toLang(lang, i.value))
           .join(",")})\r\n  Tests passed: ${
           runStats.counters.passedTests
         }\r\n  Tests failed: ${runStats.counters.failedTests}`,
@@ -876,10 +869,7 @@ export class Tester {
       {
         const startMeasureTime = performance.now(); // start timer
         const measurements = this._measures.map((e) =>
-          e.measure(
-            JSON5.parse<typeof genInput>(JSON5.stringify(genInput)),
-            JSON5.parse<typeof result>(JSON5.stringify(result))
-          )
+          e.measure(structuredClone(genInput), structuredClone(result))
         );
 
         // Provide measures feedback to the composite input generator
@@ -1082,7 +1072,7 @@ export function categorizeResult(result: FuzzTestResult): FuzzResultCategory {
  * @returns string representation of input key
  */
 export function getIoKey(io: FuzzIoElement[]): string {
-  return JSON5.stringify(
+  return JSONN.stringify(
     io.map((input) => {
       return { value: input.value };
     })

--- a/src/fuzzer/adapters/LlmAdapter.ts
+++ b/src/fuzzer/adapters/LlmAdapter.ts
@@ -304,7 +304,7 @@ const prompt = {
     return `You are an experienced software engineer who writes efficient tests that thoroughly evaluate the correctness of programs. You are aware of the important differences between a programming language's various equality operators.`;
   },
   genInputs: (vars: ReturnType<LlmAdapter["_getPromptVars"]>): string => {
-    return `To evaluate whether the following  ${vars.lang} program "${vars.fnName}" behaves correctly relative to its specification, generate 25 program inputs that are important to determine whether the program satisfies its specification. Each program input includes all the arguments needed to call the program.
+    return `To evaluate whether the following ${vars.lang} program "${vars.fnName}" behaves correctly relative to its specification, generate 25 program inputs that are important to determine whether the program satisfies its specification. Each program input includes all the arguments needed to call the program.
 
 The specification for the "${vars.fnName}" program:
 \`\`\`

--- a/src/fuzzer/adapters/ParserAdapter.ts
+++ b/src/fuzzer/adapters/ParserAdapter.ts
@@ -1,0 +1,248 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+import * as TSWeb from "web-tree-sitter";
+import { ProgramLanguage } from "../Fuzzer";
+
+/**
+ * This module provide a more consistent interface for consumers of
+ * `tree-sitter` regardless of whether they are running in a webview
+ * (`web-tree-sitter`) or as node modules (`tree-sitter`).
+ *
+ * This is necessary because, e.g., `ValueMapper` uses `tree-sitter`
+ * and runs in electron, node, and webviews. Performance of
+ * `tree-sitter` is better than `web-tree-sitter`, but we can't
+ * use its native bindings from the Webview... hence, we need
+ * `web-tree-sitter` for the webviews.
+ *
+ * Note: if bundled, `web-tree-sitter` must be bundled as an esm
+ * module; otherwise, it won't resolve its `web-tree-sitter.wasm`.
+ */
+
+// internal variables
+const parsers: Record<string, Parser> = {};
+const grammars = ["tree-sitter-typescript", "tree-sitter-python"];
+let loaded: "no" | "pending" | "yes" = "no";
+
+// if this is node, auto-init the parsers
+if (!process.env.TARGET_WEB) {
+  initNode();
+} else {
+  initWeb(); // start the init process
+}
+
+/**
+ * Init for node tree-sitter
+ */
+export function initNode(): void {
+  if (loaded === "yes") {
+    return;
+  }
+  if (process.env.TARGET_WEB) {
+    throw new Error(`initNode is not for webviews`);
+  } else {
+    loaded = "pending";
+    const TSNode = require("tree-sitter");
+    grammars.forEach(async (g) => {
+      const parser = new TSNode();
+      parser.setLanguage(
+        g === `tree-sitter-typescript` ? require(g).typescript : require(g)
+      );
+      parsers[g] = parser;
+    });
+    loaded = "yes";
+  }
+}
+
+let initPromise: Promise<void> | undefined;
+
+/**
+ * Init for web-tree-sitter
+ */
+export async function initWeb(): Promise<void> {
+  if (loaded === "yes") {
+    return;
+  }
+  if (!process.env.TARGET_WEB) {
+    throw new Error(`initWeb is only for webviews`);
+  }
+  if (loaded === "pending" && initPromise) {
+    return initPromise;
+  }
+
+  initPromise = new Promise<void>((resolve, reject) => {
+    loaded = "pending";
+    let urlDir: string;
+    TSWeb.Parser.init({
+      locateFile(name: string, dir: string) {
+        urlDir = dir;
+        return `${dir}/${name}`;
+      },
+    }).then(
+      async (_fulfilled) => {
+        for (const g of grammars) {
+          const url = `${urlDir}/${g}.wasm`;
+          const grammar = await TSWeb.Language.load(url);
+          const parser = new TSWeb.Parser();
+          parser.setLanguage(grammar);
+          parsers[g] = parser;
+        }
+        loaded = "yes";
+        resolve();
+      },
+      (rejectReason) => {
+        reject(rejectReason);
+      }
+    );
+  });
+
+  return initPromise;
+}
+
+/**
+ * Parse text
+ *
+ * @param `lang` language to parse
+ * @param `text` text to parse
+ * @returns parse tree
+ */
+export function parse(
+  lang: Omit<ProgramLanguage, "*">,
+  text: string
+): Tree | null {
+  if (loaded !== "yes") {
+    throw new Error(
+      loaded === "no"
+        ? `init() not called prior to getParser()`
+        : `init() must complete prior to calling getParser()`
+    );
+  }
+  const grammar = `tree-sitter-${lang}`;
+  if (!(grammar in parsers)) {
+    throw new Error(
+      `Grammar ${grammar} not present (available grammars: ${Object.keys(
+        parsers
+      )
+        .map((g) => g)
+        .join(", ")}`
+    );
+  }
+  return parsers[grammar].parse(text);
+}
+
+type Parser = {
+  parse(text: string): Tree | null;
+};
+
+/**
+ * Interface to bridge the two tree-sitters. Adapted from:
+ * https://nachawati.me/blog/2023/08/17/tree-sitter-api-differences-node-and-web-workaround/
+ * https://gist.github.com/nachawati/351cba7c0b9adff2b75a2fafe3e73ac3#file-tree-sitter-api-ts
+ */
+export type Point = {
+  row: number;
+  column: number;
+};
+
+export type Range = {
+  startPosition: Point;
+  endPosition: Point;
+  startIndex: number;
+  endIndex: number;
+};
+
+export type Edit = {
+  startIndex: number;
+  oldEndIndex: number;
+  newEndIndex: number;
+  startPosition: Point;
+  oldEndPosition: Point;
+  newEndPosition: Point;
+};
+
+export interface SyntaxNode {
+  tree: Tree;
+  type: string;
+  text: string;
+  startPosition: Point;
+  endPosition: Point;
+  startIndex: number;
+  endIndex: number;
+  parent: SyntaxNode | null;
+  children: Array<SyntaxNode>;
+  namedChildren: Array<SyntaxNode>;
+  childCount: number;
+  namedChildCount: number;
+  firstChild: SyntaxNode | null;
+  firstNamedChild: SyntaxNode | null;
+  lastChild: SyntaxNode | null;
+  lastNamedChild: SyntaxNode | null;
+  nextSibling: SyntaxNode | null;
+  nextNamedSibling: SyntaxNode | null;
+  previousSibling: SyntaxNode | null;
+  previousNamedSibling: SyntaxNode | null;
+
+  hasChanges: boolean; // modified
+  hasError: boolean; // modified
+  isMissing: boolean; // modified
+  toString(): string;
+  child(index: number): SyntaxNode | null;
+  namedChild(index: number): SyntaxNode | null;
+
+  walk(): TreeCursor;
+}
+
+export interface TreeCursor {
+  nodeType: string;
+  nodeText: string;
+  nodeIsNamed: boolean;
+  nodeIsMissing: boolean;
+  startPosition: Point;
+  endPosition: Point;
+  startIndex: number;
+  endIndex: number;
+
+  reset(node: SyntaxNode): void;
+  gotoParent(): boolean;
+  gotoFirstChild(): boolean;
+  gotoFirstChildForIndex(index: number): boolean;
+  gotoNextSibling(): boolean;
+}
+
+export interface Tree {
+  readonly rootNode: SyntaxNode;
+
+  //edit(delta: Edit): Tree; // modified
+  walk(): TreeCursor;
+  getChangedRanges(other: Tree): Range[];
+  //getEditedRange(other: Tree): Range; // modified
+}
+
+export function currentFieldName(cursor: any) {
+  return typeof cursor.currentFieldName === "function"
+    ? cursor.currentFieldName.bind(cursor)()
+    : cursor.currentFieldName;
+}
+
+export function currentNode(cursor: any) {
+  return typeof cursor.currentNode === "function"
+    ? cursor.currentNode.bind(cursor)()
+    : cursor.currentNode;
+}
+
+export function childForFieldName(
+  syntaxNode: SyntaxNode,
+  fieldName: string
+): SyntaxNode | null {
+  return childrenForFieldName(syntaxNode, fieldName).next().value ?? null;
+}
+
+export function* childrenForFieldName(
+  syntaxNode: SyntaxNode,
+  fieldName: string
+): IterableIterator<SyntaxNode> {
+  const cursor = syntaxNode.walk();
+  if (cursor.gotoFirstChild()) {
+    do {
+      if (currentFieldName(cursor) === fieldName) yield currentNode(cursor);
+    } while (cursor.gotoNextSibling());
+  }
+}

--- a/src/fuzzer/adapters/jest/JestAdapter.ts
+++ b/src/fuzzer/adapters/jest/JestAdapter.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { FuzzTests, Result } from "../../Fuzzer";
-import * as JSON5 from "json5";
+import * as ValueMapper from "../../mappers/ValueMapper";
 import * as os from "os";
 import * as path from "path";
 import { implicitOracle } from "../../oracles/ImplicitOracle";
@@ -67,7 +67,7 @@ export class JestAdapter extends AbstractTestAdapter {
       ``,
       `// @ts-ignore`,
       `const runPropertyValidator = (input, testFn, validFn, timeout) => {`,
-      `  const result = {...${JSON5.stringify(result)}, out: undefined, in: input};`,
+      `  const result = {...${ValueMapper.toLang("typescript", result)}, out: undefined, in: input};`,
       `  const startElapsedTime = performance.now(); // start timer`,
       `  try {`,
       `    result.out = testFn();`,
@@ -100,7 +100,7 @@ export class JestAdapter extends AbstractTestAdapter {
           .map((e) => e.value)
           .forEach((e) => {
             inputStr += x++ ? "," : "";
-            inputStr += JSON5.stringify(e);
+            inputStr += ValueMapper.toLang("typescript", e);
           });
 
         // Human-annotated expected output - if human validation is turned on
@@ -123,7 +123,8 @@ export class JestAdapter extends AbstractTestAdapter {
           } else {
             jestData.push(
               `  // Expect output value`,
-              `  it("${fn}.${i}.expect", () => {expect(themodule.${fn}(${inputStr})).toEqual(${JSON5.stringify(
+              `  it("${fn}.${i}.expect", () => {expect(themodule.${fn}(${inputStr})).toEqual(${ValueMapper.toLang(
+                "typescript",
                 expectedOutput[0].value
               )});},${timeout});`,
               ``
@@ -136,7 +137,10 @@ export class JestAdapter extends AbstractTestAdapter {
             jestData.push(
               `  // Expect property validator to not return "fail"`,
               `  it("${fn}.${i}.prop.${validator.slice(fn.length)}", () => {`,
-              `    expect(runPropertyValidator( ${JSON5.stringify(thisTest.input.map((e) => e.value))}, () => themodule.${fn}(${inputStr}), themodule.${validator}, ${thisFn.options.fnTimeout})).not.toEqual("fail");`,
+              `    expect(runPropertyValidator( ${ValueMapper.toLang(
+                "typescript",
+                thisTest.input.map((e) => e.value)
+              )}, () => themodule.${fn}(${inputStr}), themodule.${validator}, ${thisFn.options.fnTimeout})).not.toEqual("fail");`,
               `  });`,
               ``
             );

--- a/src/fuzzer/adapters/pytest/PytestAdapter.ts
+++ b/src/fuzzer/adapters/pytest/PytestAdapter.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { FuzzTests } from "../../Fuzzer";
-import * as JSON5 from "json5";
+import * as ValueMapper from "../../mappers/ValueMapper";
 import * as fs from "node:fs";
 import * as os from "os";
 import * as path from "path";
@@ -84,8 +84,8 @@ export class PytestAdapter extends AbstractTestAdapter {
         }
         i++;
         const inputArrStr = `[${thisTest.input
-          .map((e) => JSON5.stringify(e.value))
-          .join(",")}]`; // !!!!!!!!!! translation
+          .map((e) => ValueMapper.toLang("python", e.value))
+          .join(",")}]`;
 
         // Human-annotated expected output - if human validation is turned on
         const expectedOutput = thisTest.expectedOutput;
@@ -112,7 +112,7 @@ export class PytestAdapter extends AbstractTestAdapter {
               `@pytest.mark.timeout(${timeout} / 1000)`,
               `def test_${fn}_${i}_expect():`,
               `  # Expect output value`,
-              `  assert themodule.${fn}(*${inputArrStr}) == ${JSON5.stringify(expectedOutput[0].value)}`, // !!!!!!!!!! translation
+              `  assert themodule.${fn}(*${inputArrStr}) == ${ValueMapper.toLang("python", expectedOutput[0].value)}`,
               ``
             );
           }

--- a/src/fuzzer/analysis/ArgDef.test.ts
+++ b/src/fuzzer/analysis/ArgDef.test.ts
@@ -1,7 +1,7 @@
 import { ArgTag, ArgType, ArgOptions, Interval } from "./Types";
 import { ArgDef } from "./ArgDef";
 import seedrandom from "seedrandom";
-import * as JSON5 from "json5";
+import * as JSON5 from "../../Jsonn";
 import { ArgDefValidator } from "./ArgDefValidator";
 import { ArgDefGenerator } from "./ArgDefGenerator";
 import { ArgDefMutator } from "./ArgDefMutator";
@@ -163,7 +163,7 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
       ]
     );
     expect(TypescriptProgram.getTypeAnnotation(argDef)).toBe(
-      "(boolean[] | string | 5 | 'x' | undefined)[]"
+      `(boolean[] | string | 5 | "x" | undefined)[]`
     );
   });
 
@@ -212,7 +212,7 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
       ]
     );
     expect(TypescriptProgram.getTypeAnnotation(argDef)).toBe(
-      "(boolean[] | string | 5 | 'x' | undefined)[] | undefined"
+      `(boolean[] | string | 5 | "x" | undefined)[] | undefined`
     );
   });
 
@@ -261,7 +261,7 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
       ]
     );
     expect(TypescriptProgram.getTypeAnnotation(argDef)).toBe(
-      "boolean[] | string | 5 | 'x' | undefined"
+      `boolean[] | string | 5 | "x" | undefined`
     );
   });
 
@@ -310,7 +310,7 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
       ]
     );
     expect(TypescriptProgram.getTypeAnnotation(argDef)).toBe(
-      "boolean[] | string | 5 | 'x' | undefined"
+      `boolean[] | string | 5 | "x" | undefined`
     );
   });
 
@@ -349,7 +349,7 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
       ]
     );
     expect(TypescriptProgram.getTypeAnnotation(argDef)).toBe(
-      "boolean[] | string | 5 | 'x' | undefined"
+      `boolean[] | string | 5 | "x" | undefined`
     );
   });
 

--- a/src/fuzzer/analysis/ArgDef.ts
+++ b/src/fuzzer/analysis/ArgDef.ts
@@ -1,4 +1,3 @@
-import * as JSON5 from "json5";
 import vscode from "vscode";
 import {
   ArgOptionOverride,
@@ -77,7 +76,7 @@ export class ArgDef<T extends ArgType> {
     // Ensure the options are valid before ingesting them
     if (!ArgDef.isOptionValid(options))
       throw new Error(
-        `Invalid options provided.  Check intervals and length values: ${JSON5.stringify(
+        `Invalid options provided.  Check intervals and length values: ${JSON.stringify(
           options,
           null,
           2
@@ -97,7 +96,7 @@ export class ArgDef<T extends ArgType> {
       this.options.dimLength.filter((e) => e.min > e.max || e.min < 0).length
     ) {
       throw new Error(
-        `Invalid dimension length: ${JSON5.stringify(this.options.dimLength)}`
+        `Invalid dimension length: ${JSON.stringify(this.options.dimLength)}`
       );
     }
 
@@ -117,7 +116,7 @@ export class ArgDef<T extends ArgType> {
     // Ensure each non-array dimension is valid
     if (this.intervals.filter((e) => e.min > e.max).length) {
       throw new Error(
-        `Invalid interval: ${JSON5.stringify(this.intervals, undefined, 2)}`
+        `Invalid interval: ${JSON.stringify(this.intervals, undefined, 2)}`
       );
     }
   } // end: constructor
@@ -142,7 +141,7 @@ export class ArgDef<T extends ArgType> {
     // Ensure we have a resolved type
     if (!ref.type)
       throw new Error(
-        `Internal error: unable to create ArgDef for unresolved TypeRef: ${JSON5.stringify(
+        `Internal error: unable to create ArgDef for unresolved TypeRef: ${JSON.stringify(
           ref
         )}`
       );
@@ -311,7 +310,7 @@ export class ArgDef<T extends ArgType> {
   public setIntervals(intervals: Interval<T>[]): void {
     if (intervals.some((e) => e.min > e.max))
       throw new Error(
-        `Invalid interval provided (max>min): ${JSON5.stringify(intervals)}`
+        `Invalid interval provided (max>min): ${JSON.stringify(intervals)}`
       );
     this.intervals = intervals;
   } // fn: setIntervals()
@@ -330,7 +329,7 @@ export class ArgDef<T extends ArgType> {
     ) as Interval<T>[];
     if (intervals.some((e) => e.min > e.max))
       throw new Error(
-        `Invalid interval provided (max>min): ${JSON5.stringify(intervals)}`
+        `Invalid interval provided (max>min): ${JSON.stringify(intervals)}`
       );
     this.intervals = intervals;
   } // fn: setIntervals()
@@ -429,7 +428,7 @@ export class ArgDef<T extends ArgType> {
     // Ensure the options are valid before ingesting them
     if (!ArgDef.isOptionValid(newOptions))
       throw new Error(
-        `Invalid options provided. Check intervals and length values: ${JSON5.stringify(
+        `Invalid options provided. Check intervals and length values: ${JSON.stringify(
           newOptions,
           null,
           2

--- a/src/fuzzer/analysis/ArgDefMutator.ts
+++ b/src/fuzzer/analysis/ArgDefMutator.ts
@@ -2,7 +2,7 @@ import { ArgDef } from "./ArgDef";
 import { ArgDefGenerator } from "./ArgDefGenerator";
 import { ArgDefValidator } from "./ArgDefValidator";
 import { ArgTag, ArgType, ArgValueType, ArgValueTypeWrapped } from "./Types";
-import * as JSON5 from "json5";
+import * as JSON5 from "../../Jsonn";
 
 /**
  * Utilities for mutating values described by an ArgDef spec

--- a/src/fuzzer/analysis/ArgDefValidator.ts
+++ b/src/fuzzer/analysis/ArgDefValidator.ts
@@ -1,6 +1,5 @@
 import { ArgDef } from "./ArgDef";
 import { ArgTag, ArgType, ArgValueType, ArgValueTypeWrapped } from "./Types";
-import * as JSON5 from "json5";
 
 /**
  * Valides values against their corresponding ArgDef specs
@@ -159,12 +158,12 @@ export class ArgDefValidator {
         }
         case ArgTag.UNRESOLVED: {
           throw new Error(
-            `Encountered unresolved ArgDef: ${JSON5.stringify(spec)}`
+            `Encountered unresolved ArgDef: ${JSON.stringify(spec)}`
           );
         }
       } // switch: argdef type
       throw new Error(
-        `Cannot validate unsupported ArgDef type: ${JSON5.stringify(spec)}`
+        `Cannot validate unsupported ArgDef type: ${JSON.stringify(spec)}`
       );
     }
   } // fn: validate (static)

--- a/src/fuzzer/analysis/FunctionDef.ts
+++ b/src/fuzzer/analysis/FunctionDef.ts
@@ -1,4 +1,3 @@
-import * as JSON5 from "json5";
 import { ArgDef } from "./ArgDef";
 import {
   ArgType,
@@ -41,7 +40,7 @@ export class FunctionDef {
     this._cmt = ref.cmt;
 
     if (!ref.args) {
-      throw new Error(`FunctionRef.args is undefined: ${JSON5.stringify(ref)}`);
+      throw new Error(`FunctionRef.args is undefined: ${JSON.stringify(ref)}`);
     }
 
     // Extract the function arguments

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -13,6 +13,7 @@ import {
   ProgramLanguage,
 } from "../Types";
 import { getErrorMessageOrJson } from "../../Util";
+import * as ValueMapper from "../../mappers/ValueMapper";
 import * as ProgramFactory from "../ProgramFactory";
 import * as JSON5 from "json5";
 import Parser, { Query, QueryCapture } from "tree-sitter";
@@ -1262,7 +1263,7 @@ export class PythonProgram extends AbstractProgram {
       }
 
       case ArgTag.LITERAL: {
-        return `Literal[${JSON5.stringify(arg.getConstantValue())}]`; // !!!!!!!!!! translation
+        return `Literal[${ValueMapper.toLang("python", arg.getConstantValue())}]`;
       }
 
       case ArgTag.TUPLE: {

--- a/src/fuzzer/analysis/typescript/TypescriptProgram.ts
+++ b/src/fuzzer/analysis/typescript/TypescriptProgram.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/switch-exhaustiveness-check */
 import * as JSON5 from "json5";
+import * as ValueMapper from "../../mappers/ValueMapper";
 import { removeParents } from "../Util";
 import { parse, ParseResult } from "@babel/parser";
 import _traverse, { NodePath } from "@babel/traverse";
@@ -1165,7 +1166,7 @@ export class TypescriptProgram extends AbstractProgram {
       }
 
       case ArgTag.LITERAL: {
-        return `${JSON5.stringify(arg.getConstantValue())}`;
+        return `${ValueMapper.toLang("typescript", arg.getConstantValue())}`;
       }
 
       case ArgTag.TUPLE: {

--- a/src/fuzzer/compilers/TypescriptCompiler.ts
+++ b/src/fuzzer/compilers/TypescriptCompiler.ts
@@ -150,9 +150,7 @@ export class TypescriptCompiler {
     updateFn: (msg: FuzzBusyStatusMessage) => void
   ): ReturnType<NodeJS.Require> {
     // Determine options using the module path
-    this._options = JSON5.parse<typeof defaultOptions>(
-      JSON5.stringify(defaultOptions)
-    );
+    this._options = structuredClone(defaultOptions);
     this._determineOptions();
 
     // Track local compilations

--- a/src/fuzzer/generators/AiInputGenerator.ts
+++ b/src/fuzzer/generators/AiInputGenerator.ts
@@ -4,8 +4,10 @@ import {
   ArgType,
   ArgValueType,
   ArgValueTypeWrapped,
+  ProgramLanguage,
 } from "../analysis/Types";
 import * as JSON5 from "json5";
+import * as ValueMapper from "../mappers/ValueMapper";
 import { LlmAdapter } from "../adapters/LlmAdapter";
 import { ArgDef, FunctionDef, InputAndSource } from "../Fuzzer";
 import { ArgDefValidator } from "../analysis/ArgDefValidator";
@@ -112,7 +114,7 @@ export class AiInputGenerator extends AbstractInputGenerator {
         const validator = new ArgDefValidator(this._specs);
 
         this._stats.calls.sent++;
-        const [schema, directives] = this._getInputsSchema();
+        const [schema, directives] = this._getInputsSchema(this._fn.getLang());
 
         // Fetch inputs from the llm
         this._llm.genInputs(this._fn, [schema, directives]).then((inputs) => {
@@ -228,7 +230,7 @@ export class AiInputGenerator extends AbstractInputGenerator {
    *
    * @returns JSON schema
    */
-  protected _getInputsSchema(): [zod.ZodObject, string[]] {
+  protected _getInputsSchema(lang: ProgramLanguage): [zod.ZodObject, string[]] {
     const zodObj: { [k: string]: zod.ZodType } = {};
     const directives: string[] = [];
     this._specs.forEach((arg) => {
@@ -239,16 +241,16 @@ export class AiInputGenerator extends AbstractInputGenerator {
       );
     });
     directives.push(
-      `${NANOFUZZ_UNDEFINED} is a placeholder for the actual value \`undefined\``
+      `${NANOFUZZ_UNDEFINED} is a placeholder for the actual value \`${ValueMapper.toLang(lang, undefined)}\``
     );
     directives.push(
       `${NANOFUZZ_MISSING_PROPERTY} is a placeholder for a missing property`
     );
     directives.push(
-      `${NANOFUZZ_TRUE} is a placeholder for the actual value \`true\``
+      `${NANOFUZZ_TRUE} is a placeholder for the actual value \`${ValueMapper.toLang(lang, true)}\``
     );
     directives.push(
-      `${NANOFUZZ_FALSE} is a placeholder for the actual value \`false\``
+      `${NANOFUZZ_FALSE} is a placeholder for the actual value \`${ValueMapper.toLang(lang, false)}\``
     );
     return [
       zod.strictObject({ programInputs: zod.array(zod.strictObject(zodObj)) }),

--- a/src/fuzzer/generators/CompositeInputGenerator.ts
+++ b/src/fuzzer/generators/CompositeInputGenerator.ts
@@ -1,7 +1,6 @@
 import { AbstractInputGenerator } from "./AbstractInputGenerator";
 import { AbstractMeasure, BaseMeasurement } from "../measures/AbstractMeasure";
 import { Leaderboard } from "./Leaderboard";
-import * as JSON5 from "json5";
 import { ScoredInput } from "./Types";
 import { FuzzOptions, InputAndSource } from "./../Types";
 import { FunctionDef, FuzzTestStats } from "../Fuzzer";
@@ -329,7 +328,7 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
       }
     }
     throw new Error(
-      `Internal failure selecting subgen: ${JSON5.stringify(
+      `Internal failure selecting subgen: ${JSON.stringify(
         {
           progress,
           cost,

--- a/src/fuzzer/generators/CompositeInputGenerator.ts
+++ b/src/fuzzer/generators/CompositeInputGenerator.ts
@@ -180,9 +180,7 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
       ...this._subgens[this._selectedSubgenIndex].next(),
       tick: this._tick,
     };
-    return JSON5.parse<typeof this._lastInput>(
-      JSON5.stringify(this._lastInput)
-    );
+    return structuredClone(this._lastInput);
   } // fn: next
 
   /**

--- a/src/fuzzer/generators/Leaderboard.ts
+++ b/src/fuzzer/generators/Leaderboard.ts
@@ -1,5 +1,3 @@
-import * as JSON5 from "json5";
-
 /**
  * Running list of "interesting" inputs.
  */
@@ -68,7 +66,7 @@ export class Leaderboard<T> {
     // Only post scores > minimum score
     if (score > this._minScore) {
       const thisLeader = {
-        leader: JSON5.parse<typeof leader>(JSON5.stringify(leader)),
+        leader: structuredClone(leader),
         score,
         focus: this._initialFocus,
       };
@@ -128,7 +126,7 @@ export class Leaderboard<T> {
       }
     });
     const leader = this._leaders[leaderIdx ?? 0].leader;
-    return JSON5.parse<typeof leader>(JSON5.stringify(leader));
+    return structuredClone(leader);
   } // fn: getRandomLeader
 
   /**
@@ -138,6 +136,6 @@ export class Leaderboard<T> {
    * @returns array of leaders
    */
   public getLeaders(): { leader: T; score: number }[] {
-    return JSON5.parse<typeof this._leaders>(JSON5.stringify(this._leaders));
+    return structuredClone(this._leaders);
   } // fn: getLeaders
 } // class: Leaderboard

--- a/src/fuzzer/mappers/ValueMapper.ts
+++ b/src/fuzzer/mappers/ValueMapper.ts
@@ -1,0 +1,47 @@
+import { ProgramLanguage } from "../Fuzzer";
+import * as PythonValueMapper from "./python/PythonValueMapper";
+import * as TypescriptValueMapper from "./typescript/TypescriptValueMapper";
+import * as JSONN from "../../Jsonn";
+
+export class ValueMapper<T> {
+  protected _jsValue: T;
+
+  constructor(jsValue: T) {
+    this._jsValue = jsValue;
+  }
+
+  public static unserialize<T>(text: string): ValueMapper<T> {
+    return new ValueMapper<T>(JSONN.parse(text));
+  }
+
+  public static fromString<T>(
+    lang: Omit<ProgramLanguage, "*">,
+    text: string
+  ): ValueMapper<T> {
+    switch (lang) {
+      case "python":
+        return new ValueMapper<T>(PythonValueMapper.fromPython(text));
+      case "typescript":
+        return new ValueMapper<T>(TypescriptValueMapper.fromTypescript(text));
+    }
+    throw new Error(`Unknown language: ${lang}`);
+  }
+
+  public get value(): T {
+    return this._jsValue;
+  }
+
+  public serialize(): string {
+    return JSONN.stringify(this._jsValue);
+  }
+
+  public toString(lang: Omit<ProgramLanguage, "*">): string {
+    switch (lang) {
+      case "python":
+        return PythonValueMapper.toPython(this._jsValue);
+      case "typescript":
+        return TypescriptValueMapper.toTypescript(this._jsValue);
+    }
+    throw new Error(`Unknown language: ${lang}`);
+  }
+} // class: ValueMapper

--- a/src/fuzzer/mappers/ValueMapper.ts
+++ b/src/fuzzer/mappers/ValueMapper.ts
@@ -1,8 +1,28 @@
 import { ProgramLanguage } from "../Fuzzer";
 import * as PythonValueMapper from "./python/PythonValueMapper";
 import * as TypescriptValueMapper from "./typescript/TypescriptValueMapper";
-import * as JSONN from "../../Jsonn";
 
+export function toLang(lang: Omit<ProgramLanguage, "*">, val: unknown): string {
+  switch (lang) {
+    case "python":
+      return PythonValueMapper.toPython(val);
+    case "typescript":
+      return TypescriptValueMapper.toTypescript(val);
+  }
+  throw new Error(`Unknown language: ${lang}`);
+}
+
+export function fromLang<T>(lang: Omit<ProgramLanguage, "*">, text: string): T {
+  switch (lang) {
+    case "python":
+      return PythonValueMapper.fromPython(text);
+    case "typescript":
+      return TypescriptValueMapper.fromTypescript(text);
+  }
+  throw new Error(`Unknown language: ${lang}`);
+}
+
+/*
 export class ValueMapper<T> {
   protected _jsValue: T;
 
@@ -45,3 +65,4 @@ export class ValueMapper<T> {
     throw new Error(`Unknown language: ${lang}`);
   }
 } // class: ValueMapper
+*/

--- a/src/fuzzer/mappers/python/PythonValueMapper.test.ts
+++ b/src/fuzzer/mappers/python/PythonValueMapper.test.ts
@@ -1,0 +1,67 @@
+import * as PythonValueMapper from "./PythonValueMapper";
+
+describe("fuzzer/mappers/python/PythonValueMapper: ", () => {
+  it("round-trip values", () => {
+    [
+      //null,
+      undefined,
+      true,
+      false,
+      Infinity,
+      -Infinity,
+      3,
+      "hello",
+      true,
+      false,
+      {
+        trueValue: true,
+        noValue: undefined,
+        //nullValue: null,
+        arrayValue: [
+          //null,
+          undefined,
+          true,
+          false,
+          Infinity,
+          -Infinity,
+          3,
+          "hello",
+          true,
+          false,
+        ],
+      },
+      [
+        //null,
+        undefined,
+        true,
+        false,
+        Infinity,
+        -Infinity,
+        3,
+        "hello",
+        true,
+        false,
+        {
+          trueValue: true,
+          noValue: undefined,
+          //nullValue: null
+        },
+      ],
+    ].forEach((value) => {
+      const pythonStr = PythonValueMapper.toPython(value);
+      const roundtripValue = PythonValueMapper.fromPython(pythonStr);
+      expect(roundtripValue).toEqual(value);
+    });
+  });
+
+  it("single/double quoted strings", () => {
+    [
+      { python: `"hello"`, js: "hello" },
+      { python: `"hello 'bob'"`, js: "hello 'bob'" },
+      { python: `'hello'`, js: "hello" },
+      { python: `'hello "bob"'`, js: `hello "bob"` },
+    ].forEach((value) => {
+      expect(PythonValueMapper.fromPython(value.python)).toEqual(value.js);
+    });
+  });
+});

--- a/src/fuzzer/mappers/python/PythonValueMapper.test.ts
+++ b/src/fuzzer/mappers/python/PythonValueMapper.test.ts
@@ -5,7 +5,7 @@ describe("fuzzer/mappers/python/PythonValueMapper: ", () => {
     [
       //null,
       NaN,
-      undefined,
+      //undefined, not round trippable
       true,
       false,
       Infinity,
@@ -16,13 +16,13 @@ describe("fuzzer/mappers/python/PythonValueMapper: ", () => {
       false,
       {
         trueValue: true,
-        noValue: undefined,
-        //nullValue: null,
+        //noValue: undefined, not round trippable
+        nullValue: null,
         nanValue: NaN,
         arrayValue: [
-          //null,
+          null,
           NaN,
-          undefined,
+          //undefined, not round trippable
           true,
           false,
           Infinity,
@@ -34,9 +34,9 @@ describe("fuzzer/mappers/python/PythonValueMapper: ", () => {
         ],
       },
       [
-        //null,
+        null,
         NaN,
-        undefined,
+        //undefined, not round trippable
         true,
         false,
         Infinity,
@@ -47,8 +47,8 @@ describe("fuzzer/mappers/python/PythonValueMapper: ", () => {
         false,
         {
           trueValue: true,
-          noValue: undefined,
-          //nullValue: null
+          //noValue: undefined, not round trippable
+          nullValue: null,
           nanValue: NaN,
         },
       ],

--- a/src/fuzzer/mappers/python/PythonValueMapper.test.ts
+++ b/src/fuzzer/mappers/python/PythonValueMapper.test.ts
@@ -4,6 +4,7 @@ describe("fuzzer/mappers/python/PythonValueMapper: ", () => {
   it("round-trip values", () => {
     [
       //null,
+      NaN,
       undefined,
       true,
       false,
@@ -17,8 +18,10 @@ describe("fuzzer/mappers/python/PythonValueMapper: ", () => {
         trueValue: true,
         noValue: undefined,
         //nullValue: null,
+        nanValue: NaN,
         arrayValue: [
           //null,
+          NaN,
           undefined,
           true,
           false,
@@ -32,6 +35,7 @@ describe("fuzzer/mappers/python/PythonValueMapper: ", () => {
       },
       [
         //null,
+        NaN,
         undefined,
         true,
         false,
@@ -45,6 +49,7 @@ describe("fuzzer/mappers/python/PythonValueMapper: ", () => {
           trueValue: true,
           noValue: undefined,
           //nullValue: null
+          nanValue: NaN,
         },
       ],
     ].forEach((value) => {
@@ -56,12 +61,12 @@ describe("fuzzer/mappers/python/PythonValueMapper: ", () => {
 
   it("single/double quoted strings", () => {
     [
-      { python: `"hello"`, js: "hello" },
-      { python: `"hello 'bob'"`, js: "hello 'bob'" },
-      { python: `'hello'`, js: "hello" },
-      { python: `'hello "bob"'`, js: `hello "bob"` },
+      { str: `"hello"`, val: "hello" },
+      { str: `"hello 'bob'"`, val: "hello 'bob'" },
+      { str: `'hello'`, val: "hello" },
+      { str: `'hello "bob"'`, val: `hello "bob"` },
     ].forEach((value) => {
-      expect(PythonValueMapper.fromPython(value.python)).toEqual(value.js);
+      expect(PythonValueMapper.fromPython(value.str)).toEqual(value.val);
     });
   });
 });

--- a/src/fuzzer/mappers/python/PythonValueMapper.ts
+++ b/src/fuzzer/mappers/python/PythonValueMapper.ts
@@ -1,0 +1,181 @@
+import * as JSONN from "../../../Jsonn";
+import Parser from "tree-sitter";
+import PythonGrammar from "tree-sitter-python";
+
+// Type definitions are broken in tree-sitter-python
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+const Python: Parser.Language = PythonGrammar as Parser.Language;
+
+/**
+ * Converts an arbitrary JavaScript value of type `unknown` into a Python literal string.
+ * - `true` -> `True`
+ * - `false` -> `False`
+ * - `null` / `undefined` -> `None`
+ * - Objects -> Python dictionaries (`{...}`)
+ * - Arrays -> Python lists (`[...]`)
+ *
+ * @param `jsValue` An arbitrary JavaScript value
+ * @returns A string formatted as a valid Python literal expression
+ */
+export function toPython(jsValue: unknown): string {
+  return toPythonFormat(toPythonValues(jsValue));
+}
+
+/**
+ * Converts a snippet of Python code containing a value into
+ * a corresponding Javascript representation.
+ *
+ * @param `text` textual representation of a Python value
+ * @returns Javascript value corresponding to `text`
+ */
+export function fromPython<T>(text: string): T {
+  return toJavascriptValues(text) as T;
+}
+
+// ---------------------- From Javascript to Python ----------------------
+
+/**
+ * Recursively converts Javascript booleans, null/undefined, arrays, and objects
+ * to match Python structures.
+ *
+ * @param `val` arbitrary Javascript value
+ * @returns `val` where JS values are mapped to Python values
+ */
+function toPythonValues(val: unknown): unknown {
+  if (val === undefined || val === null) {
+    return PythonNone;
+  }
+
+  if (Array.isArray(val)) {
+    return val.map(toPythonValues);
+  }
+
+  if (val !== null && typeof val === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(val)) {
+      result[k] = toPythonValues(v);
+    }
+    return result;
+  }
+
+  if (typeof val === "function") {
+    throw new Error("Functions are not supported");
+  }
+
+  if (typeof val === "bigint") {
+    throw new Error("Bigints are not supported");
+  }
+
+  return val; // Passthrough strings, numbers, booleans
+}
+
+// Python's `None` value
+const PythonNone = Symbol("PythonNone");
+
+/**
+ * Outputs a value in Python syntax instead of JS
+ *
+ * @param `val` Python value (but still in JS)
+ * @returns string representation of `val` in Python format
+ */
+function toPythonFormat(val: unknown): string {
+  if (val === PythonNone) {
+    return "None";
+  }
+  if (typeof val === "boolean") {
+    return val ? "True" : "False";
+  }
+  if (typeof val === "string") {
+    return JSON.stringify(val); // handles strings quotes and escapes
+  }
+  if (typeof val === "number") {
+    return String(val);
+  }
+
+  if (Array.isArray(val)) {
+    const items = val.map(toPythonFormat);
+    return `[${items.join(", ")}]`;
+  }
+
+  if (val !== null && typeof val === "object") {
+    const entries = Object.entries(val).map(([k, v]) => {
+      return `${JSON.stringify(k)}: ${toPythonFormat(v)}`;
+    });
+    return `{${entries.join(", ")}}`;
+  }
+
+  return String(val);
+}
+
+// ---------------------- From Python to Javascript ----------------------
+
+/**
+ * Accepts a Python literal string (the output of `valueToPython`)
+ * and parses it back into a corresponding JavaScript value.
+ *
+ * @param text A string formatted as a Python literal (e.g., `{"a": True, "b": None}`)
+ * @returns The corresponding JavaScript value
+ */
+function toJavascriptValues(text: string): unknown {
+  if (!text || typeof text !== "string") {
+    throw new Error("Input must be a non-empty string");
+  }
+
+  const trimmed = text.trim();
+  if (trimmed === "True") return true;
+  if (trimmed === "False") return false;
+  if (trimmed === "None") return undefined;
+
+  // Use tree-sitter to replace Python values with Javascript values
+  const parser = new Parser();
+  parser.setLanguage(Python);
+  const tree = parser.parse(text);
+  const replacements: Array<{ start: number; end: number; text: string }> = [];
+  const collectReplacements = (node: Parser.SyntaxNode) => {
+    switch (node.type) {
+      case "true":
+        replacements.push({
+          start: node.startIndex,
+          end: node.endIndex,
+          text: "true",
+        });
+        break;
+      case "false":
+        replacements.push({
+          start: node.startIndex,
+          end: node.endIndex,
+          text: "false",
+        });
+        break;
+      case "none":
+        replacements.push({
+          start: node.startIndex,
+          end: node.endIndex,
+          text: JSONN.getPlaceholder("undefined"),
+        });
+        break;
+      default:
+        // Recursively traverse children
+        for (let i = 0; i < node.childCount; i++) {
+          const child = node.child(i);
+          if (child) {
+            collectReplacements(child);
+          }
+        }
+        break;
+    }
+  };
+  collectReplacements(tree.rootNode);
+
+  // Apply replacements in right to left order
+  replacements.sort((a, b) => b.start - a.start);
+  let modifiedText = text;
+  for (const r of replacements) {
+    modifiedText =
+      modifiedText.slice(0, r.start) + r.text + modifiedText.slice(r.end);
+  }
+
+  // Offload the rest to JSONN
+  const result = JSONN.parse(`${JSONN.predicate}${modifiedText}`);
+  return result === null ? undefined : result;
+}

--- a/src/fuzzer/mappers/python/PythonValueMapper.ts
+++ b/src/fuzzer/mappers/python/PythonValueMapper.ts
@@ -1,10 +1,5 @@
 import * as JSONN from "../../../Jsonn";
-import Parser from "tree-sitter";
-import PythonGrammar from "tree-sitter-python";
-
-// Type definitions are broken in tree-sitter-python
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-const Python: Parser.Language = PythonGrammar as Parser.Language;
+import * as Parser from "../../adapters/ParserAdapter";
 
 /**
  * Converts an arbitrary JavaScript value of type `unknown` into a Python literal string.
@@ -32,7 +27,7 @@ export function fromPython<T>(text: string): T {
   return toJavascriptValues(text) as T;
 }
 
-// --------------- From Javascript value to Python string ---------------
+// --------------- From Javascript value to Python string --------------- //
 
 /**
  * Recursively converts Javascript booleans, null/undefined, arrays, and objects
@@ -128,12 +123,13 @@ function toJavascriptValues(text: string): unknown {
   const trimmed = text.trim();
   if (trimmed === "True") return true;
   if (trimmed === "False") return false;
-  if (trimmed === "None") return undefined;
+  if (trimmed === "None") return null;
 
-  // Use tree-sitter to replace Python values with Javascript values
-  const parser = new Parser();
-  parser.setLanguage(Python);
-  const tree = parser.parse(text);
+  // Parse and replace Python values with Javascript values
+  const tree = Parser.parse(`python`, text);
+  if (tree === null) {
+    throw new Error(`parser returned null`);
+  }
   const replacements: Array<{ start: number; end: number; text: string }> = [];
   const collectReplacements = (node: Parser.SyntaxNode) => {
     switch (node.type) {
@@ -155,16 +151,13 @@ function toJavascriptValues(text: string): unknown {
         replacements.push({
           start: node.startIndex,
           end: node.endIndex,
-          text: JSONN.getPlaceholder("undefined"),
+          text: "null",
         });
         break;
       default:
         // Recursively traverse children
-        for (let i = 0; i < node.childCount; i++) {
-          const child = node.child(i);
-          if (child) {
-            collectReplacements(child);
-          }
+        for (const child of node.children) {
+          collectReplacements(child);
         }
         break;
     }
@@ -180,6 +173,5 @@ function toJavascriptValues(text: string): unknown {
   }
 
   // Offload the rest to JSONN
-  const result = JSONN.parse(`${JSONN.predicate}${modifiedText}`);
-  return result === null ? undefined : result;
+  return JSONN.parse(modifiedText);
 }

--- a/src/fuzzer/mappers/python/PythonValueMapper.ts
+++ b/src/fuzzer/mappers/python/PythonValueMapper.ts
@@ -32,7 +32,7 @@ export function fromPython<T>(text: string): T {
   return toJavascriptValues(text) as T;
 }
 
-// ---------------------- From Javascript to Python ----------------------
+// --------------- From Javascript value to Python string ---------------
 
 /**
  * Recursively converts Javascript booleans, null/undefined, arrays, and objects
@@ -64,6 +64,10 @@ function toPythonValues(val: unknown): unknown {
 
   if (typeof val === "bigint") {
     throw new Error("Bigints are not supported");
+  }
+
+  if (typeof val === "symbol") {
+    throw new Error("Symbols are not supported");
   }
 
   return val; // Passthrough strings, numbers, booleans
@@ -107,13 +111,13 @@ function toPythonFormat(val: unknown): string {
   return String(val);
 }
 
-// ---------------------- From Python to Javascript ----------------------
+// --------------- From Python string to Javascript value ---------------
 
 /**
  * Accepts a Python literal string (the output of `valueToPython`)
  * and parses it back into a corresponding JavaScript value.
  *
- * @param text A string formatted as a Python literal (e.g., `{"a": True, "b": None}`)
+ * @param `text` string formatted as a Python literal (e.g., `{"a": True, "b": None}`)
  * @returns The corresponding JavaScript value
  */
 function toJavascriptValues(text: string): unknown {

--- a/src/fuzzer/mappers/typescript/TypescriptValueMapper.test.ts
+++ b/src/fuzzer/mappers/typescript/TypescriptValueMapper.test.ts
@@ -1,0 +1,74 @@
+import * as TypescriptValueMapper from "./TypescriptValueMapper";
+
+describe("fuzzer/mappers/typescript/TypescriptValueMapper: ", () => {
+  it("round-trip values", () => {
+    [
+      null,
+      NaN,
+      undefined,
+      true,
+      false,
+      Infinity,
+      -Infinity,
+      3,
+      "hello",
+      true,
+      false,
+      {
+        trueValue: true,
+        noValue: undefined,
+        nullValue: null,
+        nanValue: NaN,
+        arrayValue: [
+          null,
+          NaN,
+          undefined,
+          true,
+          false,
+          Infinity,
+          -Infinity,
+          3,
+          "hello",
+          true,
+          false,
+        ],
+      },
+      [
+        null,
+        NaN,
+        undefined,
+        true,
+        false,
+        Infinity,
+        -Infinity,
+        3,
+        "hello",
+        true,
+        false,
+        {
+          trueValue: true,
+          noValue: undefined,
+          nullValue: null,
+          nanValue: NaN,
+        },
+      ],
+    ].forEach((value) => {
+      const tsStr = TypescriptValueMapper.toTypescript(value);
+      const roundtripValue = TypescriptValueMapper.fromTypescript(tsStr);
+      expect(roundtripValue).toEqual(value);
+    });
+  });
+
+  it("single/double quoted strings", () => {
+    [
+      { str: `"hello"`, val: `hello` },
+      { str: `"hello 'bob'"`, val: `hello 'bob'` },
+      { str: `'hello'`, val: `hello` },
+      { str: `'hello "bob"'`, val: `hello "bob"` },
+    ].forEach((value) => {
+      expect(TypescriptValueMapper.fromTypescript(value.str)).toEqual(
+        value.val
+      );
+    });
+  });
+});

--- a/src/fuzzer/mappers/typescript/TypescriptValueMapper.ts
+++ b/src/fuzzer/mappers/typescript/TypescriptValueMapper.ts
@@ -1,0 +1,164 @@
+import * as JSONN from "../../../Jsonn";
+import Parser from "tree-sitter";
+import TypescriptGrammar from "tree-sitter-typescript";
+import { isKeyedObject } from "../../../Util";
+
+// Type definitions are broken in tree-sitter-typescript
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+const Typescript: Parser.Language =
+  TypescriptGrammar.typescript as Parser.Language;
+
+/**
+ * Accepts an arbitrary JavaScript value and returns a string representing
+ * that value in valid TypeScript/JavaScript format.
+ * Supports `undefined` explicitly (both in object properties and array items).
+ *
+ * @param `jsValue` An arbitrary JavaScript value
+ * @returns A string formatted as a valid TypeScript expression
+ */
+export function toTypescript(jsValue: unknown): string {
+  return toJavascriptValues(jsValue);
+}
+
+/**
+ * Converts a snippet of Javacript code containing a value into
+ * a corresponding Javascript representation.
+ *
+ * @param `text` textual representation of a Javascript value
+ * @returns Javascript value corresponding to `text`
+ */
+export function fromTypescript<T>(text: string): T {
+  return toJavascriptValue(text) as T;
+}
+
+// ------------- From Javascript value to Javascript string -------------
+
+/**
+ * Recursively converts Javascript booleans, null/undefined, arrays, and objects
+ * to match Python structures.
+ *
+ * @param `val` arbitrary Javascript value
+ * @returns `val` where JS values are mapped to Python values
+ */
+function toJavascriptValues(val: unknown): string {
+  if (val === undefined) {
+    return "undefined";
+  }
+
+  if (val === null) {
+    return "null";
+  }
+
+  if (typeof val === "boolean") {
+    return val ? "true" : "false";
+  }
+
+  if (typeof val === "number") {
+    if (Object.is(val, NaN)) return "NaN";
+    if (Object.is(val, Infinity)) return "Infinity";
+    if (Object.is(val, -Infinity)) return "-Infinity";
+    return String(val);
+  }
+
+  if (typeof val === "string") {
+    return JSON.stringify(val); // handles quotes and escapes
+  }
+
+  if (Array.isArray(val)) {
+    const items = val.map((item) => toJavascriptValues(item));
+    return `[${items.join(", ")}]`;
+  }
+
+  if (val !== null && typeof val === "object") {
+    const entries: string[] = [];
+    if (isKeyedObject(val)) {
+      for (const key of Object.keys(val)) {
+        const propValue = val[key];
+        const formattedKey = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key)
+          ? key
+          : JSON.stringify(key); // Quote key if not a valid identifier
+        const formattedValue = toJavascriptValues(propValue);
+        entries.push(`${formattedKey}: ${formattedValue}`);
+      }
+    }
+    return `{${entries.join(", ")}}`;
+  }
+
+  if (typeof val === "function") {
+    throw new Error("Functions are not supported");
+  }
+
+  if (typeof val === "bigint") {
+    throw new Error("Bigints are not supported");
+  }
+
+  if (typeof val === "symbol") {
+    throw new Error("Symbols are not supported");
+  }
+
+  return String(val);
+}
+
+// ------------- From Javascript string to Javascript value -------------
+
+/**
+ * Accepts a Javascript literal string (the output of `valueToTypescript`)
+ * and parses it back into a corresponding JavaScript value.
+ *
+ * @param `text` string formatted as a Javascript literal
+ * @returns The corresponding JavaScript value
+ */
+function toJavascriptValue(text: string): unknown {
+  if (!text || typeof text !== "string") {
+    throw new Error("Input must be a non-empty string");
+  }
+
+  const trimmed = text.trim();
+  if (trimmed === "undefined") return undefined;
+  if (trimmed === "NaN") return NaN;
+  if (trimmed === "Infinity") return Infinity;
+  if (trimmed === "-Infinity") return -Infinity;
+  if (trimmed === "true") return true;
+  if (trimmed === "false") return false;
+
+  // Use tree-sitter to parse the Javascript
+  const parser = new Parser();
+  parser.setLanguage(Typescript);
+  const tree = parser.parse(text);
+  const replacements: Array<{ start: number; end: number; text: string }> = [];
+
+  const collectReplacements = (node: Parser.SyntaxNode) => {
+    switch (node.type) {
+      case "undefined":
+        if (node.text === "undefined") {
+          replacements.push({
+            start: node.startIndex,
+            end: node.endIndex,
+            text: JSONN.getPlaceholder("undefined"),
+          });
+        }
+        break;
+      default:
+        // Recursively traverse children
+        for (let i = 0; i < node.childCount; i++) {
+          const child = node.child(i);
+          if (child) {
+            collectReplacements(child);
+          }
+        }
+        break;
+    }
+  };
+  collectReplacements(tree.rootNode);
+
+  // Apply replacements in right to left order
+  replacements.sort((a, b) => b.start - a.start);
+  let modifiedText = text;
+  for (const r of replacements) {
+    modifiedText =
+      modifiedText.slice(0, r.start) + r.text + modifiedText.slice(r.end);
+  }
+
+  // Offload the rest to JSONN
+  return JSONN.parse(`${JSONN.predicate}${modifiedText}`);
+}

--- a/src/fuzzer/mappers/typescript/TypescriptValueMapper.ts
+++ b/src/fuzzer/mappers/typescript/TypescriptValueMapper.ts
@@ -1,12 +1,6 @@
 import * as JSONN from "../../../Jsonn";
-import Parser from "tree-sitter";
-import TypescriptGrammar from "tree-sitter-typescript";
 import { isKeyedObject } from "../../../Util";
-
-// Type definitions are broken in tree-sitter-typescript
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-const Typescript: Parser.Language =
-  TypescriptGrammar.typescript as Parser.Language;
+import * as Parser from "../../adapters/ParserAdapter";
 
 /**
  * Accepts an arbitrary JavaScript value and returns a string representing
@@ -99,7 +93,7 @@ function toJavascriptValues(val: unknown): string {
   return String(val);
 }
 
-// ------------- From Javascript string to Javascript value -------------
+// ------------- From Javascript string to Javascript value ------------- //
 
 /**
  * Accepts a Javascript literal string (the output of `valueToTypescript`)
@@ -121,12 +115,12 @@ function toJavascriptValue(text: string): unknown {
   if (trimmed === "true") return true;
   if (trimmed === "false") return false;
 
-  // Use tree-sitter to parse the Javascript
-  const parser = new Parser();
-  parser.setLanguage(Typescript);
-  const tree = parser.parse(text);
+  // Parse the Javascript value
+  const tree = Parser.parse(`typescript`, text);
+  if (tree === null) {
+    throw new Error(`parser returned null`);
+  }
   const replacements: Array<{ start: number; end: number; text: string }> = [];
-
   const collectReplacements = (node: Parser.SyntaxNode) => {
     switch (node.type) {
       case "undefined":
@@ -160,5 +154,5 @@ function toJavascriptValue(text: string): unknown {
   }
 
   // Offload the rest to JSONN
-  return JSONN.parse(`${JSONN.predicate}${modifiedText}`);
+  return JSONN.parse(modifiedText);
 }

--- a/src/fuzzer/oracles/ExampleOracle.ts
+++ b/src/fuzzer/oracles/ExampleOracle.ts
@@ -1,6 +1,6 @@
 import { FuzzIoElement } from "../Types";
 import { Judgment } from "./Types";
-import * as JSON5 from "json5";
+import * as JSONN from "../../Jsonn";
 
 export class ExampleOracle {
   public static judge(
@@ -28,12 +28,12 @@ export class ExampleOracle {
       }
 
       // Compare expected to actual values.
-      return JSON5.stringify(
+      return JSONN.stringify(
         outputValue.map((output) => {
           return { value: output.value };
         })
       ) ===
-        JSON5.stringify(
+        JSONN.stringify(
           expectedOutput.map((output) => {
             return { value: output.value };
           })

--- a/src/fuzzer/runners/JavascriptRunner.ts
+++ b/src/fuzzer/runners/JavascriptRunner.ts
@@ -4,7 +4,7 @@ import { isError } from "../Util";
 import vm from "vm";
 
 /**
- * Javascript test runner
+ * Javascript runner
  */
 export class JavascriptRunner extends AbstractRunner {
   protected readonly _module: NodeJS.Module; // Node module

--- a/src/fuzzer/test_fixtures/Fuzzer.testfixtures.py
+++ b/src/fuzzer/test_fixtures/Fuzzer.testfixtures.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal, List, TypedDict
+from typing import Any, Literal, List, TypedDict, Union
 
 
 type a = str
@@ -27,3 +27,12 @@ def throws(n: int) -> int:
     if (n % 2 == 0):
         raise Exception("some put exception")
     return n
+
+
+Issue301Out = TypedDict('Issue301Out', {'a': Union[int, None]})
+
+
+def issue301(r: int) -> Issue301Out:
+    if r == 6:
+        return {'a': None}
+    return {'a': r}

--- a/src/fuzzer/test_fixtures/Fuzzer.testfixtures.ts
+++ b/src/fuzzer/test_fixtures/Fuzzer.testfixtures.ts
@@ -142,3 +142,10 @@ export type FuzzTestResult = {
   exception: boolean;
   timeout: boolean;
 };
+
+export function issue301(r: number): { a: number | undefined } {
+  if (r === 6) {
+    return { a: undefined };
+  }
+  return { a: r };
+}

--- a/src/telemetry/Logger.ts
+++ b/src/telemetry/Logger.ts
@@ -47,7 +47,7 @@ export class Logger {
     const chunkUri = vscode.Uri.joinPath(
       workspaceFolders[0].uri,
       "telemetry",
-      chunkName + ".json"
+      chunkName + ".json5"
     );
 
     // Persist the log chunk if data is present

--- a/src/telemetry/Telemetry.ts
+++ b/src/telemetry/Telemetry.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { Logger, LoggerEntry } from "./Logger";
-import { Listener } from "../extension";
+import { Listener } from "../Extension";
 
 let currentWindow = ""; // Current editor window filename / uri
 let currentTerm = ""; // Current terminal window name

--- a/src/ui/FuzzPanelController.ts
+++ b/src/ui/FuzzPanelController.ts
@@ -1753,9 +1753,16 @@ ${inArgConsts}
       const lang = this._fuzzEnv.function.getLang(); // function language
       const argDefs = fn.getArgDefs();
       const counterArgDef = { id: 0 }; // Unique counter for argument ids
+      const heuristicFailValues = [
+        ...new Set(
+          (fn.isVoid() ? [undefined] : [null, undefined, Infinity, NaN]).map(
+            (v) => ValueMapper.toLang(lang, v)
+          )
+        ),
+      ].join(", "); // translate to language values, discard dupes, add commas
       const heuristicValidatorDescription = fn.isVoid()
-        ? "Heuristic validator (for void functions). Fails: timeout, exception, values !==undefined"
-        : "Heuristic validator. Fails: timeout, exception, null, undefined, Infinity, NaN";
+        ? `Heuristic validator (for void functions). Fails: timeout, exception, values!==${heuristicFailValues}`
+        : `Heuristic validator. Fails: timeout, exception, ${heuristicFailValues}`;
 
       // If fuzzer results are available, calculate how many tests passed, failed, etc.
       if (this._state === FuzzPanelState.done && this._results !== undefined) {

--- a/src/ui/FuzzPanelController.ts
+++ b/src/ui/FuzzPanelController.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
-import * as JSON5 from "json5";
+import * as JSON5 from "../Jsonn";
+import * as ValueMapper from "../fuzzer/mappers/ValueMapper";
 import * as fuzzer from "../fuzzer/Fuzzer";
 import * as fs from "fs";
 import { htmlEscape } from "escape-goat";
@@ -506,7 +507,9 @@ export class FuzzPanel {
 
     // Read the file; if it doesn't exist, load default values
     try {
-      inputTests = JSON5.parse(fs.readFileSync(jsonFile).toString());
+      inputTests = JSON5.parse<fuzzer.FuzzTests>(
+        fs.readFileSync(jsonFile).toString()
+      );
       testSet = inputTests;
     } catch (_e: unknown) {
       return this._initFuzzTestsForThisFn();
@@ -661,7 +664,7 @@ export class FuzzPanel {
    *          tests with an expected output.
    */
   private _pruneTestSet(testSet: fuzzer.FuzzTests): fuzzer.FuzzTests {
-    const prunedTestSet = JSON5.parse<typeof testSet>(JSON5.stringify(testSet));
+    const prunedTestSet = structuredClone(testSet);
     for (const fn in prunedTestSet.functions) {
       for (const test in prunedTestSet.functions[fn].tests) {
         const thisTest = prunedTestSet.functions[fn].tests[test];
@@ -1701,7 +1704,7 @@ ${inArgConsts}
       `style-src ${webview.cspSource} 'unsafe-inline' 'self'`,
       `font-src ${webview.cspSource} data: 'self'`,
       `img-src ${webview.cspSource} data: blob:`,
-      `script-src ${webview.cspSource} 'self'`,
+      `script-src ${webview.cspSource} 'self' 'wasm-unsafe-eval'`,
       `connect-src ${webview.cspSource}`,
     ].join("; ");
     const htmlHead = /*html*/ `
@@ -1715,12 +1718,6 @@ ${inArgConsts}
               "webview-ui-toolkit",
               "dist",
               "toolkit.js",
-            ])}"></script>
-            <script src="${getUri(webview, extensionUri, [
-              "node_modules",
-              "json5",
-              "dist",
-              "index.js",
             ])}"></script>
             <script type="module" src="${getUri(webview, extensionUri, [
               "build",
@@ -1753,6 +1750,7 @@ ${inArgConsts}
       }; // Summary of fuzzing results
       const env = this._fuzzEnv; // Fuzzer environment
       const fn = env.function; // Function under test
+      const lang = this._fuzzEnv.function.getLang(); // function language
       const argDefs = fn.getArgDefs();
       const counterArgDef = { id: 0 }; // Unique counter for argument ids
       const heuristicValidatorDescription = fn.isVoid()
@@ -2063,7 +2061,7 @@ ${inArgConsts}
               </div>
               <h2 style="margin-bottom:.3em;">Add a test input</h2>
               <p class="fuzzPanelDescription">
-                Enter literal Javascript input value${ argDefs.length ===1 ? "" : "s"} below in JSON format. 
+                Enter literal ${lang} input value${ argDefs.length ===1 ? "" : "s"} below. 
                 ${ argDefs.length ===1 ? "It" : "They"} won't be type-checked.
                 Click <span class="codicon codicon-run-below"></span> to test.
               </p>
@@ -2082,7 +2080,7 @@ ${inArgConsts}
                       .map(
                         (arg,i) => /*html*/
                           `<td>
-                            <vscode-text-field ${disabledFlag} id="addInputArg-${i}-value" name="addInputArg-${i}-value" placeholder="Literal value (JSON)" value=""></vscode-text-field>
+                            <vscode-text-field ${disabledFlag} id="addInputArg-${i}-value" name="addInputArg-${i}-value" placeholder="Literal value (${lang})" value=""></vscode-text-field>
                           </td>`
                       )
                       .join("\r\n")}
@@ -2535,10 +2533,11 @@ ${inArgConsts}
                         `<tr class="editorFont"><td><span>${htmlEscape(
                           i.input.tick.toString()
                         )}</span></td>${i.input.value
-                          .map((i) =>
-                            i.value === undefined
-                              ? `<td class="noInput">(no input)</td>`
-                              : `<td>${htmlEscape(JSON5.stringify(i.value))}</td>`
+                          .map(
+                            (i) =>
+                              i.value === undefined
+                                ? `<td class="noInput">(no input)</td>`
+                                : `<td>${htmlEscape(ValueMapper.toLang(lang, i.value))}</td>` // !!!!!!!!!!!!
                           )
                           .join("\r\n")}
                         <td>${htmlEscape(
@@ -2668,7 +2667,7 @@ ${inArgConsts}
 
             html += /*html*/ `
                   <div class="fuzzGridPanel${showThisGrid ? `` : ` hidden`}" id="view-${e.id}">
-                    <div class="fuzzPanelDescription">${e.description}</div>`;
+                    <div class="fuzzPanelDescription">${htmlEscape(e.description)}</div>`;
             if (e.hasGrid) {
               html += /*html*/ `
                     <div id="fuzzResultsGrid-${e.id}">
@@ -2784,6 +2783,11 @@ ${inArgConsts}
               )}
             </div>
 
+            <!-- Lamguage: for the client script to process -->
+            <div id="fuzzLang" class="hidden">
+              ${htmlEscape(JSON5.stringify(lang))}
+            </div>
+
             <!-- Fuzzer State Payload: for the client script to persist -->
             <div id="fuzzPanelState" class="hidden">
               ${htmlEscape(JSON5.stringify(this.getState()))}
@@ -2840,6 +2844,7 @@ ${inArgConsts}
     const optionalString = arg.isOptional() ? "?" : ""; // Text indication arg optionality
     const htmlEllipsis = `<span class="hidden argDef-ellipsis">...</span>`;
     const isArgArray = arg.getDim() > 0; // Is this an array argument?
+    const lang = this._fuzzEnv.function.getLang();
 
     let typeString: string; // Text indicating the type of argument
     const argTypeRef = arg.getTypeRef();
@@ -2861,7 +2866,7 @@ ${inArgConsts}
             typeString =
               constantValue === undefined
                 ? "undefined"
-                : htmlEscape(JSON5.stringify(constantValue, undefined, 2));
+                : htmlEscape(ValueMapper.toLang(lang, constantValue));
           }
           break;
       }

--- a/src/ui/FuzzPanelController.ts
+++ b/src/ui/FuzzPanelController.ts
@@ -419,7 +419,7 @@ export class FuzzPanel {
             this._saveColumnSortOrders(message.json);
             break;
           case "validator.add":
-            this._doAddValidatorCmd();
+            await this._doAddValidatorCmd();
             this._doGetValidators();
             break;
           case "validator.getList":
@@ -934,11 +934,6 @@ export class FuzzPanel {
         }
       });
 
-    // Determine if we need to add an import
-    const hasImport = Object.keys(program.imports).some(
-      (e) => e === "FuzzTestResult"
-    );
-
     const inArgs = fn.getArgDefs();
     const validatorArgs = this._getValidatorArgs(inArgs);
 
@@ -965,8 +960,13 @@ export class FuzzPanel {
           } = ${resultArgName}.out;`;
           return outVarString;
         },
-        importMapper: () => `import { FuzzTestResult } from "@nanofuzz/runtime";
+        importMapper: () => [
+          {
+            name: `FuzzTestResult`,
+            stmt: `import { FuzzTestResult } from "@nanofuzz/runtime";
 `,
+          },
+        ],
         skelMapper: (
           validatorName: string,
           validatorArgs: ReturnType<typeof this._getValidatorArgs>,
@@ -1003,8 +1003,18 @@ ${inArgConsts}
           } = ${resultArgName}['out']`;
           return outVarString;
         },
-        importMapper: () => `from nanofuzz_runtime import FuzzTestResult
+        importMapper: () => [
+          {
+            name: "FuzzTestResult",
+            stmt: `from nanofuzz_runtime import FuzzTestResult
 `,
+          },
+          {
+            name: "Literal",
+            stmt: `from typing import Literal
+`,
+          },
+        ],
         skelMapper: (
           validatorName: string,
           validatorArgs: ReturnType<typeof this._getValidatorArgs>,
@@ -1060,12 +1070,18 @@ ${inArgConsts}
 
     // Append the code skeleton to the source file
     try {
-      if (!hasImport) {
+      let importData = "";
+      skelGenerators[program.lang].importMapper().forEach((i) => {
+        // If there is no import, then add it
+        if (!Object.keys(program.imports).some((e) => e === i.name)) {
+          importData += i.stmt;
+        }
+      });
+
+      if (importData.length) {
         // Pre-pend the import & append the validator
         const fileData = fs.readFileSync(module);
-        const importStmt = Buffer.from(
-          skelGenerators[program.lang].importMapper()
-        );
+        const importStmt = Buffer.from(importData);
         const validatorFn = Buffer.from(skeleton);
         const fd = fs.openSync(module, "w+");
 
@@ -1086,7 +1102,7 @@ ${inArgConsts}
         fs.closeSync(fd);
       }
 
-      // Change focus to the generated validator
+      // Change focus and scroll to the generated validator
       try {
         const fn = ProgramFactory.fromFile(module).functions[validatorName];
         this._navigateToSource(fn.getModule(), fn.getStartOffset());

--- a/src/ui/FuzzPanelController.ts
+++ b/src/ui/FuzzPanelController.ts
@@ -2870,10 +2870,7 @@ ${inArgConsts}
         case fuzzer.ArgTag.LITERAL:
           if (arg.isConstant()) {
             const constantValue = arg.getConstantValue();
-            typeString =
-              constantValue === undefined
-                ? "undefined"
-                : htmlEscape(ValueMapper.toLang(lang, constantValue));
+            typeString = htmlEscape(ValueMapper.toLang(lang, constantValue));
           }
           break;
       }

--- a/src/ui/FuzzPanelController.ts
+++ b/src/ui/FuzzPanelController.ts
@@ -6,7 +6,7 @@ import { htmlEscape } from "escape-goat";
 import * as telemetry from "../telemetry/Telemetry";
 import * as TestAdapterFactory from "../fuzzer/adapters/TestAdapterFactory";
 import { isError, getErrorMessageOrJson } from "../fuzzer/Util";
-import { Listener } from "../extension";
+import { Listener } from "../Extension";
 import { Tester } from "../fuzzer/Fuzzer";
 import {
   applyCoverageHeatmapToEditor,

--- a/src/ui/FuzzPanelView.ts
+++ b/src/ui/FuzzPanelView.ts
@@ -1,4 +1,5 @@
-import * as JSON5 from "json5";
+import * as JSON5 from "../Jsonn";
+import * as ValueMapper from "../fuzzer/mappers/ValueMapper";
 import { getElementByIdOrThrow, getElementByIdWithTypeOrThrow } from "./Util";
 import {
   FuzzArgOverride,
@@ -11,10 +12,12 @@ import {
   isFuzzResultTab,
   Judgment,
 } from "../fuzzer/Types";
+import * as Parser from "../fuzzer/adapters/ParserAdapter";
 import {
   ArgValueType,
   ArgValueTypeWrapped,
   FuzzTestResults,
+  ProgramLanguage,
 } from "../fuzzer/Fuzzer";
 import {
   FuzzPanelFuzzRunMessage,
@@ -91,6 +94,8 @@ const defaultColumnSortOrders: FuzzSortColumns = {
 let columnSortOrders: FuzzSortColumns;
 // Fuzzer Results (filled by main during load event)
 let resultsData: FuzzTestResults;
+// Fuzzer Language (filled by main during load event)
+let lang: ProgramLanguage;
 // Results grouped by type (filled by main during load event)
 const data: Record<FuzzResultCategory, any[]> = {
   ok: [],
@@ -117,7 +122,12 @@ let coverageHeatmapIsStale = false;
  * Sets up the UI when the page is loaded, including setting up
  * event handlers and filling the output grids if data is available.
  */
-function main() {
+async function main() {
+  // Initialize the parser
+  const parserPromise = Parser.initWeb();
+
+  // --------------------- Event Handlers --------------------- //
+
   // Add event listener for the fuzz.run button
   getElementByIdOrThrow("fuzz.run").addEventListener("click", () => {
     handleFuzzRun();
@@ -235,11 +245,6 @@ function main() {
     // Undo the the parent checkbox click
     getElementByIdOrThrow("fuzz-gen-AiInputGenerator-enabled").click();
   });
-
-  // Load the fuzzer results data from the HTML
-  resultsData = JSON5.parse(
-    htmlUnescape(getElementByIdOrThrow("fuzzResultsData").innerHTML)
-  );
 
   // Add event listener for the validator buttons
   getElementByIdOrThrow("validator.add").addEventListener(
@@ -382,6 +387,13 @@ function main() {
     }); // onScroll event handler
   } // if: tabstrip found
 
+  // ----------------------- Data Loads ----------------------- //
+
+  // Load the fuzzer results data from the HTML
+  resultsData = JSON5.parse(
+    htmlUnescape(getElementByIdOrThrow("fuzzResultsData").innerHTML)
+  );
+
   // Load & display the validator functions from the HTML
   validators = JSON5.parse(
     htmlUnescape(getElementByIdOrThrow("validators").innerHTML)
@@ -464,6 +476,16 @@ function main() {
   if (Array.isArray(addlHiddenColumns)) {
     hiddenColumns.push(...addlHiddenColumns);
   }
+
+  // Get the fuzzer language
+  lang = JSON5.parse<ProgramLanguage>(
+    htmlUnescape(getElementByIdOrThrow("fuzzLang").innerHTML)
+  );
+
+  // ----------------------- Fill Grids ----------------------- //
+
+  // Await parser init
+  await parserPromise;
 
   // Fill the result grids
   if (Object.keys(resultsData).length) {
@@ -555,7 +577,9 @@ function main() {
       const inputs: Record<string, string> = {};
       e.input.forEach((i) => {
         inputs[`input: ${i.name}`] =
-          i.value === undefined ? "(no input)" : JSON5.stringify(i.value);
+          i.value === undefined
+            ? "(no input)"
+            : ValueMapper.toLang(lang, i.value);
       });
 
       // There are 0-1 outputs: if an output is present, just name it `output`
@@ -564,7 +588,9 @@ function main() {
       const outputs: Record<string, string> = {};
       e.output.forEach((o) => {
         outputs[`output`] =
-          o.value === undefined ? "undefined" : JSON5.stringify(o.value);
+          o.value === undefined
+            ? "undefined"
+            : ValueMapper.toLang(lang, o.value);
       });
       if (e.validatorException) {
         outputs[`output`] =
@@ -931,10 +957,10 @@ function getInputValues(): ArgValueTypeWrapped[] | undefined {
         tag: "ArgValueTypeWrapped",
         value:
           unparsedValue === null ||
-          unparsedValue === "undefined" ||
+          //unparsedValue === "undefined" ||
           unparsedValue === ""
             ? undefined
-            : JSON5.parse(unparsedValue),
+            : ValueMapper.fromLang(lang, unparsedValue),
       });
     } catch (_err) {
       // Error feedback
@@ -1882,8 +1908,7 @@ function handleExpectedOutput({
         } else if (expectedOutput[0].isException) {
           expectedText = "exception";
         } else {
-          // expectedText = `output value: ${JSON5.stringify(expectedOutput[0].value)}`;
-          expectedText = `output: ${JSON5.stringify(expectedOutput[0].value)}`;
+          expectedText = `output: ${ValueMapper.toLang(lang, expectedOutput[0].value)}`;
         }
       } else {
         expectedText = "value: undefined";
@@ -1954,7 +1979,7 @@ function expectedOutputHtml(
       <vscode-radio id="fuzz-radioValue${id}" ${isValueAnnotation ? " checked " : ""}>Value:</vscode-radio>
     </vscode-radio-group> 
     <div>
-      <vscode-text-field id="fuzz-expectedOutput${id}" class="${isValueAnnotation ? "" : "hidden"}" placeholder="Literal value (JSON)" value=${JSON5.stringify(defaultOutput.value)}></vscode-text-field>
+      <vscode-text-field id="fuzz-expectedOutput${id}" class="${isValueAnnotation ? "" : "hidden"}" placeholder="Literal value (${lang})" value="${htmlEscape(ValueMapper.toLang(lang,defaultOutput.value))}"></vscode-text-field>
       <span><vscode-button id="fuzz-expectedOutputOk${id}" aria-label="ok" style="display: table-cell; vertical-align: top;">ok</vscode-button></span>
       <span id="fuzz-expectedOutputMessage${id}"></span>
     </div>
@@ -1983,17 +2008,17 @@ function buildExpectedTestCase(
   const errorMessage = getElementByIdOrThrow(`fuzz-expectedOutputMessage${id}`);
   const okButton = getElementByIdOrThrow(`fuzz-expectedOutputOk${id}`);
 
-  // Check if the expected value is valid JSON
+  // Check if the expected value is valid
   const expectedValue = textField.getAttribute("current-value");
   let parsedExpectedValue: ArgValueType;
   try {
     // Attempt to parse the expected value
     parsedExpectedValue =
       expectedValue === null ||
-      expectedValue === "undefined" ||
+      // expectedValue === "undefined" ||
       expectedValue === ""
         ? undefined
-        : JSON5.parse(expectedValue);
+        : ValueMapper.fromLang(lang, expectedValue);
   } catch (_e) {
     // Only validate the value if we are doing a value check
     if ("checked" in radioValue && radioValue.checked) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3819,6 +3819,11 @@ version-range@^4.15.0:
   resolved "https://registry.yarnpkg.com/version-range/-/version-range-4.15.0.tgz#89df1e921b14d37515aab5e42ed4ac0515cab2c1"
   integrity sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==
 
+web-tree-sitter@^0.26.11:
+  version "0.26.11"
+  resolved "https://registry.yarnpkg.com/web-tree-sitter/-/web-tree-sitter-0.26.11.tgz#4cf91d060f4203b9975bf7f8f66008b1466457d6"
+  integrity sha512-Q5Dm3YTIXSXuH6FxX6RuzX2Qwpc4DPGiYMU87Wg5Z8OIStiQFiUex4zMDc0vBTw78EphaYJacncJghCHzbZptg==
+
 whatwg-encoding@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz#d0f4ef769905d426e1688f3e34381a99b60b76e5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2837,12 +2837,12 @@ node-addon-api@^4.3.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.3.0.tgz#52a1a0b475193e0928e98e0426a0d1254782b77f"
   integrity sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==
 
-node-addon-api@^8.3.0, node-addon-api@^8.5.0:
+node-addon-api@^8.2.2, node-addon-api@^8.3.0, node-addon-api@^8.5.0:
   version "8.9.0"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-8.9.0.tgz#d2467090e6195c428ccd510dfd604f01c027f0a0"
   integrity sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==
 
-node-gyp-build@^4.8.4:
+node-gyp-build@^4.8.2, node-gyp-build@^4.8.4:
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.4.tgz#8a70ee85464ae52327772a90d66c6077a900cfc8"
   integrity sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==
@@ -3640,6 +3640,14 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tree-sitter-javascript@^0.23.1:
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/tree-sitter-javascript/-/tree-sitter-javascript-0.23.1.tgz#4e49fa3ad5f996b3ac5cf4f78d6c5dd876788faf"
+  integrity sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==
+  dependencies:
+    node-addon-api "^8.2.2"
+    node-gyp-build "^4.8.2"
+
 tree-sitter-python@^0.25.0:
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/tree-sitter-python/-/tree-sitter-python-0.25.0.tgz#c1c460915cb883feb2d9ecefeb98b3794eba85f5"
@@ -3647,6 +3655,15 @@ tree-sitter-python@^0.25.0:
   dependencies:
     node-addon-api "^8.5.0"
     node-gyp-build "^4.8.4"
+
+tree-sitter-typescript@^0.23.2:
+  version "0.23.2"
+  resolved "https://registry.yarnpkg.com/tree-sitter-typescript/-/tree-sitter-typescript-0.23.2.tgz#70bc615a2f664a8e9c87c533382beca587f28ab3"
+  integrity sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==
+  dependencies:
+    node-addon-api "^8.2.2"
+    node-gyp-build "^4.8.2"
+    tree-sitter-javascript "^0.23.1"
 
 tree-sitter@^0.25.0:
   version "0.25.0"


### PR DESCRIPTION
When generating a Python property validator, if `Literal` is not already imported, also generate a `Literal` import statement.