### PR TITLE
fix: extract Python function docstrings

### DIFF
--- a/src/fuzzer/analysis/python/PythonProgram.test.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.test.ts
@@ -95,6 +95,36 @@ def greeting(name: a) -> a:
     expect(PythonProgram.getTypeAnnotation(args[0])).toEqual("a");
   });
 
+  it("extracts Python function docstrings", () => {
+    const functions = ProgramFactory.fromSource(
+      () => `def plain():
+  "one line"
+def multiline():
+  r"""first line
+  second line"""
+def concatenated():
+  "first" " second"
+def formatted():
+  f"value {1}"
+def not_first():
+  pass
+  "not a docstring"`,
+      "python"
+    ).functionsExported;
+
+    expect(
+      ["plain", "multiline", "concatenated", "formatted", "not_first"].map(
+        (name) => functions[name].getCmt()
+      )
+    ).toEqual([
+      '"one line"',
+      'r"""first line\n  second line"""',
+      '"first" " second"',
+      undefined,
+      undefined,
+    ]);
+  });
+
   it("extracts primitive, collection, union, and literal aliases", () => {
     // PEP 695 aliases are analyzed without importing a runtime typing module.
     const types = ProgramFactory.fromSource(

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -881,6 +881,23 @@ export class PythonProgram extends AbstractProgram {
     if (!nameNode || !defNode) {
       return undefined;
     }
+    const docstringNode = defNode.node
+      .childForFieldName("body")
+      ?.namedChild(0)
+      ?.namedChild(0);
+    const stringNodes =
+      docstringNode?.type === "concatenated_string"
+        ? docstringNode.namedChildren
+        : docstringNode
+          ? [docstringNode]
+          : [];
+    const cmt =
+      stringNodes.length > 0 &&
+      stringNodes.every(
+        (node) => node.type === "string" && !/^[^'"]*[bf]/i.test(node.text)
+      )
+        ? docstringNode?.text
+        : undefined;
     try {
       if (typeNode) {
         isVoid = typeNode.node.namedChild(0)?.type === "none";
@@ -912,7 +929,7 @@ export class PythonProgram extends AbstractProgram {
         )
         .map((arg) => this._getTypeRefFromAstNode(arg)),
       returnType,
-      // not sure how to get docstring yet
+      cmt,
     };
   }
 


### PR DESCRIPTION
## Summary

- extract the first string expression in Python function bodies into the function comment metadata
- support plain, raw multiline, and implicitly concatenated docstrings
- exclude formatted/byte strings and string expressions that are not the first statement

Fixes #417

## Tests

- `node --no-experimental-strip-types ./node_modules/jasmine/bin/jasmine.js src/fuzzer/analysis/python/PythonProgram.test.ts` (29 specs)
- `node --no-experimental-strip-types ./node_modules/jasmine/bin/jasmine.js` (229 specs)
- `eslint src/fuzzer/analysis/python/PythonProgram.ts src/fuzzer/analysis/python/PythonProgram.test.ts`
- `yarn build`