### PR TITLE
chore: build: sync Python runtime package metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,10 +71,12 @@ jobs:
         run: |
           source .venv/bin/activate
           cd packages/runtime/python
+          python prebuild.py
           python -m build
       - name: Build Python package (Windows)
         if: runner.os == 'Windows'
         run: |
           .venv\Scripts\activate
           cd packages\runtime\python
+          python prebuild.py
           python -m build

--- a/packages/runtime/python/LICENSE
+++ b/packages/runtime/python/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Penrose
+Copyright (c) 2021-2026 Penrose
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/runtime/python/prebuild.py
+++ b/packages/runtime/python/prebuild.py
@@ -1,0 +1,43 @@
+"""Synchronize package metadata before building the Python runtime."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tomllib
+from pathlib import Path
+
+
+PACKAGE_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = PACKAGE_DIR.parents[2]
+
+
+def _release_version(version: str) -> str:
+    """Return the major, minor, and patch portion used by the npm runtime check."""
+    return version.split("-", 1)[0]
+
+
+def sync_package_metadata(
+    repository_root: Path = REPOSITORY_ROOT,
+    package_dir: Path = PACKAGE_DIR,
+) -> None:
+    """Verify package versions and copy the repository license into the package."""
+    root_package = json.loads((repository_root / "package.json").read_text())
+    with (package_dir / "pyproject.toml").open("rb") as pyproject_file:
+        python_package = tomllib.load(pyproject_file)
+
+    root_version = _release_version(root_package["version"])
+    python_version = _release_version(python_package["project"]["version"])
+    if python_version != root_version:
+        raise RuntimeError(
+            "Package versions are not the same! "
+            f"Package: {root_version}; Python runtime: {python_version}"
+        )
+
+    shutil.copyfile(repository_root / "LICENSE", package_dir / "LICENSE")
+    print("Package versions match")
+    print("Copied repository license")
+
+
+if __name__ == "__main__":
+    sync_package_metadata()

--- a/packages/runtime/python/pyproject.toml
+++ b/packages/runtime/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nanofuzz-runtime"
-version = "0.3.10"
+version = "0.3.6"
 description = "Runtime support and types for NaNofuzz"
 readme = "README.md"
 authors = [

--- a/packages/runtime/python/tests/test_prebuild.py
+++ b/packages/runtime/python/tests/test_prebuild.py
@@ -1,0 +1,44 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = Path(__file__).parents[1] / "prebuild.py"
+SPEC = importlib.util.spec_from_file_location("python_runtime_prebuild", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+PREBUILD = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PREBUILD)
+
+
+def _write_package_files(
+    root: Path, package: Path, root_version: str, package_version: str
+):
+    root.mkdir()
+    package.mkdir(parents=True)
+    (root / "package.json").write_text(json.dumps({"version": root_version}))
+    (root / "LICENSE").write_text("current license\n")
+    (package / "pyproject.toml").write_text(
+        f'[project]\nversion = "{package_version}"\n'
+    )
+
+
+def test_sync_package_metadata_copies_license(tmp_path):
+    root = tmp_path / "repository"
+    package = root / "packages" / "runtime" / "python"
+    _write_package_files(root, package, "1.2.3-beta.1", "1.2.3")
+    (package / "LICENSE").write_text("stale license\n")
+
+    PREBUILD.sync_package_metadata(root, package)
+
+    assert (package / "LICENSE").read_text() == "current license\n"
+
+
+def test_sync_package_metadata_rejects_version_mismatch(tmp_path):
+    root = tmp_path / "repository"
+    package = root / "packages" / "runtime" / "python"
+    _write_package_files(root, package, "1.2.3", "1.2.4")
+
+    with pytest.raises(RuntimeError, match="Package versions are not the same"):
+        PREBUILD.sync_package_metadata(root, package)


### PR DESCRIPTION
## Summary
- add a Python prebuild script that verifies the runtime version matches the root package
- copy the current repository license into the Python runtime before packaging
- run the prebuild step in Linux, macOS, and Windows CI builds
- align the current Python runtime version and license, with regression tests for sync and mismatch paths

## Validation
- `python -m pytest packages/runtime/python/tests/test_prebuild.py -q` (2 passed)
- `python packages/runtime/python/prebuild.py` using Python 3.12
- `python -m pip wheel packages/runtime/python --no-deps` (built `nanofuzz_runtime-0.3.6-py3-none-any.whl`)
- `ruff check packages/runtime/python/prebuild.py packages/runtime/python/tests/test_prebuild.py`
- `ruff format --check packages/runtime/python/prebuild.py packages/runtime/python/tests/test_prebuild.py`
- `python -m py_compile packages/runtime/python/prebuild.py packages/runtime/python/tests/test_prebuild.py`
- `git diff --check`

Closes #413.

AI assistance was used to inspect the existing TypeScript prebuild pattern, prepare the Python implementation and tests, and run validation. The final diff was reviewed before submission.