### PR TITLE
chore: remove `Fuzzer` dependency on `TypescriptCompiler`

### DIFF
--- a/src/Jsonn.test.ts
+++ b/src/Jsonn.test.ts
@@ -15,11 +15,15 @@ describe("JSONN: ", () => {
       "hello",
       true,
       false,
+      BigInt(100),
+      100n,
       {
         trueValue: true,
         noValue: undefined,
         nullValue: null,
         nanValue: NaN,
+        bigintValue1: BigInt(100),
+        bigintValue2: 100n,
         arrayValue: [
           null,
           NaN,
@@ -32,6 +36,8 @@ describe("JSONN: ", () => {
           "hello",
           true,
           false,
+          BigInt(100),
+          100n,
         ],
       },
       [
@@ -46,7 +52,16 @@ describe("JSONN: ", () => {
         "hello",
         true,
         false,
-        { trueValue: true, noValue: undefined, nanValue: NaN, nullValue: null },
+        BigInt(100),
+        100n,
+        {
+          trueValue: true,
+          noValue: undefined,
+          nanValue: NaN,
+          nullValue: null,
+          bigintValue1: BigInt(100),
+          bigintValue2: 100n,
+        },
       ],
     ].forEach((value) => {
       const roundtripValue = JSONN.parse<typeof value>(JSONN.stringify(value));

--- a/src/Jsonn.ts
+++ b/src/Jsonn.ts
@@ -5,12 +5,12 @@ import { isKeyedObject } from "./Util";
  * JSONN: JavaScript Object Notation for NaNofuzz
  *
  * Mostly a drop-in replacement for JSON5. Adds support for serializing
- * and unserializing `undefined`, including in arrays and object members.
+ * and unserializing `undefined` and `bigint`, including in arrays and
+ * object members.
  *
  * While JSONN is valid JSON5 and might be parsed ok by JSON5, `undefined`
- * values will be parsed inaccurately by the standard JSON5 library.
- *
- * JSONN output includes the predicate above.
+ * and `bigint` values will be parsed inaccurately by the standard JSON5
+ * library.
  */
 
 /**
@@ -42,20 +42,14 @@ export function stringify(
     | undefined,
   space?: string | number | null | undefined
 ): string {
-  const stats: JsonnStats = { replacements: false };
   const text = JSON5.stringify(
     value,
     replacer
       ? function (this: unknown, key: string, value: unknown): unknown {
-          return jsonnReplacer.call(
-            this,
-            key,
-            replacer.call(this, key, value),
-            stats
-          );
+          return jsonnReplacer.call(this, key, replacer.call(this, key, value));
         }
       : function (this: unknown, key: string, value: unknown): unknown {
-          return jsonnReplacer.call(this, key, value, stats);
+          return jsonnReplacer.call(this, key, value);
         },
     space
   );
@@ -120,7 +114,7 @@ export function parse<T>(
  * @returns stringified placeholder value
  */
 export function getPlaceholder(_key: "undefined"): string {
-  return `{${PlaceHolderKey}:'${UndefinedKey}'}`;
+  return `{${PlaceHolderValueKey}:'${UndefinedKey}'}`;
   //  return Undefined;
 }
 
@@ -132,19 +126,21 @@ export function getPlaceholder(_key: "undefined"): string {
  * @param `value` value at object key
  * @returns the replacement value
  */
-function jsonnReplacer(
-  this: unknown,
-  key: string,
-  value: unknown,
-  stats: JsonnStats
-): unknown {
-  if (value === undefined) {
-    stats.replacements = true;
-    return {
-      [PlaceHolderKey]: UndefinedKey,
-    };
+function jsonnReplacer(this: unknown, key: string, value: unknown): unknown {
+  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
+  switch (typeof value) {
+    case "undefined":
+      return {
+        [PlaceHolderValueKey]: UndefinedKey,
+      };
+    case "bigint":
+      return {
+        [PlaceHolderTypeKey]: BigIntKey,
+        [PlaceHolderValueKey]: value.toString(),
+      };
+    default:
+      return value;
   }
-  return value;
 }
 
 /**
@@ -164,18 +160,36 @@ function jsonnReviver(
   value: unknown,
   targets: ReviveTarget[]
 ): unknown {
-  if (
-    isKeyedObject(value) &&
-    PlaceHolderKey in value &&
-    value[PlaceHolderKey] === UndefinedKey
-  ) {
-    if (key === "") {
-      return undefined;
-    } else {
-      if (Array.isArray(this)) {
-        targets.push({ arr: this, key, value: undefined });
-      } else if (isKeyedObject(this)) {
-        targets.push({ obj: this, key, value: undefined });
+  if (isKeyedObject(value)) {
+    const valueType = value[PlaceHolderTypeKey];
+    const valueValue = value[PlaceHolderValueKey];
+    switch (valueType) {
+      case undefined: {
+        if (valueValue === UndefinedKey) {
+          if (key === "") {
+            return undefined;
+          } else {
+            if (Array.isArray(this)) {
+              targets.push({ arr: this, key, value: undefined });
+            } else if (isKeyedObject(this)) {
+              targets.push({ obj: this, key, value: undefined });
+            }
+          }
+        }
+        break;
+      }
+      case BigIntKey: {
+        const newValue = BigInt(String(valueValue));
+        if (key === "") {
+          return newValue;
+        } else {
+          if (Array.isArray(this)) {
+            targets.push({ arr: this, key, value: newValue });
+          } else if (isKeyedObject(this)) {
+            targets.push({ obj: this, key, value: newValue });
+          }
+        }
+        break;
       }
     }
   }
@@ -187,7 +201,7 @@ type ReviveTarget = {
   value: unknown;
 } & ({ obj: Record<string, unknown> } | { arr: unknown[] });
 
-type JsonnStats = { replacements: boolean };
-
-const PlaceHolderKey = "____JSONN____61581952310____VALUE____";
+const PlaceHolderValueKey = "____JSONN____61581952310____VALUE____";
+const PlaceHolderTypeKey = "____JSONN____61581952310____TYPE____";
 const UndefinedKey = "__undefined__";
+const BigIntKey = "__bigint__";

--- a/src/Jsonn.ts
+++ b/src/Jsonn.ts
@@ -114,7 +114,7 @@ export function parse<T>(
  * @returns stringified placeholder value
  */
 export function getPlaceholder(_key: "undefined"): string {
-  return `{${PlaceHolderValueKey}:'${UndefinedKey}'}`;
+  return `{${PlaceHolderValueKey}:'${UndefinedValue}'}`;
   //  return Undefined;
 }
 
@@ -131,12 +131,11 @@ function jsonnReplacer(this: unknown, key: string, value: unknown): unknown {
   switch (typeof value) {
     case "undefined":
       return {
-        [PlaceHolderValueKey]: UndefinedKey,
+        [PlaceHolderValueKey]: UndefinedValue,
       };
     case "bigint":
       return {
-        [PlaceHolderTypeKey]: BigIntKey,
-        [PlaceHolderValueKey]: value.toString(),
+        [PlaceHolderBigIntKey]: value.toString(),
       };
     default:
       return value;
@@ -161,35 +160,27 @@ function jsonnReviver(
   targets: ReviveTarget[]
 ): unknown {
   if (isKeyedObject(value)) {
-    const valueType = value[PlaceHolderTypeKey];
-    const valueValue = value[PlaceHolderValueKey];
-    switch (valueType) {
-      case undefined: {
-        if (valueValue === UndefinedKey) {
-          if (key === "") {
-            return undefined;
-          } else {
-            if (Array.isArray(this)) {
-              targets.push({ arr: this, key, value: undefined });
-            } else if (isKeyedObject(this)) {
-              targets.push({ obj: this, key, value: undefined });
-            }
-          }
+    if (value[PlaceHolderValueKey] === UndefinedValue) {
+      if (key === "") {
+        return undefined;
+      } else {
+        if (Array.isArray(this)) {
+          targets.push({ arr: this, key, value: undefined });
+        } else if (isKeyedObject(this)) {
+          targets.push({ obj: this, key, value: undefined });
         }
-        break;
       }
-      case BigIntKey: {
-        const newValue = BigInt(String(valueValue));
-        if (key === "") {
-          return newValue;
-        } else {
-          if (Array.isArray(this)) {
-            targets.push({ arr: this, key, value: newValue });
-          } else if (isKeyedObject(this)) {
-            targets.push({ obj: this, key, value: newValue });
-          }
+    }
+    if (typeof value[PlaceHolderBigIntKey] === "string") {
+      const newValue = BigInt(String(value[PlaceHolderBigIntKey]));
+      if (key === "") {
+        return newValue;
+      } else {
+        if (Array.isArray(this)) {
+          targets.push({ arr: this, key, value: newValue });
+        } else if (isKeyedObject(this)) {
+          targets.push({ obj: this, key, value: newValue });
         }
-        break;
       }
     }
   }
@@ -202,6 +193,5 @@ type ReviveTarget = {
 } & ({ obj: Record<string, unknown> } | { arr: unknown[] });
 
 const PlaceHolderValueKey = "____JSONN____61581952310____VALUE____";
-const PlaceHolderTypeKey = "____JSONN____61581952310____TYPE____";
-const UndefinedKey = "__undefined__";
-const BigIntKey = "__bigint__";
+const PlaceHolderBigIntKey = "____JSONN____61581952310____BIGINT____";
+const UndefinedValue = "__undefined__";

--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -3,7 +3,6 @@ import * as JSONN from "../Jsonn";
 import { ArgDef } from "./analysis/ArgDef";
 import { ArgValueType, FunctionRef } from "./analysis/Types";
 import { CompositeInputGenerator } from "./generators/CompositeInputGenerator";
-import * as compiler from "./compilers/TypescriptCompiler";
 import * as CompilerFactory from "./compilers/CompilerFactory";
 import * as ProgramFactory from "./analysis/ProgramFactory";
 import * as ValueMapper from "./mappers/ValueMapper";
@@ -29,8 +28,8 @@ import { ImplicitOracle } from "./oracles/ImplicitOracle";
 import { ExampleOracle } from "./oracles/ExampleOracle";
 import { PropertyOracle } from "./oracles/PropertyOracle";
 import { AbstractProgram } from "./analysis/AbstractProgram";
-import { TypescriptProgram } from "./analysis/typescript/TypescriptProgram";
 import { RunnerResult } from "./runners/AbstractRunner";
+import { CompilerStaleness } from "./compilers/Types";
 
 export class Tester {
   protected _module: string; // module filename
@@ -46,7 +45,9 @@ export class Tester {
   protected _function: FunctionDef; // function under test
   protected _compositeInputGenerator: CompositeInputGenerator; // composite input generator
   protected _validators: FunctionRef[] = []; // property validator functions
-  protected _lastCompiler?: compiler.TypescriptCompiler; // last compiler object used
+  protected _lastCompiler?: ReturnType<
+    (typeof CompilerFactory)["fromSourcefile"]
+  >; // last compiler object used
 
   protected _results: FuzzTestResults; // test results
 
@@ -117,11 +118,12 @@ export class Tester {
       this._results.stats.generators
     );
 
-    // Start a background compilation
-    if (mode.precompile && CompilerFactory.needsCompilation(module)) {
-      compiler.TypescriptCompiler.compileAsync(module);
+    // Start a background compilation if precompile mode is active
+    // and this is a compiled language.
+    if (mode.precompile) {
+      CompilerFactory.fromSourcefile(module)?.compileAsync(module);
     }
-  }
+  } // constructor
 
   /**
    * Returns `true` if the tester is out-of-date or crashed
@@ -131,10 +133,7 @@ export class Tester {
    */
   public isStale(
     options: FuzzOptions
-  ):
-    | ReturnType<compiler.TypescriptCompiler["isStale"]>
-    | "optionschanged"
-    | "crashed" {
+  ): CompilerStaleness | "optionschanged" | "crashed" {
     // Stale: compilation is stale
     if (this._lastCompiler) {
       const compilerIsStale = this._lastCompiler.isStale();
@@ -465,10 +464,7 @@ export class Tester {
     // it to JavaScript (and possibly instrument it) prior to execution.
     const fqSrcFile = fs.realpathSync(this._function.getModule()); // Help the module loader
     const startCompTime = performance.now(); // start time: compile & instrument
-    const isNativeTs = TypescriptProgram.understands({ filename: fqSrcFile });
-    if (isNativeTs) {
-      this._lastCompiler = new compiler.TypescriptCompiler(fqSrcFile);
-    }
+    this._lastCompiler = CompilerFactory.fromSourcefile(fqSrcFile);
     const mod = this._lastCompiler
       ? this._lastCompiler.compileSync(this._measures, update) // native ts
       : fqSrcFile; // something other than native ts

--- a/src/fuzzer/compilers/CompilerFactory.ts
+++ b/src/fuzzer/compilers/CompilerFactory.ts
@@ -2,7 +2,9 @@ import { TypescriptProgram } from "../analysis/typescript/TypescriptProgram";
 import { TypescriptCompiler } from "./TypescriptCompiler";
 
 // TODO: Create an AbstractCompiler class & a matching strategy
-export function fromSource(fqSrcFile: string): TypescriptCompiler | undefined {
+export function fromSourcefile(
+  fqSrcFile: string
+): TypescriptCompiler | undefined {
   return TypescriptProgram.understands({ filename: fqSrcFile })
     ? new TypescriptCompiler(fqSrcFile)
     : undefined;

--- a/src/fuzzer/compilers/Types.ts
+++ b/src/fuzzer/compilers/Types.ts
@@ -1,0 +1,6 @@
+export type CompilerStaleness =
+  | false
+  | "notcompiled"
+  | "sourcechanged"
+  | "compilerchanged"
+  | "configchanged";

--- a/src/fuzzer/compilers/TypescriptCompiler.ts
+++ b/src/fuzzer/compilers/TypescriptCompiler.ts
@@ -24,6 +24,7 @@ import {
   VmGlobals,
 } from "../Types";
 import { findInAncestor } from "../Util";
+import { CompilerStaleness } from "./Types";
 
 // Global list of compilations by entrypoint module
 const _compilationsByModule: {
@@ -140,6 +141,9 @@ export class TypescriptCompiler {
         reject();
       }
     });
+  }
+  public async compileAsync(fqModulePath: string): Promise<void> {
+    return TypescriptCompiler.compileAsync(fqModulePath);
   } // fn: compileAsync
 
   /**
@@ -299,14 +303,7 @@ export class TypescriptCompiler {
    *
    * @returns a reason code if re-compilation is needed and `false` otherwise.
    */
-  public isStale(
-    inSrcFile?: string
-  ):
-    | false
-    | "notcompiled"
-    | "sourcechanged"
-    | "compilerchanged"
-    | "configchanged" {
+  public isStale(inSrcFile?: string): CompilerStaleness {
     // Stale: no compilations for this module have yet taken place
     if (
       !fs.existsSync(this._getJsFilename(this._moduleFile)) ||


### PR DESCRIPTION
Modifies `Fuzzer` to use the new `CompilerFactory` instead of depending directly on `TypescriptCompiler`.

We don't actually have multiple compilers yet, but using the factory removes more Typescript-specific code from `Fuzzer`, which is a good thing.