### PR TITLE
feat: bring back `test again` button

### DIFF
--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -529,9 +529,9 @@ export class Tester {
         update({
           msg: `Testing ${
             cancelFn && cancelFn() ? "paused" : "finished"
-          }.\r\n  Tests passed: ${
+          }.\r\n  Passed: ${
             runStats.counters.passedTests
-          }\r\n  Tests failed: ${runStats.counters.failedTests}`,
+          }\r\n  Failed: ${runStats.counters.failedTests}`,
           milestone: false,
           pct: 100,
         });
@@ -727,13 +727,13 @@ export class Tester {
 
       // Front-end status update
       update({
-        msg: `${cancelFn && cancelFn() && stillInjecting ? "Pause pending retest of prior inputs.\r\n" : ""}${stillInjecting ? "Retesting prior" : "Generating new test"} input# ${
+        msg: `${cancelFn && cancelFn() && stillInjecting ? "Pause pending retest of prior inputs.\r\n" : ""}${stillInjecting ? "Retesting prior" : "Testing new"} example# ${
           runStats.counters.passedTests + runStats.counters.failedTests + 1
         }: ${this._function.getName()}(${result.input
           .map((i) => ValueMapper.toLang(lang, i.value))
-          .join(",")})\r\n  Tests passed: ${
+          .join(",")})\r\n  Passed: ${
           runStats.counters.passedTests
-        }\r\n  Tests failed: ${runStats.counters.failedTests}`,
+        }\r\n  Failed: ${runStats.counters.failedTests}`,
         pct: typeof stopCondition === "number" ? stopCondition : 100,
       });
 

--- a/src/ui/FuzzPanelController.ts
+++ b/src/ui/FuzzPanelController.ts
@@ -378,6 +378,14 @@ export class FuzzPanel {
           case "fuzz.run":
             this._hideCoverageHeatmap();
             this._doGetValidators();
+            if (this._results) {
+              this._testClear(message.json);
+            }
+            this._testRun(message.json, { gen: true });
+            break;
+          case "fuzz.continue":
+            this._hideCoverageHeatmap();
+            this._doGetValidators();
             this._testRun(message.json, { gen: true });
             break;
           case "fuzz.retest":
@@ -1973,6 +1981,7 @@ ${inArgConsts}
       // Determine button states
       const activeButtons: {
         run?: true;
+        continue?: true;
         pause?: true;
         retest?: true;
         clear?: true;
@@ -1989,6 +1998,7 @@ ${inArgConsts}
             activeButtons.run = true;
             activeButtons.options = true;
             if (this._results) {
+              activeButtons.continue = true;
               activeButtons.retest = true;
               activeButtons.clear = true;
             }
@@ -1996,6 +2006,7 @@ ${inArgConsts}
           }
           case "paused": {
             activeButtons.run = true;
+            activeButtons.continue = true;
             activeButtons.retest = true;
             activeButtons.clear = true;
             activeButtons.add = true;
@@ -2015,6 +2026,7 @@ ${inArgConsts}
           case "crashed": {
             activeButtons.run = true;
             if (this._results) {
+              activeButtons.continue = true;
               activeButtons.retest = true;
               activeButtons.clear = true;
             }
@@ -2042,30 +2054,36 @@ ${inArgConsts}
       html += /*html*/ `
             <!-- Button Bar -->
             <div>
-              <vscode-button ${disabledFlag} ${!activeButtons.run ? `class="hidden"` : ""} id="fuzz.run" class="tooltipped tooltipped-ne" appearance="primary icon" aria-label="${this._results ? "Generate more tests": "Generate tests"}">
-                ${this._results ? `<span class="codicon codicon-play"></span><span class="codicon codicon-add"></span>` : `<span class="codicon codicon-play"></span>`}
+              <vscode-button ${disabledFlag} ${!activeButtons.run ? `class="hidden"` : ""} id="fuzz.run" class="tooltipped tooltipped-ne" appearance="primary icon" aria-label="${this._results ? "Test again": "Start testing"}">
+                ${this._results ? `<span class="codicon codicon-debug-rerun"></span>` : `<span class="codicon codicon-play"></span>`}
               </vscode-button>
-              <span class="${!activeButtons.pause ? `hidden ` : ""}tooltipped tooltipped-ne" aria-label="Pause testing">
+              <span class="${!activeButtons.pause ? `hidden ` : ""}tooltipped tooltipped-ne" appearance="primary icon" aria-label="Pause testing">
                 <vscode-button id="fuzz.pause" appearance="primary icon">
                   <span class="codicon codicon-debug-pause"></span>
                 </vscode-button>
               </span>
-              <vscode-button ${disabledFlag} ${!activeButtons.retest ? `class="hidden"` : ""} id="fuzz.retest" class="tooltipped tooltipped-ne" appearance="secondary icon" aria-label="Retest these results">
-                <span class="codicon codicon-debug-rerun"></span>
+              <vscode-button ${disabledFlag} ${!activeButtons.retest ? `class="hidden"` : ""} id="fuzz.retest" class="tooltipped tooltipped-ne" appearance="secondary icon" aria-label="Retest these examples">
+                <span class="codicon codicon-sync"></span>
+              </vscode-button>
+              <vscode-button ${disabledFlag} ${!activeButtons.continue ? `class="hidden"` : ""} id="fuzz.continue" class="tooltipped tooltipped-ne" appearance="secondary icon" aria-label="Generate more examples"}">
+                <span class="codicon codicon-debug-continue"></span>
               </vscode-button>
               <span ${!activeButtons.add ? `class="hidden"` : ""}>
-                <vscode-button ${disabledFlag} id="fuzz.addTestInputOptions.open" class="tooltipped tooltipped-n" appearance="secondary icon" aria-label="Add one test input">
+                <vscode-button ${disabledFlag} id="fuzz.addTestInputOptions.open" class="tooltipped tooltipped-n" appearance="secondary icon" aria-label="Add one example">
                   <span class="codicon codicon-add"></span>
                 </vscode-button>
-                <vscode-button ${disabledFlag} id="fuzz.addTestInputOptions.close" class="hidden tooltipped tooltipped-n" appearance="secondary icon depressed" aria-label="Add a test input (close)">
+                <vscode-button ${disabledFlag} id="fuzz.addTestInputOptions.close" class="hidden tooltipped tooltipped-n" appearance="secondary icon depressed" aria-label="Add one example (close)">
                   <span class="codicon codicon-add"></span>
                 </vscode-button>
               </span>
+
+              ${activeButtons.coverage ? "&nbsp;" : ""}
+
               <span ${!activeButtons.coverage ? `class="hidden"` : ``}>
                 <span class="tooltipped tooltipped-n" aria-label="${activeButtons.coverage === "disabled" ? "Coverage measure is disabled" : "Show coverage heatmap"}">
                   <vscode-button ${disabledFlag || activeButtons.coverage === "disabled" ? " disabled" : ""} id="fuzz.coverage.show" appearance="secondary icon">
                     <span class="codicon codicon-coverage"></span>
-                  </vscode-button>  
+                  </vscode-button>
                 </span>
                 <span class="tooltipped tooltipped-n" aria-label="${activeButtons.coverage === "disabled" ? "Coverage measure is disabled" : "Hide coverage heatmap"}">
                   <vscode-button ${disabledFlag || activeButtons.coverage === "disabled" ? " disabled" : ""} id="fuzz.coverage.hide" appearance="secondary icon depressed" class="hidden">
@@ -2077,7 +2095,7 @@ ${inArgConsts}
               ${activeButtons.run || activeButtons.pause || activeButtons.retest || activeButtons.add || activeButtons.coverage ? `&nbsp;` : ""}
 
               <span ${!activeButtons.clear ? `class="hidden"` : ""}>
-                <vscode-button ${disabledFlag} id="fuzz.clear" class="tooltipped tooltipped-n" appearance="secondary icon" aria-label="Discard these results">
+                <vscode-button ${disabledFlag} id="fuzz.clear" class="tooltipped tooltipped-n" appearance="secondary icon" aria-label="Start over">
                   <span class="codicon codicon-discard"></span>
                 </vscode-button>
                 &nbsp;
@@ -3779,6 +3797,7 @@ export type FuzzPanelMessageFromWebView =
   | {
       command:
         | "fuzz.run"
+        | "fuzz.continue"
         | "fuzz.retest"
         | "fuzz.addTestInput"
         | "fuzz.clear"

--- a/src/ui/FuzzPanelView.ts
+++ b/src/ui/FuzzPanelView.ts
@@ -133,6 +133,11 @@ async function main() {
     handleFuzzRun();
   });
 
+  // Add event listener for the fuzz.continue button
+  getElementByIdOrThrow("fuzz.continue").addEventListener("click", () => {
+    handleFuzzContinue();
+  });
+
   // Add event listener for the fuzz.retest button
   getElementByIdOrThrow("fuzz.retest").addEventListener("click", () => {
     handleFuzzRetest();
@@ -2065,6 +2070,18 @@ function buildExpectedTestCase(
 function handleFuzzRun() {
   const message: FuzzPanelMessageFromWebView = {
     command: "fuzz.run",
+    json: JSON5.stringify(getConfigFromUi()),
+  };
+  vscode.postMessage(message);
+} // fn: handleFuzzRun
+
+/**
+ * Handles the fuzz.continue button onClick() event: retrieves the fuzzer options
+ * from the UI and sends them to the extension to start the fuzzer.
+ */
+function handleFuzzContinue() {
+  const message: FuzzPanelMessageFromWebView = {
+    command: "fuzz.continue",
     json: JSON5.stringify(getConfigFromUi()),
   };
   vscode.postMessage(message);


### PR DESCRIPTION
This PR brings back the `test again` button that was present in prior versions of NaNofuzz. The `test again` button threw away the non-saved test set and generated a new set.

During v0.4 development, we replaced that single button with new `continue` and `re-test` buttons that generated additional examples and re-tested the existing set of examples, respectively. The idea was to use guidance from previous runs, like coverage data and interesting examples, to inform input generation for the next inputs generated. The prior `test again` method was still possible, but it required two button presses plus a confusing screen transition.

With this change, both the original `test again` and the new `continue, re-test` methods are both equally easy to do, and the distracting screen transition is no longer present for `test again`.