### PR TITLE
fix: `FuzzPanelView` on argument count changes

### DIFF
--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -704,7 +704,7 @@ export class Tester {
         }
       }
 
-      // If the function accepts inputs check if the input is a duplicate
+      // If the function accepts inputs, check if the input is a dupe
       if (this._function.getArgDefs().length) {
         // Skip tests if we previously processed the input
         // Note the our hash value is language specific

--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -382,7 +382,7 @@ export class Tester {
    * @returns test results
    */
   protected async *_run(
-    injectTests: FuzzPinnedTest[] = [],
+    injectTestsIn: FuzzPinnedTest[] = [],
     mode: FuzzMode = { gen: true },
     updateFn?: (payload: FuzzBusyStatusMessage) => void,
     cancelFn?: () => boolean
@@ -391,6 +391,7 @@ export class Tester {
     FuzzTestResults,
     FuzzTestResults | undefined
   > {
+    const injectTests = structuredClone(injectTestsIn);
     const state = this.state;
     if (!(state === "init" || state === "paused")) {
       throw new Error(
@@ -439,6 +440,8 @@ export class Tester {
     // any "interesting" inputs might be further used by other generators.
     this._compositeInputGenerator.inject(
       injectTests.map((t): Omit<InputAndSource, "tick"> => {
+        // Don't inject more inputs than the PUT accepts
+        t.input = t.input.slice(0, argDefs.length);
         return {
           value: t.input.map((i) => {
             return {
@@ -702,12 +705,13 @@ export class Tester {
         }
       }
 
-      // If the function accepts inputs, check if the input is a dupe
+      // If the function accepts inputs and we are not still injecting,
+      // check if the input is a duplicate
       if (this._function.getArgDefs().length) {
         // Skip tests if we previously processed the input
         // Note the our hash value is language specific
         const inputHash = getLangIoKey(lang, result.input);
-        if (this._allInputs.has(inputHash)) {
+        if (this._allInputs.has(inputHash) && !stillInjecting) {
           runStats.counters.dupesSequential++; // increment the sequential dupe counter
           runStats.counters.dupesGenerated++; // incremement the total run dupe counter
           this._compositeInputGenerator.onInputFeedback([], result.timers.gen); // return empty input generator feedback

--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -382,7 +382,7 @@ export class Tester {
    * @returns test results
    */
   protected async *_run(
-    injectTestsIn: FuzzPinnedTest[] = [],
+    injectTests: FuzzPinnedTest[] = [],
     mode: FuzzMode = { gen: true },
     updateFn?: (payload: FuzzBusyStatusMessage) => void,
     cancelFn?: () => boolean
@@ -391,7 +391,6 @@ export class Tester {
     FuzzTestResults,
     FuzzTestResults | undefined
   > {
-    const injectTests = structuredClone(injectTestsIn);
     const state = this.state;
     if (!(state === "init" || state === "paused")) {
       throw new Error(
@@ -440,8 +439,6 @@ export class Tester {
     // any "interesting" inputs might be further used by other generators.
     this._compositeInputGenerator.inject(
       injectTests.map((t): Omit<InputAndSource, "tick"> => {
-        // Don't inject more inputs than the PUT accepts
-        t.input = t.input.slice(0, argDefs.length);
         return {
           value: t.input.map((i) => {
             return {
@@ -637,7 +634,7 @@ export class Tester {
       result.timers.gen = performance.now() - startGenTime; // total time: input generation
       result.input = genInput.value.map((e, i) => {
         return {
-          name: argDefs[i].getName(),
+          name: argDefs[i]?.getName() ?? "?",
           offset: i,
           value: e.value,
           origin: genInput.source,
@@ -654,9 +651,11 @@ export class Tester {
       if (genInput.injected) {
         // Ensure the injected inputs are in the expected order
         const expectedInput = JSONN.stringify(
-          injectTests[runStats.counters.inputsInjected].input
+          injectTests[runStats.counters.inputsInjected].input.map(
+            (i) => i.value
+          )
         );
-        const returnedInput = JSONN.stringify(result.input);
+        const returnedInput = JSONN.stringify(result.input.map((i) => i.value));
         if (expectedInput !== returnedInput) {
           throw new Error(
             `Injected inputs in unexpected order at injected input# ${runStats.counters.inputsInjected}. Expected: "${expectedInput}". Got: "${returnedInput}".` +
@@ -705,13 +704,12 @@ export class Tester {
         }
       }
 
-      // If the function accepts inputs and we are not still injecting,
-      // check if the input is a duplicate
+      // If the function accepts inputs check if the input is a duplicate
       if (this._function.getArgDefs().length) {
         // Skip tests if we previously processed the input
         // Note the our hash value is language specific
         const inputHash = getLangIoKey(lang, result.input);
-        if (this._allInputs.has(inputHash) && !stillInjecting) {
+        if (this._allInputs.has(inputHash)) {
           runStats.counters.dupesSequential++; // increment the sequential dupe counter
           runStats.counters.dupesGenerated++; // incremement the total run dupe counter
           this._compositeInputGenerator.onInputFeedback([], result.timers.gen); // return empty input generator feedback

--- a/src/ui/FuzzPanelController.ts
+++ b/src/ui/FuzzPanelController.ts
@@ -2817,6 +2817,22 @@ ${inArgConsts}
               }
             </div>
 
+            <!-- Current program inputs: for the client script to process -->
+            <div id="fuzzInputCols" class="hidden">
+              ${
+                this._results === undefined ||
+                this._state !== FuzzPanelState.done
+                  ? "{}"
+                  : htmlEscape(
+                      JSONN.stringify(
+                        this._fuzzEnv.function
+                          .getArgDefs()
+                          .map((a) => a.getName())
+                      )
+                    )
+              }
+            </div>
+
             <!-- Fuzzer Sort Columns: for the client script to process -->
             <div id="fuzzSortColumns" class="hidden">
               ${
@@ -2829,7 +2845,7 @@ ${inArgConsts}
             <!-- Fuzzer Coverage Heatmap Setting: for the client script to process -->
             <div id="fuzzShowCoverageHeatmap" class="hidden">${this._coverageStats && this._wasShowingCoverage}</div>
 
-            <!-- Fuzzer Sort Columns: for the client script to process -->
+            <!-- Fuzzer Hide Columns: for the client script to process -->
             <div id="fuzzHideColumns" class="hidden">
               ${htmlEscape(JSONN.stringify(hiddenColumns))}
             </div>

--- a/src/ui/FuzzPanelController.ts
+++ b/src/ui/FuzzPanelController.ts
@@ -473,24 +473,19 @@ export class FuzzPanel {
       )
     );
 
-    // Update the back-end results data
-    if (this._results) {
-      if (
-        msg.id < this._results.results.length &&
-        fuzzer.getIoKey(msg.test.input) ===
-          fuzzer.getIoKey(this._results.results[msg.id].input)
-      ) {
-        this._results.results[msg.id].pinned = msg.test.pinned;
-        this._results.results[msg.id].expectedOutput = msg.test.expectedOutput;
-      }
-    } else {
-      throw new Error(
-        "front-end input value to pin/unpin does not match that of back-end id"
-      );
-    }
+    if (this._results && msg.id >= 0 && msg.id < this._results.results.length) {
+      // Update the back-end results data
+      this._results.results[msg.id].pinned = msg.test.pinned;
+      this._results.results[msg.id].expectedOutput = msg.test.expectedOutput;
 
-    // Update set of saved tests
-    this._updateFuzzTestsForThisFn(msg.test);
+      // Update set of saved tests
+      this._updateFuzzTestsForThisFn({
+        ...msg.test,
+        input: this._results.results[msg.id].input, // avoid argument changes jank
+      });
+    } else {
+      throw new Error("Invalid pin/unpin message");
+    }
   } // fn: _doTestPinnedCmd()
 
   /**

--- a/src/ui/FuzzPanelController.ts
+++ b/src/ui/FuzzPanelController.ts
@@ -3543,7 +3543,7 @@ function _applyArgOverrides(
   // Make the user aware if it appears that the function arguments changed
   if (argOverrides.length && argOverrides.length !== argsFlat.length) {
     vscode.window.showInformationMessage(
-      `Check the testing config: '${fn.getName()}()' may have changed`
+      `Check the testing config: arguments for '${fn.getName()}()' changed`
     );
   }
 

--- a/src/ui/FuzzPanelController.ts
+++ b/src/ui/FuzzPanelController.ts
@@ -2812,7 +2812,7 @@ ${inArgConsts}
               }
             </div>
 
-            <!-- Current program inputs: for the client script to process -->
+            <!-- Current PUT arguments: for the client script to process -->
             <div id="fuzzInputCols" class="hidden">
               ${
                 this._results === undefined ||

--- a/src/ui/FuzzPanelView.ts
+++ b/src/ui/FuzzPanelView.ts
@@ -487,7 +487,7 @@ async function main() {
     htmlUnescape(getElementByIdOrThrow("fuzzLang").innerHTML)
   );
 
-  // Get the actual input columns
+  // Get the PUT's current input argument names
   const putInputCols = JSONN.parse<string[]>(
     htmlUnescape(getElementByIdOrThrow("fuzzInputCols").innerHTML)
   );
@@ -503,7 +503,7 @@ async function main() {
       data[type] = [];
     });
 
-    // Calculate maximum number of inputs
+    // Calculate maximum number of arguments present in the data
     let dataInputColCount = 0;
     for (const e of resultsData.results) {
       if (e.input.length > dataInputColCount) {
@@ -512,7 +512,7 @@ async function main() {
     }
 
     // An empty input set containing the maximum number
-    // of inputs present in the data.
+    // of arguments present in the data.
     const emptyInputs: Record<string, string> = {};
     for (let i = 0; i < dataInputColCount; i++) {
       emptyInputs[
@@ -609,7 +609,6 @@ async function main() {
             ? "(no input)"
             : ValueMapper.toLang(lang, input.value);
       });
-      console.debug(`Input--> ${JSONN.stringify(inputs)}`); // !!!!!!!!!!!
 
       // There are 0-1 outputs: if an output is present, just name it `output`
       // and make it clear which outputs are undefined.  Otherwise, stringify

--- a/src/ui/FuzzPanelView.ts
+++ b/src/ui/FuzzPanelView.ts
@@ -487,6 +487,11 @@ async function main() {
     htmlUnescape(getElementByIdOrThrow("fuzzLang").innerHTML)
   );
 
+  // Get the actual input columns
+  const putInputCols = JSONN.parse<string[]>(
+    htmlUnescape(getElementByIdOrThrow("fuzzInputCols").innerHTML)
+  );
+
   // ----------------------- Fill Grids ----------------------- //
 
   // Await parser init
@@ -498,9 +503,19 @@ async function main() {
       data[type] = [];
     });
 
+    // An empty input set
+    const emptyInputs: Record<string, string> = {};
+    putInputCols.forEach((name) => {
+      emptyInputs[`input: ${name}`] = "(no input)";
+    });
+
     // Loop over each result
     let idx = 0;
+    let dataInputColCount = 0;
     for (const e of resultsData.results) {
+      if (e.input.length > dataInputColCount) {
+        dataInputColCount = e.input.length;
+      }
       // Indicate which tests are pinned
       const pinned = { [pinnedLabel]: !!e.pinned };
       const id = { [idLabel]: idx++ };
@@ -579,12 +594,14 @@ async function main() {
       // Name each input argument and make it clear which inputs were not provided
       // (i.e., the argument was optional).  Otherwise, stringify the value for
       // display.
-      const inputs: Record<string, string> = {};
-      e.input.forEach((i) => {
-        inputs[`input: ${i.name}`] =
-          i.value === undefined
-            ? "(no input)"
-            : ValueMapper.toLang(lang, i.value);
+      const inputs: Record<string, string> = { ...emptyInputs };
+      e.input.forEach((input, i) => {
+        if (i < putInputCols.length) {
+          inputs[`input: ${putInputCols[i] ?? "?"}`] =
+            input.value === undefined
+              ? "(no input)"
+              : ValueMapper.toLang(lang, input.value);
+        }
       });
 
       // There are 0-1 outputs: if an output is present, just name it `output`

--- a/src/ui/FuzzPanelView.ts
+++ b/src/ui/FuzzPanelView.ts
@@ -503,19 +503,26 @@ async function main() {
       data[type] = [];
     });
 
-    // An empty input set
-    const emptyInputs: Record<string, string> = {};
-    putInputCols.forEach((name) => {
-      emptyInputs[`input: ${name}`] = "(no input)";
-    });
-
-    // Loop over each result
-    let idx = 0;
+    // Calculate maximum number of inputs
     let dataInputColCount = 0;
     for (const e of resultsData.results) {
       if (e.input.length > dataInputColCount) {
         dataInputColCount = e.input.length;
       }
+    }
+
+    // An empty input set containing the maximum number
+    // of inputs present in the data.
+    const emptyInputs: Record<string, string> = {};
+    for (let i = 0; i < dataInputColCount; i++) {
+      emptyInputs[
+        `input: ${putInputCols[i] ?? "?".repeat(i - putInputCols.length + 1)}`
+      ] = "(no input)";
+    }
+
+    // Loop over each result
+    let idx = 0;
+    for (const e of resultsData.results) {
       // Indicate which tests are pinned
       const pinned = { [pinnedLabel]: !!e.pinned };
       const id = { [idLabel]: idx++ };
@@ -592,17 +599,17 @@ async function main() {
       });
 
       // Name each input argument and make it clear which inputs were not provided
-      // (i.e., the argument was optional).  Otherwise, stringify the value for
-      // display.
+      // (i.e., it was optional). Otherwise, translate & display the value.
       const inputs: Record<string, string> = { ...emptyInputs };
       e.input.forEach((input, i) => {
-        if (i < putInputCols.length) {
-          inputs[`input: ${putInputCols[i] ?? "?"}`] =
-            input.value === undefined
-              ? "(no input)"
-              : ValueMapper.toLang(lang, input.value);
-        }
+        inputs[
+          `input: ${putInputCols[i] ?? "?".repeat(i - putInputCols.length + 1)}`
+        ] =
+          input.value === undefined
+            ? "(no input)"
+            : ValueMapper.toLang(lang, input.value);
       });
+      console.debug(`Input--> ${JSONN.stringify(inputs)}`); // !!!!!!!!!!!
 
       // There are 0-1 outputs: if an output is present, just name it `output`
       // and make it clear which outputs are undefined.  Otherwise, stringify


### PR DESCRIPTION
This PR fixes much of the jank previously associated with changing the PUT's number of arguments. 

Specifically, `FuzzPanelView` now shows the argument count of the example with the _most_ arguments in the test set. Previously, the first input loaded determined the argument set, which could be a saved input from a prior version of the PUT with more or fewer arguments than the current PUT. In cases where the PUT _gained_ arguments, this behavior hid the new arguments. Different problems occurred when the number of arguments was reduced.

By showing all arguments for all examples, pin/unpin and annotation activities behave in more obvious and consistent ways. This PR does not update saved inputs when arguments are re-ordered, re-typed, or re-named.