### PR TITLE
chore: finish JSONN migration

### DIFF
--- a/src/fuzzer/Util.ts
+++ b/src/fuzzer/Util.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
 import * as fs from "node:fs";
-import JSON5 from "json5";
+import * as JSONN from "../Jsonn";
 
 /**
  * Type guard function that returns true if the input object
@@ -48,14 +48,14 @@ export function normalizePathForKey(rawPath: string): string {
  * Extracts an error message from an unknown exception value.
  *
  * If the value is an Error-like object (has message and stack),
- * returns the message. Otherwise, stringifies the value using JSON5.
+ * returns the message. Otherwise, stringifies the value using JSONN.
  *
  * @param e the exception value to extract a message from
  *
  * @returns the error message string
  */
 export function getErrorMessageOrJson(e: unknown): string {
-  return isError(e) ? e.message : JSON5.stringify(e);
+  return isError(e) ? e.message : JSONN.stringify(e);
 } // fn: getErrorMessageOrJson
 
 /**

--- a/src/fuzzer/adapters/LlmAdapter.ts
+++ b/src/fuzzer/adapters/LlmAdapter.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { ArgValueType, ProgramLanguage } from "../analysis/Types";
-import * as JSON5 from "json5";
+import * as JSONN from "../../Jsonn";
 import { FunctionDef } from "../analysis/FunctionDef";
 import * as nodellm from "@node-llm/core";
 import { isError } from "../Util";
@@ -21,7 +21,7 @@ export class LlmAdapter {
     LlmAdapter._handleDebug();
 
     const cfg = LlmAdapter._getConfig();
-    this._cfgString = JSON5.stringify(cfg);
+    this._cfgString = JSONN.stringify(cfg);
 
     if (!LlmAdapter.isConfigured()) {
       throw new Error("AI Models are disabled");
@@ -55,7 +55,7 @@ export class LlmAdapter {
    * @returns `true` if the LLM config has changed since instantiation
    */
   public isStale(): boolean {
-    return JSON5.stringify(LlmAdapter._getConfig()) !== this._cfgString;
+    return JSONN.stringify(LlmAdapter._getConfig()) !== this._cfgString;
   } // fn: isStale
 
   /**
@@ -105,7 +105,7 @@ export class LlmAdapter {
       };
     }
     const inputs: { programInputs: { [k: string]: ArgValueType }[] } =
-      JSON5.parse(response.response);
+      JSONN.parse(response.response);
 
     // Sanity check llm output
     if (

--- a/src/fuzzer/analysis/ArgDef.test.ts
+++ b/src/fuzzer/analysis/ArgDef.test.ts
@@ -1,7 +1,7 @@
 import { ArgTag, ArgType, ArgOptions, Interval } from "./Types";
 import { ArgDef } from "./ArgDef";
 import seedrandom from "seedrandom";
-import * as JSON5 from "../../Jsonn";
+import * as JSONN from "../../Jsonn";
 import { ArgDefValidator } from "./ArgDefValidator";
 import { ArgDefGenerator } from "./ArgDefGenerator";
 import { ArgDefMutator } from "./ArgDefMutator";
@@ -450,7 +450,7 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
         let input = gen.next();
         const isValid = val.validate(input);
         if (!isValid) {
-          const itxt = JSON5.stringify(input[0]);
+          const itxt = JSONN.stringify(input[0]);
           stats.gens.invalid++;
           stats.specsWithErrors[stxt] = stats.specsWithErrors[stxt] ?? {};
           stats.specsWithErrors[stxt][itxt] =
@@ -464,13 +464,13 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
 
           let k = 100;
           while (k--) {
-            const inputStringBefore = JSON5.stringify(input);
+            const inputStringBefore = JSONN.stringify(input);
             const muts = ArgDefMutator.getMutators(spec, input, prng);
             if (muts.length) {
               const index = Math.floor(prng() * (muts.length - 1));
               const mut = muts[index];
               mut.fn(); // mutate the input
-              const inputStringAfter = JSON5.stringify(input);
+              const inputStringAfter = JSONN.stringify(input);
               if (inputStringBefore === inputStringAfter) {
                 stats.muts.dupe++;
                 dupeMutators[mut.name] = (failingMutators[mut.name] ?? 0) + 1;
@@ -489,7 +489,7 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
 
                 // Revert to the previous input so that we don't confuse
                 // the issue about which mutator broke the input chain
-                input = JSON5.parse<typeof input>(inputStringBefore);
+                input = JSONN.parse<typeof input>(inputStringBefore);
               } else {
                 stats.muts.valid++;
               }
@@ -525,17 +525,17 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
     console.debug(
       `${
         Object.keys(failingMutators).length
-      } failing mutators: ${JSON5.stringify(failingMutators, null, 3)}`
+      } failing mutators: ${JSONN.stringify(failingMutators, null, 3)}`
     );
     console.debug(
-      `${Object.keys(dupeMutators).length} dupe mutators: ${JSON5.stringify(
+      `${Object.keys(dupeMutators).length} dupe mutators: ${JSONN.stringify(
         dupeMutators,
         null,
         3
       )}`
     );
 
-    console.debug(`Stats: ${JSON5.stringify(stats, null, 3)}`);
+    console.debug(`Stats: ${JSONN.stringify(stats, null, 3)}`);
 
     expect(stats.gens.valid).not.toBe(0);
     expect(stats.gens.invalid).toBe(0);
@@ -552,7 +552,7 @@ function abbrSpec(spec: ArgDef<ArgType>, indents = 0): string[] {
   const line: string[] = [];
   line.push(space);
   line.push(`${spec.getName()}:${TypescriptProgram.getTypeAnnotation(spec)}`);
-  line.push(`dims: ${JSON5.stringify(spec.getOptions().dimLength)}`);
+  line.push(`dims: ${JSONN.stringify(spec.getOptions().dimLength)}`);
   if (spec.isNoInput()) line.push(`NOINPUT`);
   if (spec.isOptional()) line.push(`OPTIONAL`);
   if (spec.getType() === ArgTag.NUMBER && spec.getOptions().numInteger)
@@ -562,7 +562,7 @@ function abbrSpec(spec: ArgDef<ArgType>, indents = 0): string[] {
     spec.getType() === ArgTag.BOOLEAN ||
     spec.getType() === ArgTag.LITERAL
   )
-    line.push(`range: ${JSON5.stringify(spec.getIntervals())}`);
+    line.push(`range: ${JSONN.stringify(spec.getIntervals())}`);
 
   const children = spec.getChildren();
   const clines: string[] = [];

--- a/src/fuzzer/analysis/ArgDefMutator.ts
+++ b/src/fuzzer/analysis/ArgDefMutator.ts
@@ -2,7 +2,7 @@ import { ArgDef } from "./ArgDef";
 import { ArgDefGenerator } from "./ArgDefGenerator";
 import { ArgDefValidator } from "./ArgDefValidator";
 import { ArgTag, ArgType, ArgValueType, ArgValueTypeWrapped } from "./Types";
-import * as JSON5 from "../../Jsonn";
+import * as JSONN from "../../Jsonn";
 
 /**
  * Utilities for mutating values described by an ArgDef spec
@@ -32,7 +32,7 @@ export class ArgDefMutator {
       throw new Error(
         `Different number of inputs (${value.length}) relative to ArgDefs (${
           ArgDef.length
-        }) for input: ${JSON5.stringify(value)}`
+        }) for input: ${JSONN.stringify(value)}`
       );
     }
 
@@ -67,7 +67,7 @@ export class ArgDefMutator {
               value: [...a].reverse(),
               path: [...path],
             },
-          ].filter((e) => JSON5.stringify(e.value) !== JSON5.stringify(a))
+          ].filter((e) => JSONN.stringify(e.value) !== JSONN.stringify(a))
         );
       } // if: array length > 1
 
@@ -89,7 +89,7 @@ export class ArgDefMutator {
               },
             ].filter(
               (e) =>
-                JSON5.stringify(e.value) !== JSON5.stringify(a) &&
+                JSONN.stringify(e.value) !== JSONN.stringify(a) &&
                 options.dimLength[level - 1].max >= e.value.length &&
                 options.dimLength[level - 1].min <= e.value.length
             ) // filter
@@ -297,7 +297,7 @@ export class ArgDefMutator {
                         },
                       ].filter(
                         (e) =>
-                          JSON5.stringify(e.value) !== JSON5.stringify(oldValue)
+                          JSONN.stringify(e.value) !== JSONN.stringify(oldValue)
                       )
                     );
                   } else {
@@ -364,7 +364,7 @@ export class ArgDefMutator {
                   },
                 ].filter(
                   (e) =>
-                    JSON5.stringify(e.value) !== JSON5.stringify(value) &&
+                    JSONN.stringify(e.value) !== JSONN.stringify(value) &&
                     !(e.value === undefined && this.isNull(value))
                 )
               );
@@ -390,7 +390,7 @@ export class ArgDefMutator {
                         },
                       ].filter(
                         (e) =>
-                          JSON5.stringify(e.value) !== JSON5.stringify(oldValue)
+                          JSONN.stringify(e.value) !== JSONN.stringify(oldValue)
                       )
                     );
                   } else {
@@ -417,7 +417,7 @@ export class ArgDefMutator {
 
           case ArgTag.UNRESOLVED: {
             throw new Error(
-              `Encountered unresolved ArgDef: ${JSON5.stringify(spec)}`
+              `Encountered unresolved ArgDef: ${JSONN.stringify(spec)}`
             );
           }
         } // switch: ArgDef type
@@ -472,9 +472,9 @@ export class ArgDefMutator {
           element = element[String(key)];
         } else {
           throw new Error(
-            `Cannot follow path through non-array / non-object. Input: ${JSON5.stringify(
+            `Cannot follow path through non-array / non-object. Input: ${JSONN.stringify(
               value
-            )}, Element: ${JSON5.stringify(element)}, path: ${JSON5.stringify(
+            )}, Element: ${JSONN.stringify(element)}, path: ${JSONN.stringify(
               path
             )} at step: ${step}`
           );
@@ -487,9 +487,9 @@ export class ArgDefMutator {
           element[String(key)] = newValue;
         } else {
           throw new Error(
-            `Cannot mutate value through non-array / non-object. Input: ${JSON5.stringify(
+            `Cannot mutate value through non-array / non-object. Input: ${JSONN.stringify(
               value
-            )}, Element: ${JSON5.stringify(element)}, Path: ${JSON5.stringify(
+            )}, Element: ${JSONN.stringify(element)}, Path: ${JSONN.stringify(
               path
             )} at step: ${step}`
           );

--- a/src/fuzzer/analysis/typescript/TypescriptProgram.ts
+++ b/src/fuzzer/analysis/typescript/TypescriptProgram.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/switch-exhaustiveness-check */
-import * as JSON5 from "json5";
+import * as JSONN from "../../../Jsonn";
 import * as ValueMapper from "../../mappers/ValueMapper";
 import { removeParents } from "../Util";
 import { parse, ParseResult } from "@babel/parser";
@@ -372,7 +372,7 @@ export class TypescriptProgram extends AbstractProgram {
 
     if (!typeRef.typeRefName) {
       throw new Error(
-        `Internal error: typeRef is undefined in Typeref (${JSON5.stringify(
+        `Internal error: typeRef is undefined in Typeref (${JSONN.stringify(
           typeRef
         )})`
       );
@@ -577,7 +577,7 @@ export class TypescriptProgram extends AbstractProgram {
         // Throw an error if type annotations are missing
         if (!node.typeAnnotation) {
           throw new Error(
-            `Missing type annotation (already transpiled to JS?): ${JSON5.stringify(
+            `Missing type annotation (already transpiled to JS?): ${JSONN.stringify(
               node,
               removeParents
             )}`
@@ -588,7 +588,7 @@ export class TypescriptProgram extends AbstractProgram {
           node.typeAnnotation.type === "TypeAnnotation"
         ) {
           throw new Error(
-            `This type of type annotation is not supported: ${JSON5.stringify(
+            `This type of type annotation is not supported: ${JSONN.stringify(
               node,
               removeParents
             )}`
@@ -618,7 +618,7 @@ export class TypescriptProgram extends AbstractProgram {
           thisType.name = node.key.name;
         } else {
           throw new Error(
-            `Unsupported property key type: ${JSON5.stringify(
+            `Unsupported property key type: ${JSONN.stringify(
               node,
               removeParents
             )}`
@@ -758,7 +758,7 @@ export class TypescriptProgram extends AbstractProgram {
       default:
         throw new Error(
           "Unsupported type annotation: " +
-            JSON5.stringify(node, removeParents, 2)
+            JSONN.stringify(node, removeParents, 2)
         );
     }
   } // fn: _getTypeFromAstNode()
@@ -781,7 +781,7 @@ export class TypescriptProgram extends AbstractProgram {
     }
     throw new Error(
       "Unsupported literal value type in type annotation: " +
-        JSON5.stringify(node, removeParents, 2)
+        JSONN.stringify(node, removeParents, 2)
     );
   } // fn: _getLiteralValueFromNode()
 
@@ -807,7 +807,7 @@ export class TypescriptProgram extends AbstractProgram {
         return this._getChildrenFromNode(node.typeAnnotation);
       case "TSTypeReference":
         throw new Error(
-          `Internal Error: Unresolved type reference found: ${JSON5.stringify(
+          `Internal Error: Unresolved type reference found: ${JSONN.stringify(
             node,
             removeParents
           )}`
@@ -819,7 +819,7 @@ export class TypescriptProgram extends AbstractProgram {
           else
             throw new Error(
               "Unsupported object property type annotation: " +
-                JSON5.stringify(member, removeParents, 2)
+                JSONN.stringify(member, removeParents, 2)
             );
         });
       }
@@ -861,7 +861,7 @@ export class TypescriptProgram extends AbstractProgram {
               else
                 throw new Error(
                   "Unsupported object property type annotation: " +
-                    JSON5.stringify(member, removeParents, 2)
+                    JSONN.stringify(member, removeParents, 2)
                 );
             });
           }
@@ -869,7 +869,7 @@ export class TypescriptProgram extends AbstractProgram {
           default:
             throw new Error(
               "Unsupported object type annotation: " +
-                JSON5.stringify(innerNode, removeParents, 2)
+                JSONN.stringify(innerNode, removeParents, 2)
             );
         }
       }
@@ -888,7 +888,7 @@ export class TypescriptProgram extends AbstractProgram {
       default:
         throw new Error(
           "Unsupported type annotation: " +
-            JSON5.stringify(node, removeParents, 2)
+            JSONN.stringify(node, removeParents, 2)
         );
     }
   } // fn: _getChildrenFromNode()
@@ -937,7 +937,7 @@ export class TypescriptProgram extends AbstractProgram {
           );
           unsupported[name] = {
             reason: msg,
-            node: JSON5.stringify(path.node),
+            node: JSONN.stringify(path.node),
           };
         }
       }, // enter

--- a/src/fuzzer/generators/AiInputGenerator.ts
+++ b/src/fuzzer/generators/AiInputGenerator.ts
@@ -6,7 +6,7 @@ import {
   ArgValueTypeWrapped,
   ProgramLanguage,
 } from "../analysis/Types";
-import * as JSON5 from "json5";
+import * as JSONN from "../../Jsonn";
 import * as ValueMapper from "../mappers/ValueMapper";
 import { LlmAdapter } from "../adapters/LlmAdapter";
 import { ArgDef, FunctionDef, InputAndSource } from "../Fuzzer";
@@ -195,7 +195,7 @@ export class AiInputGenerator extends AbstractInputGenerator {
           });
           if (invalidInputs.length && LlmAdapter.isDebugConfigured()) {
             console.debug(
-              `Discarded ${invalidInputs.length} of ${invalidInputs.length + validInputs.length} LLM inputs for being invalid: ${JSON5.stringify(invalidInputs, null, 2)}`
+              `Discarded ${invalidInputs.length} of ${invalidInputs.length + validInputs.length} LLM inputs for being invalid: ${JSONN.stringify(invalidInputs, null, 2)}`
             );
           }
 

--- a/src/fuzzer/measures/PythonCoverageMeasure.ts
+++ b/src/fuzzer/measures/PythonCoverageMeasure.ts
@@ -9,7 +9,7 @@ import {
 import { FuzzTestResult, FuzzTestResults, InputAndSource } from "../Fuzzer";
 import { CoverageInfo, PythonRunner } from "../runners/PythonRunner";
 import { AbstractRunner, Arc } from "../runners/AbstractRunner";
-import * as JSON5 from "json5";
+import * as JSONN from "../../Jsonn";
 import { normalizePathForKey } from "../Util";
 import {
   AbstractCoverageMeasure,
@@ -236,8 +236,8 @@ export class PythonCoverageMeasure extends AbstractCoverageMeasure {
             const fileSummary = pyCoverageMap
               .fileCoverageFor(filePath)
               .toSummary();
-            const fileMap = JSON5.parse<FileCoverage>(
-              JSON5.stringify(pyCoverageMap.fileCoverageFor(filePath))
+            const fileMap = JSONN.parse<FileCoverage>(
+              JSONN.stringify(pyCoverageMap.fileCoverageFor(filePath))
             );
             // Omit functions and branches with no hits
             for (const k of Object.keys(fileMap.f)) {

--- a/src/fuzzer/measures/TypescriptCoverageMeasure.ts
+++ b/src/fuzzer/measures/TypescriptCoverageMeasure.ts
@@ -1,4 +1,4 @@
-import * as JSON5 from "json5";
+import * as JSONN from "../../Jsonn";
 import { createInstrumenter } from "istanbul-lib-instrument";
 import { createSourceMapStore, MapStore } from "istanbul-lib-source-maps";
 import { RawSourceMap } from "source-map";
@@ -217,8 +217,8 @@ export class TypescriptCoverageMeasure extends AbstractCoverageMeasure {
             const fileSummary = tsCoverageMap
               .fileCoverageFor(filePath)
               .toSummary();
-            const fileMap = JSON5.parse<FileCoverage>(
-              JSON5.stringify(tsCoverageMap.fileCoverageFor(filePath))
+            const fileMap = JSONN.parse<FileCoverage>(
+              JSONN.stringify(tsCoverageMap.fileCoverageFor(filePath))
             );
             // Omit functions and branches with no hits
             for (const k of Object.keys(fileMap.f)) {

--- a/src/telemetry/Logger.ts
+++ b/src/telemetry/Logger.ts
@@ -1,6 +1,6 @@
 import * as util from "util";
 import * as vscode from "vscode";
-import * as JSON5 from "json5";
+import * as JSONN from "../Jsonn";
 
 /**
  * Lightweight storage for event data prior to de-staging.
@@ -56,7 +56,7 @@ export class Logger {
       this.log = []; // Clear the persisted data
       vscode.workspace.fs.writeFile(
         chunkUri,
-        Buffer.from(JSON5.stringify(logCopy))
+        Buffer.from(JSONN.stringify(logCopy))
       );
     } else {
       console.debug("No telemetry log data to persist");

--- a/src/ui/FuzzPanelController.ts
+++ b/src/ui/FuzzPanelController.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import * as JSON5 from "../Jsonn";
+import * as JSONN from "../Jsonn";
 import * as ValueMapper from "../fuzzer/mappers/ValueMapper";
 import * as fuzzer from "../fuzzer/Fuzzer";
 import * as fs from "fs";
@@ -99,7 +99,7 @@ export class FuzzPanel {
     options: fuzzer.FuzzOptions
   ): FuzzPanel {
     // Differentiate panels by the module and function under test
-    const fnRef = JSON5.stringify({
+    const fnRef = JSONN.stringify({
       module: moduleFile,
       fnName: fnName,
     });
@@ -197,7 +197,7 @@ export class FuzzPanel {
         // It's possible the source code changed between restarting;
         // just log the exception and continue. Restoring these panels
         // is best effort anyway.
-        const msg = isError(e) ? e.message : JSON5.stringify(e);
+        const msg = isError(e) ? e.message : JSONN.stringify(e);
         console.error(`Unable to revive FuzzPanel: ${msg}`);
       }
     }
@@ -314,7 +314,7 @@ export class FuzzPanel {
    * @returns A key string that represents the fuzz environment
    */
   public getFnRefKey(): string {
-    return JSON5.stringify({
+    return JSONN.stringify({
       module: this._fuzzEnv.function.getModule(),
       fnName: this._fuzzEnv.function.getName(),
     });
@@ -461,7 +461,7 @@ export class FuzzPanel {
    * @param pin true=save test; false=unsave test
    */
   private _doTestPinnedCmd(json: string, pin: boolean) {
-    const msg: FuzzPanelPinMessage = JSON5.parse(json); // !!! validation
+    const msg: FuzzPanelPinMessage = JSONN.parse(json); // !!! validation
 
     // Log the telemetry event
     vscode.commands.executeCommand(
@@ -533,7 +533,7 @@ export class FuzzPanel {
 
     // Read the file; if it doesn't exist, load default values
     try {
-      inputTests = JSON5.parse<fuzzer.FuzzTests>(
+      inputTests = JSONN.parse<fuzzer.FuzzTests>(
         fs.readFileSync(jsonFile).toString()
       );
       testSet = inputTests;
@@ -765,9 +765,9 @@ export class FuzzPanel {
 
     // Persist the test set
     try {
-      fs.writeFileSync(jsonFile, JSON5.stringify(fullSet)); // Update the file
+      fs.writeFileSync(jsonFile, JSONN.stringify(fullSet)); // Update the file
     } catch (e: unknown) {
-      const msg = isError(e) ? e.message : JSON5.stringify(e);
+      const msg = isError(e) ? e.message : JSONN.stringify(e);
       vscode.window.showErrorMessage(
         `Unable to update json file: ${jsonFile} (${msg})`
       );
@@ -788,7 +788,7 @@ export class FuzzPanel {
       try {
         fs.writeFileSync(testAdapter.filename, jestTests);
       } catch (e: unknown) {
-        const msg = isError(e) ? e.message : JSON5.stringify(e);
+        const msg = isError(e) ? e.message : JSONN.stringify(e);
 
         vscode.window.showErrorMessage(
           `Unable to update ${testAdapter.toolname} test file: ${testAdapter.filename} (${msg})`
@@ -799,7 +799,7 @@ export class FuzzPanel {
       try {
         fs.rmSync(testAdapter.filename);
       } catch (e: unknown) {
-        const msg = isError(e) ? e.message : JSON5.stringify(e);
+        const msg = isError(e) ? e.message : JSONN.stringify(e);
         vscode.window.showErrorMessage(
           `Unable to remove ${testAdapter.toolname} test file: ${testAdapter.filename} (${msg})`
         );
@@ -853,7 +853,7 @@ export class FuzzPanel {
    * Message handler for the `columns.sort' command.
    */
   private _saveColumnSortOrders(json: string) {
-    this._sortColumns = JSON5.parse(json); // !!! validation
+    this._sortColumns = JSONN.parse(json); // !!! validation
   } // fn: _saveColumnSortOrders
 
   /**
@@ -1237,11 +1237,11 @@ ${inArgConsts}
     }
     const fn = this._fuzzEnv.function; // Function under test
 
-    const oldValidatorNames = JSON5.stringify(
+    const oldValidatorNames = JSONN.stringify(
       this._fuzzEnv.validators.map((e) => e.name)
     );
     const newValidators = fuzzer.getValidators(program, fn);
-    const newValidatorNames = JSON5.stringify(newValidators.map((e) => e.name));
+    const newValidatorNames = JSONN.stringify(newValidators.map((e) => e.name));
 
     // Only send the message if there has been a change
     if (oldValidatorNames !== newValidatorNames) {
@@ -1281,7 +1281,7 @@ ${inArgConsts}
     this._coverageStats = undefined;
 
     // Get the panel input & use it to update options
-    const panelInput: FuzzPanelFuzzRunMessage = JSON5.parse(json);
+    const panelInput: FuzzPanelFuzzRunMessage = JSONN.parse(json);
     this._getConfigFromUi(panelInput); // needed for accuate stale check
 
     // We need to build a new tester if the current tester is
@@ -1426,9 +1426,9 @@ ${inArgConsts}
               if (
                 testToAdd &&
                 result.results.length &&
-                JSON5.stringify(
+                JSONN.stringify(
                   result.results[result.results.length - 1].input
-                ) === JSON5.stringify(testToAdd.input)
+                ) === JSONN.stringify(testToAdd.input)
               ) {
                 // Give focus to the newInput
                 this._focusInput = [
@@ -1449,7 +1449,7 @@ ${inArgConsts}
                 new telemetry.LoggerEntry(
                   "FuzzPanel.fuzz.done",
                   "Fuzzing completed successfully. Target: %s. Results: %s",
-                  [this.getFnRefKey(), JSON5.stringify(this._results)]
+                  [this.getFnRefKey(), JSONN.stringify(this._results)]
                 )
               );
 
@@ -1528,7 +1528,7 @@ ${inArgConsts}
     this._fuzzEnv = this._tester.env;
 
     // Get the panel input
-    const panelInput: FuzzPanelFuzzRunMessage = JSON5.parse(json);
+    const panelInput: FuzzPanelFuzzRunMessage = JSONN.parse(json);
     this._getConfigFromUi(panelInput);
 
     // Update the UI
@@ -2787,7 +2787,7 @@ ${inArgConsts}
         html += /*html*/ `
             <!-- Fuzzer Result to receive UI focus -->
             <div id="fuzzFocusInput" class="hidden">
-              ${htmlEscape(JSON5.stringify(this._focusInput))}
+              ${htmlEscape(JSONN.stringify(this._focusInput))}
             </div>
         `;
       }
@@ -2813,7 +2813,7 @@ ${inArgConsts}
                 this._results === undefined ||
                 this._state !== FuzzPanelState.done
                   ? "{}"
-                  : htmlEscape(JSON5.stringify(this._results))
+                  : htmlEscape(JSONN.stringify(this._results))
               }
             </div>
 
@@ -2822,7 +2822,7 @@ ${inArgConsts}
               ${
                 this._sortColumns === undefined
                   ? "{}"
-                  : htmlEscape(JSON5.stringify(this._sortColumns))
+                  : htmlEscape(JSONN.stringify(this._sortColumns))
               }
             </div>
             
@@ -2831,24 +2831,24 @@ ${inArgConsts}
 
             <!-- Fuzzer Sort Columns: for the client script to process -->
             <div id="fuzzHideColumns" class="hidden">
-              ${htmlEscape(JSON5.stringify(hiddenColumns))}
+              ${htmlEscape(JSONN.stringify(hiddenColumns))}
             </div>
 
             <!-- Validator Functions: for the client script to process -->
             <div id="validators" class="hidden">
               ${htmlEscape(
-                JSON5.stringify(this._fuzzEnv.validators.map((e) => e.name))
+                JSONN.stringify(this._fuzzEnv.validators.map((e) => e.name))
               )}
             </div>
 
             <!-- Lamguage: for the client script to process -->
             <div id="fuzzLang" class="hidden">
-              ${htmlEscape(JSON5.stringify(lang))}
+              ${htmlEscape(JSONN.stringify(lang))}
             </div>
 
             <!-- Fuzzer State Payload: for the client script to persist -->
             <div id="fuzzPanelState" class="hidden">
-              ${htmlEscape(JSON5.stringify(this.getState()))}
+              ${htmlEscape(JSONN.stringify(this.getState()))}
             </div>
           </div>
           <div id="snackbarRoot" class="hidden" />
@@ -3601,7 +3601,7 @@ function _applyArgOverrides(
       thisOverride.array.dimLength.forEach((e: fuzzer.Interval<number>) => {
         if (!(typeof e === "object" && "min" in e && "max" in e)) {
           throw new Error(
-            `Invalid interval for array dimensions: ${JSON5.stringify(e)}`
+            `Invalid interval for array dimensions: ${JSONN.stringify(e)}`
           );
         }
       });

--- a/src/ui/FuzzPanelView.ts
+++ b/src/ui/FuzzPanelView.ts
@@ -1,4 +1,4 @@
-import * as JSON5 from "../Jsonn";
+import * as JSONN from "../Jsonn";
 import * as ValueMapper from "../fuzzer/mappers/ValueMapper";
 import { getElementByIdOrThrow, getElementByIdWithTypeOrThrow } from "./Util";
 import {
@@ -395,18 +395,18 @@ async function main() {
   // ----------------------- Data Loads ----------------------- //
 
   // Load the fuzzer results data from the HTML
-  resultsData = JSON5.parse(
+  resultsData = JSONN.parse(
     htmlUnescape(getElementByIdOrThrow("fuzzResultsData").innerHTML)
   );
 
   // Load & display the validator functions from the HTML
-  validators = JSON5.parse(
+  validators = JSONN.parse(
     htmlUnescape(getElementByIdOrThrow("validators").innerHTML)
   );
   refreshValidators(validators);
 
   // Load column sort orders from the HTML
-  columnSortOrders = JSON5.parse(
+  columnSortOrders = JSONN.parse(
     htmlUnescape(getElementByIdOrThrow("fuzzSortColumns").innerHTML)
   );
   if (Object.keys(columnSortOrders).length === 0) {
@@ -471,11 +471,11 @@ async function main() {
   // an 'official' way to directly persist state within the extension itself,
   // at least as of vscode 1.69.2.  Hence, the roundtrip.
   vscode.setState(
-    JSON5.parse(htmlUnescape(getElementByIdOrThrow("fuzzPanelState").innerHTML))
+    JSONN.parse(htmlUnescape(getElementByIdOrThrow("fuzzPanelState").innerHTML))
   );
 
   // Update the list of hidden columns
-  const addlHiddenColumns = JSON5.parse(
+  const addlHiddenColumns = JSONN.parse(
     htmlUnescape(getElementByIdOrThrow("fuzzHideColumns").innerHTML)
   );
   if (Array.isArray(addlHiddenColumns)) {
@@ -483,7 +483,7 @@ async function main() {
   }
 
   // Get the fuzzer language
-  lang = JSON5.parse<ProgramLanguage>(
+  lang = JSONN.parse<ProgramLanguage>(
     htmlUnescape(getElementByIdOrThrow("fuzzLang").innerHTML)
   );
 
@@ -533,7 +533,7 @@ async function main() {
               break;
             default:
               throw new Error(
-                `Unexpected FuzzValueOrigin generator at input# ${idx}: ${JSON5.stringify(
+                `Unexpected FuzzValueOrigin generator at input# ${idx}: ${JSONN.stringify(
                   inputSrc
                 )}`
               );
@@ -541,7 +541,7 @@ async function main() {
           break;
         default:
           throw new Error(
-            `Unexpected FuzzValueOrigin at input# ${idx}: ${JSON5.stringify(
+            `Unexpected FuzzValueOrigin at input# ${idx}: ${JSONN.stringify(
               inputSrc
             )}`
           );
@@ -827,7 +827,7 @@ async function main() {
     // If we need to toast a result, do that now
     const toastResultElement = document.getElementById("fuzzFocusInput");
     if (toastResultElement) {
-      const toastResult: unknown = JSON5.parse(
+      const toastResult: unknown = JSONN.parse(
         htmlUnescape(toastResultElement.innerHTML)
       );
       if (
@@ -843,7 +843,7 @@ async function main() {
         );
       } else {
         throw new Error(
-          `Command to toast result ${JSON5.stringify(toastResult)} is invalid.`
+          `Command to toast result ${JSONN.stringify(toastResult)} is invalid.`
         );
       }
     }
@@ -895,14 +895,14 @@ function handleAddTestInput() {
   // Only call the fuzzer if the input is not already in the grid
   const tick = resultsData.results.findIndex(
     (r) =>
-      JSON5.stringify(r.input.map((i) => i.value)) ===
-      JSON5.stringify(overrides.input?.map((i) => i.value))
+      JSONN.stringify(r.input.map((i) => i.value)) ===
+      JSONN.stringify(overrides.input?.map((i) => i.value))
   );
   if (tick === -1) {
     // Call the extension to test this one input
     const message: FuzzPanelMessageFromWebView = {
       command: "fuzz.addTestInput",
-      json: JSON5.stringify(overrides),
+      json: JSONN.stringify(overrides),
     };
     vscode.postMessage(message);
   } else {
@@ -1137,7 +1137,7 @@ function handlePinToggle(id: number, type: FuzzResultCategory) {
   window.setTimeout(() => {
     const message: FuzzPanelMessageFromWebView = {
       command: pinning ? "test.pin" : "test.unpin",
-      json: JSON5.stringify(msg),
+      json: JSONN.stringify(msg),
     };
     vscode.postMessage(message);
 
@@ -1253,7 +1253,7 @@ function handleCorrectToggle(
   window.setTimeout(() => {
     const message: FuzzPanelMessageFromWebView = {
       command: isPinned ? "test.pin" : "test.unpin",
-      json: JSON5.stringify(msg),
+      json: JSONN.stringify(msg),
     };
     vscode.postMessage(message);
   });
@@ -1301,7 +1301,7 @@ function toggleExpandColumn(type: FuzzResultCategory) {
       : FuzzSortOrder.desc;
   const message: FuzzPanelMessageFromWebView = {
     command: "columns.sorted",
-    json: JSON5.stringify(columnSortOrders),
+    json: JSONN.stringify(columnSortOrders),
   };
   vscode.postMessage(message);
 } // fn: toggleExpandColumn
@@ -1480,7 +1480,7 @@ function handleColumnSort(
 
     const message: FuzzPanelMessageFromWebView = {
       command: "columns.sorted",
-      json: JSON5.stringify(columnSortOrders),
+      json: JSONN.stringify(columnSortOrders),
     };
     vscode.postMessage(message);
   }
@@ -1880,7 +1880,7 @@ function handleExpectedOutput({
           window.setTimeout(() => {
             const message: FuzzPanelMessageFromWebView = {
               command: "test.pin",
-              json: JSON5.stringify(msg),
+              json: JSONN.stringify(msg),
             };
             vscode.postMessage(message);
           });
@@ -2070,7 +2070,7 @@ function buildExpectedTestCase(
 function handleFuzzRun() {
   const message: FuzzPanelMessageFromWebView = {
     command: "fuzz.run",
-    json: JSON5.stringify(getConfigFromUi()),
+    json: JSONN.stringify(getConfigFromUi()),
   };
   vscode.postMessage(message);
 } // fn: handleFuzzRun
@@ -2082,7 +2082,7 @@ function handleFuzzRun() {
 function handleFuzzContinue() {
   const message: FuzzPanelMessageFromWebView = {
     command: "fuzz.continue",
-    json: JSON5.stringify(getConfigFromUi()),
+    json: JSONN.stringify(getConfigFromUi()),
   };
   vscode.postMessage(message);
 } // fn: handleFuzzRun
@@ -2094,7 +2094,7 @@ function handleFuzzContinue() {
 function handleFuzzRetest() {
   const message: FuzzPanelMessageFromWebView = {
     command: "fuzz.retest",
-    json: JSON5.stringify(getConfigFromUi()),
+    json: JSONN.stringify(getConfigFromUi()),
   };
   vscode.postMessage(message);
 } // fn: handleFuzzRetest
@@ -2106,7 +2106,7 @@ function handleFuzzRetest() {
 function handleFuzzClear() {
   const message: FuzzPanelMessageFromWebView = {
     command: "fuzz.clear",
-    json: JSON5.stringify(getConfigFromUi()),
+    json: JSONN.stringify(getConfigFromUi()),
   };
   vscode.postMessage(message);
 } // fn: handleFuzzClear


### PR DESCRIPTION
## Summary

- rename JSONN-backed aliases so their identifiers match the module they call
- route remaining TypeScript diagnostics, configuration comparisons, telemetry, and coverage-map serialization through JSONN
- retain genuine JSON5 boundaries: JSONN still uses `json5` as its codec, and the Python runner protocol remains JSON5-compatible
- preserve existing `.json5` filenames for on-disk compatibility

Closes #415

## Validation

- `PATH="$PWD/.venv/bin:$PATH" yarn test` — build/typecheck passed; 229 Jasmine specs passed
- `.venv/bin/python -m pytest` — 1 passed on Python 3.13
- ESLint completed with 0 errors (40 pre-existing warnings)
- `git diff --check`

AI-assisted contribution; I reviewed every remaining `JSON5` occurrence and kept only intentional codec, cross-language protocol, fixture, and compatibility references.
