### PR TITLE
refactor: remove `ArgDef<T>`'s unnecessary type parameter

### DIFF
--- a/src/fuzzer/analysis/AbstractProgram.ts
+++ b/src/fuzzer/analysis/AbstractProgram.ts
@@ -6,7 +6,6 @@ import {
   ProgramImports,
   ProgramPath,
   TypeRef,
-  ArgType,
   ArgOptions,
   ProgramImport,
   ProgramLanguage,
@@ -387,7 +386,7 @@ export abstract class AbstractProgram {
    * @returns a string that works as the type annotation for the argument
    */
   public static getTypeAnnotation(
-    _arg: ArgDef<ArgType>,
+    _arg: ArgDef,
     _options: TypeAnnotationOptions = TypeAnnotationOptionDefaults
   ): string {
     throw new Error("Method must be implemented");

--- a/src/fuzzer/analysis/ArgDef.test.ts
+++ b/src/fuzzer/analysis/ArgDef.test.ts
@@ -375,7 +375,7 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
   it("NoInput test", function () {
     const prng = seedrandom("qwertyuiop");
     /*
-    const q = new ArgDef<ArgType>(
+    const q = new ArgDef(
       "q",
       0,
       ArgTag.STRING,
@@ -391,7 +391,7 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
       []
     );
     */
-    const n = new ArgDef<ArgType>(
+    const n = new ArgDef(
       "n",
       0,
       ArgTag.OBJECT,
@@ -401,7 +401,7 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
       undefined,
       []
     );
-    const h = new ArgDef<ArgType>(
+    const h = new ArgDef(
       "h",
       0,
       ArgTag.OBJECT,
@@ -547,7 +547,7 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
 });
 
 // Helper function to abbreviate ArgDef specs
-function abbrSpec(spec: ArgDef<ArgType>, indents = 0): string[] {
+function abbrSpec(spec: ArgDef, indents = 0): string[] {
   const space = "  ".repeat(indents);
   const line: string[] = [];
   line.push(space);
@@ -577,7 +577,7 @@ function getRandomArgDef(
   prng: seedrandom.prng,
   levels = 0,
   parentType?: ArgTag
-): ArgDef<ArgType> {
+): ArgDef {
   const argTagOptions: ArgTag[] = [
     ArgTag.NUMBER,
     ArgTag.STRING,
@@ -588,7 +588,7 @@ function getRandomArgDef(
   ];
   const argTag = argTagOptions[Math.floor(prng() * (argTagOptions.length - 1))];
 
-  const children: ArgDef<ArgType>[] = [];
+  const children: ArgDef[] = [];
   if (levels && (argTag === ArgTag.OBJECT || argTag === ArgTag.UNION)) {
     let childCount = 2;
     while (childCount) {
@@ -722,7 +722,7 @@ function getRandomArgDef(
       );
     }
   }
-  return new ArgDef<ArgType>(
+  return new ArgDef(
     name,
     0,
     argTag,

--- a/src/fuzzer/analysis/ArgDef.ts
+++ b/src/fuzzer/analysis/ArgDef.ts
@@ -5,6 +5,7 @@ import {
   ArgTag,
   ArgType,
   Interval,
+  TagToType,
   TypeRef,
 } from "./Types";
 
@@ -29,16 +30,16 @@ import {
  * - Deconstructed types
  * - Generics
  */
-export class ArgDef<T extends ArgType> {
+export class ArgDef<Tag extends ArgTag = ArgTag> {
   private name: string; // name of the argument
   private offset: number; // offset of the argument in the function (0-based)
-  private type: ArgTag; // type of the argument
+  private type: Tag; // type of the argument
   private typeRef?: string; // type reference name (if the type is a reference)
   private dims: number; // dimensions of the argument (e.g., number=0, number[]=1, etc)
   private optional: boolean; // whether the argument is optional
-  private intervals: Interval<T>[]; // input intervals for the argument
+  private intervals: Interval<TagToType[Tag]>[]; // input intervals for the argument
   private options: ArgOptions; // default argument options
-  private children: ArgDef<ArgType>[]; // child arguments (if this is an object)
+  private children: ArgDef[]; // child arguments (if this is an object)
 
   /**
    * Constructor to instantiate a new ArgDef object.
@@ -54,12 +55,12 @@ export class ArgDef<T extends ArgType> {
   public constructor(
     name: string,
     offset: number,
-    type: ArgTag,
+    type: Tag,
     options: ArgOptions,
     dims?: number,
     optional?: boolean,
-    intervals?: Interval<T>[],
-    children?: ArgDef<ArgType>[],
+    intervals?: Interval<TagToType[Tag]>[],
+    children?: ArgDef[],
     typeRef?: string
   ) {
     this.name = name;
@@ -110,7 +111,7 @@ export class ArgDef<T extends ArgType> {
       intervals === undefined ||
       intervals.length === 0 ||
       type === ArgTag.OBJECT
-        ? (ArgDef.getDefaultIntervals(this.type, this.options) as Interval<T>[])
+        ? (ArgDef.getDefaultIntervals(this.type, this.options) as Interval<TagToType[Tag]>[])
         : intervals;
 
     // Ensure each non-array dimension is valid
@@ -134,7 +135,7 @@ export class ArgDef<T extends ArgType> {
     ref: TypeRef,
     options: ArgOptions,
     offset?: number
-  ): ArgDef<ArgType> {
+  ): ArgDef {
     offset = offset ?? 0;
     let i = 0; // Child counter
 
@@ -158,7 +159,7 @@ export class ArgDef<T extends ArgType> {
     const typeOptions: ArgOptions = { ...options, ...ref.type.options };
 
     // Use the type reference to build the ArgDef
-    return new ArgDef<ArgType>(
+    return new ArgDef(
       ref.name ?? "unknown", // name
       offset, // offset
       ref.type.type, // type
@@ -214,7 +215,7 @@ export class ArgDef<T extends ArgType> {
    *
    * @param value Constant value to set as the input
    */
-  public makeConstant(value: T): void {
+  public makeConstant(value: TagToType[Tag]): void {
     this.intervals = [{ min: value, max: value }];
     if (this.type === ArgTag.STRING && typeof value === "string") {
       this.options.strLength = { min: value.length, max: value.length };
@@ -245,7 +246,7 @@ export class ArgDef<T extends ArgType> {
    *
    * @returns The type of the argument
    */
-  public getType(): ArgTag {
+  public getType(): Tag {
     return this.type;
   } // fn: getType()
 
@@ -301,7 +302,7 @@ export class ArgDef<T extends ArgType> {
    *
    * @returns The input intervals of the argument
    */
-  public getIntervals(): Interval<T>[] {
+  public getIntervals(): Interval<TagToType[Tag]>[] {
     return this.intervals;
   } // fn: getIntervals()
 
@@ -312,7 +313,7 @@ export class ArgDef<T extends ArgType> {
    *
    * Throws an exception if any interval's min>max.
    */
-  public setIntervals(intervals: Interval<T>[]): void {
+  public setIntervals(intervals: Interval<TagToType[Tag]>[]): void {
     if (intervals.some((e) => e.min > e.max))
       throw new Error(
         `Invalid interval provided (max>min): ${JSON.stringify(intervals)}`
@@ -331,7 +332,7 @@ export class ArgDef<T extends ArgType> {
     const intervals = ArgDef.getDefaultIntervals(
       this.type,
       options
-    ) as Interval<T>[];
+    ) as Interval<TagToType[Tag]>[];
     if (intervals.some((e) => e.min > e.max))
       throw new Error(
         `Invalid interval provided (max>min): ${JSON.stringify(intervals)}`
@@ -360,7 +361,7 @@ export class ArgDef<T extends ArgType> {
    *
    * Throws an exception is isConstant() is false
    */
-  public getConstantValue(): T | undefined {
+  public getConstantValue(): TagToType[Tag] | undefined {
     if (!this.isConstant())
       throw new Error("Arg is not a constant -- check isConstant() first");
     if (
@@ -370,7 +371,7 @@ export class ArgDef<T extends ArgType> {
       const result = this.intervals[0].min
         .padEnd(this.options.strLength.min, this.options.strCharset[0])
         .substring(0, this.options.strLength.max);
-      return result as T;
+      return result as TagToType[Tag];
     }
     if (this.type === ArgTag.LITERAL && !this.intervals.length) {
       return undefined;
@@ -411,7 +412,7 @@ export class ArgDef<T extends ArgType> {
     // Handle numMin and numMax overrides
     if (this.type === ArgTag.NUMBER) {
       if ("numIntervals" in options && options.numIntervals !== undefined)
-        this.setIntervals(options.numIntervals as Interval<T>[]);
+        this.setIntervals(options.numIntervals as Interval<TagToType[Tag]>[]);
     }
 
     // Merge the two option sets; incoming has precedence
@@ -455,7 +456,7 @@ export class ArgDef<T extends ArgType> {
    *
    * @returns the argument's children (if it is an object)
    */
-  public getChildren(): ArgDef<ArgType>[] {
+  public getChildren(): ArgDef[] {
     return [...this.children];
   } // fn: getChildren()
 
@@ -465,8 +466,8 @@ export class ArgDef<T extends ArgType> {
    *
    * @returns the argument's descendents (if it is an object)
    */
-  public getChildrenFlat(): ArgDef<ArgType>[] {
-    const ret: ArgDef<ArgType>[] = [];
+  public getChildrenFlat(): ArgDef[] {
+    const ret: ArgDef[] = [];
     for (const child of this.children) {
       ret.push(child);
       ret.push(...child.getChildrenFlat());

--- a/src/fuzzer/analysis/ArgDefGenerator.ts
+++ b/src/fuzzer/analysis/ArgDefGenerator.ts
@@ -2,7 +2,6 @@ import seedrandom from "seedrandom";
 import { ArgDef } from "./ArgDef";
 import {
   ArgTag,
-  ArgType,
   ArgValueType,
   ArgOptions,
   Interval,
@@ -22,7 +21,7 @@ export class ArgDefGenerator {
    * @param `argDefs` array of ArgDef specs that describe the shape of values
    * @param `prng` pseudo-random number generator
    */
-  public constructor(argDefs: ArgDef<ArgType>[], prng: seedrandom.prng) {
+  public constructor(argDefs: ArgDef[], prng: seedrandom.prng) {
     this._prng = prng;
     this._gens = argDefs.map((argDef) =>
       generateRandomInputFn(argDef, this._prng)
@@ -49,7 +48,7 @@ export class ArgDefGenerator {
    * @returns value that conforms to the ArgDef specs
    */
   public static gen(
-    spec: ArgDef<ArgType>,
+    spec: ArgDef,
     prng: seedrandom.prng,
     genDims = true
   ): ArgValueType {
@@ -80,8 +79,8 @@ type PublicRandFn = () => ArgValueType;
  *
  * TODO: bias selection of input interval based on interval size
  */
-function generateRandomInputFn<T extends ArgType>(
-  arg: ArgDef<T>,
+function generateRandomInputFn(
+  arg: ArgDef,
   prng: seedrandom.prng,
   genDims = true /* true=generate array dimensions if present;
                     false=generate only the value */

--- a/src/fuzzer/analysis/ArgDefMutator.ts
+++ b/src/fuzzer/analysis/ArgDefMutator.ts
@@ -1,7 +1,7 @@
 import { ArgDef } from "./ArgDef";
 import { ArgDefGenerator } from "./ArgDefGenerator";
 import { ArgDefValidator } from "./ArgDefValidator";
-import { ArgTag, ArgType, ArgValueType, ArgValueTypeWrapped } from "./Types";
+import { ArgTag, ArgValueType, ArgValueTypeWrapped } from "./Types";
 import * as JSONN from "../../Jsonn";
 
 /**
@@ -23,7 +23,7 @@ export class ArgDefMutator {
    * @returns array of mutator functions
    */
   public static getMutators(
-    specs: ArgDef<ArgType>[],
+    specs: ArgDef[],
     value: ArgValueTypeWrapped[],
     prng: seedrandom.prng
   ): mutatorFn[] {
@@ -48,7 +48,7 @@ export class ArgDefMutator {
     const mutateArray = (
       a: Array<ArgValueType>,
       path: (string | number)[],
-      spec: ArgDef<ArgType>,
+      spec: ArgDef,
       level = 1
     ): void => {
       const options = spec.getOptions();
@@ -131,7 +131,7 @@ export class ArgDefMutator {
     const subInputs: {
       subPath: (number | string)[];
       subElement: ArgValueType;
-      subSpec: ArgDef<ArgType>;
+      subSpec: ArgDef;
       inArray: boolean;
     }[] = value.map((e, i) => {
       return {

--- a/src/fuzzer/analysis/ArgDefValidator.ts
+++ b/src/fuzzer/analysis/ArgDefValidator.ts
@@ -1,18 +1,18 @@
 import { ArgDef } from "./ArgDef";
-import { ArgTag, ArgType, ArgValueType, ArgValueTypeWrapped } from "./Types";
+import { ArgTag, ArgValueType, ArgValueTypeWrapped } from "./Types";
 
 /**
  * Valides values against their corresponding ArgDef specs
  */
 export class ArgDefValidator {
-  protected _specs: ArgDef<ArgType>[];
+  protected _specs: ArgDef[];
 
   /**
    * Create an ArgDefValidator object
    *
    * @param `specs` ArgDef spec against which to check values
    */
-  constructor(specs: ArgDef<ArgType>[]) {
+  constructor(specs: ArgDef[]) {
     this._specs = specs;
   } // fn: constructor
 
@@ -43,7 +43,7 @@ export class ArgDefValidator {
    */
   public static validate(
     value: ArgValueType,
-    spec: ArgDef<ArgType>,
+    spec: ArgDef,
     inArray = false
   ): boolean {
     const options = spec.getOptions();
@@ -179,7 +179,7 @@ export class ArgDefValidator {
  */
 const traverse = (
   a: Array<ArgValueType>,
-  spec: ArgDef<ArgType>,
+  spec: ArgDef,
   currDepth = 0
 ): boolean => {
   // Check the depth and number of elements in the array

--- a/src/fuzzer/analysis/FunctionDef.ts
+++ b/src/fuzzer/analysis/FunctionDef.ts
@@ -1,6 +1,5 @@
 import { ArgDef } from "./ArgDef";
 import {
-  ArgType,
   FunctionRef,
   ArgOptionOverrides,
   ArgOptions,
@@ -22,7 +21,7 @@ import { ProgramLanguage } from "./Types";
  *   order specified in ArgOptions.strCharset.
  */
 export class FunctionDef {
-  private _argDefs: ArgDef<ArgType>[] = [];
+  private _argDefs: ArgDef[] = [];
   private _options: ArgOptions;
   private _ref: FunctionRef;
   private _cmt: string | undefined; // docstring comment for function
@@ -106,7 +105,7 @@ export class FunctionDef {
    *
    * @returns array of function arguments
    */
-  public getArgDefs(): ArgDef<ArgType>[] {
+  public getArgDefs(): ArgDef[] {
     return [...this._argDefs];
   } // fn: getArgDefs()
 
@@ -174,7 +173,7 @@ export class FunctionDef {
    * function does not have a return type annotation or the return
    * type could not be resolved.
    */
-  public getReturnArg(): ArgDef<ArgType> | undefined {
+  public getReturnArg(): ArgDef | undefined {
     // If a return type is defined and resolved, convert it to an ArgDef
     return this._ref.returnType && this._ref.returnType.type
       ? ArgDef.fromTypeRef(this._ref.returnType, this._options)
@@ -262,8 +261,8 @@ export class FunctionDef {
    *
    * @returns a flat array of all function arguments.
    */
-  public getArgDefsFlat(): ArgDef<ArgType>[] {
-    const ret: ArgDef<ArgType>[] = [];
+  public getArgDefsFlat(): ArgDef[] {
+    const ret: ArgDef[] = [];
     for (const arg of this._argDefs) {
       ret.push(arg);
       ret.push(...arg.getChildrenFlat());

--- a/src/fuzzer/analysis/TestUtils.ts
+++ b/src/fuzzer/analysis/TestUtils.ts
@@ -15,7 +15,7 @@ export function makeArgDef(
   children: TypeRef[] = [],
   typeRefName?: string,
   literalValue?: ArgType
-): ArgDef<ArgType> {
+): ArgDef {
   return ArgDef.fromTypeRef(
     makeTypeRef(
       module,

--- a/src/fuzzer/analysis/Types.ts
+++ b/src/fuzzer/analysis/Types.ts
@@ -89,6 +89,22 @@ export type ArgType =
   | {
       [key: string]: ArgType;
     };
+
+/**
+ * Maps each ArgTag to the corresponding TypeScript value type.
+ * Use this instead of pairing a separate `T extends ArgType` parameter
+ * alongside an `ArgTag` — derive `T` from the tag instead.
+ */
+export type TagToType = {
+  [ArgTag.NUMBER]: number;
+  [ArgTag.STRING]: string;
+  [ArgTag.BOOLEAN]: boolean;
+  [ArgTag.OBJECT]: { [key: string]: ArgType };
+  [ArgTag.LITERAL]: ArgType;
+  [ArgTag.UNION]: ArgType;
+  [ArgTag.TUPLE]: [ArgType];
+  [ArgTag.UNRESOLVED]: ArgType;
+};
 export type ArgValueType =
   | number
   | string

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -1225,7 +1225,7 @@ export class PythonProgram extends AbstractProgram {
    * @returns a string that works as the type annotation for the argument
    */
   public static getTypeAnnotation(
-    arg: ArgDef<ArgType>,
+    arg: ArgDef,
     options: TypeAnnotationOptions = TypeAnnotationOptionDefaults
   ): string {
     // Get the base type annotation
@@ -1261,7 +1261,7 @@ export class PythonProgram extends AbstractProgram {
    * dimensions or optionality.
    */
   protected static getBaseType(
-    arg: ArgDef<ArgType>,
+    arg: ArgDef,
     options: TypeAnnotationOptions = TypeAnnotationOptionDefaults
   ): string {
     const typeRef = arg.getTypeRef();

--- a/src/fuzzer/analysis/typescript/TypescriptProgram.ts
+++ b/src/fuzzer/analysis/typescript/TypescriptProgram.ts
@@ -1098,7 +1098,7 @@ export class TypescriptProgram extends AbstractProgram {
    * @returns a string that works as the type annotation for the argument
    */
   public static getTypeAnnotation(
-    arg: ArgDef<ArgType>,
+    arg: ArgDef,
     options: TypeAnnotationOptions = TypeAnnotationOptionDefaults
   ): string {
     // Get the base type annotation
@@ -1142,7 +1142,7 @@ export class TypescriptProgram extends AbstractProgram {
    * dimensions or optionality.
    */
   protected static getBaseType(
-    arg: ArgDef<ArgType>,
+    arg: ArgDef,
     options: TypeAnnotationOptions = TypeAnnotationOptionDefaults
   ): string {
     const typeRef = arg.getTypeRef();

--- a/src/fuzzer/generators/AbstractInputGenerator.ts
+++ b/src/fuzzer/generators/AbstractInputGenerator.ts
@@ -1,5 +1,4 @@
 import seedrandom from "seedrandom";
-import { ArgType } from "../analysis/Types";
 import { ArgDef } from "../analysis/ArgDef";
 import { InputAndSource } from "./../Types";
 import { InputGeneratorStats } from "./Types";
@@ -17,7 +16,7 @@ export abstract class AbstractInputGenerator {
    * @param `specs` ArgDef specs that describe the inputs to generate
    * @param `rngSeed` seed for pseudo random nunber generator
    */
-  protected constructor(specs: ArgDef<ArgType>[], rngSeed: string | undefined) {
+  protected constructor(specs: ArgDef[], rngSeed: string | undefined) {
     this._specs = specs;
     this._prng = seedrandom(rngSeed);
   } // fn: constructor

--- a/src/fuzzer/generators/AiInputGenerator.ts
+++ b/src/fuzzer/generators/AiInputGenerator.ts
@@ -1,7 +1,6 @@
 import { AbstractInputGenerator } from "./AbstractInputGenerator";
 import {
   ArgTag,
-  ArgType,
   ArgValueType,
   ArgValueTypeWrapped,
   ProgramLanguage,
@@ -278,7 +277,7 @@ export class AiInputGenerator extends AbstractInputGenerator {
    * @returns a Zod schema for the ArgDef
    */
   protected _argDefToSchema(
-    inArg: ArgDef<ArgType>,
+    inArg: ArgDef,
     path: string,
     directives: string[]
   ): zod.ZodType {
@@ -287,7 +286,7 @@ export class AiInputGenerator extends AbstractInputGenerator {
     const argOptions = inArg.getOptions();
 
     // Helper function that creates a Zod schema from an ArgDef
-    const argToZod = (arg: ArgDef<ArgType>): zod.ZodType => {
+    const argToZod = (arg: ArgDef): zod.ZodType => {
       switch (arg.getType()) {
         case ArgTag.NUMBER: {
           const desc = `value must be >= ${Number(argIntervals[0].min)} && <= ${Number(argIntervals[0].max)}`;

--- a/src/fuzzer/generators/MutationInputGenerator.ts
+++ b/src/fuzzer/generators/MutationInputGenerator.ts
@@ -1,6 +1,5 @@
 import { AbstractInputGenerator } from "./AbstractInputGenerator";
 import { ArgDef } from "../analysis/ArgDef";
-import { ArgType } from "../analysis/Types";
 import { Leaderboard } from "./Leaderboard";
 import { InputAndSource } from "../Types";
 import { ArgDefMutator } from "../analysis/ArgDefMutator";
@@ -20,7 +19,7 @@ export class MutationInputGenerator extends AbstractInputGenerator {
    * @param `leaderboard` Running list of "interesting" inputs
    */
   public constructor(
-    specs: ArgDef<ArgType>[],
+    specs: ArgDef[],
     rngSeed: string | undefined,
     leaderboard: Leaderboard<InputAndSource>
   ) {

--- a/src/fuzzer/generators/RandomInputGenerator.ts
+++ b/src/fuzzer/generators/RandomInputGenerator.ts
@@ -1,5 +1,4 @@
 import { ArgDef } from "../analysis/ArgDef";
-import { ArgType } from "../analysis/Types";
 import { ArgDefGenerator } from "../analysis/ArgDefGenerator";
 import { AbstractInputGenerator } from "./AbstractInputGenerator";
 import { InputAndSource } from "../Types";
@@ -16,7 +15,7 @@ export class RandomInputGenerator extends AbstractInputGenerator {
    * @param `specs` ArgDef specs that describe the input to generate
    * @param `rngSeed` seed for pseudo random number generator
    */
-  public constructor(specs: ArgDef<ArgType>[], rngSeed: string | undefined) {
+  public constructor(specs: ArgDef[], rngSeed: string | undefined) {
     super(specs, rngSeed);
   } // fn: constructor
 

--- a/src/ui/FuzzPanelController.ts
+++ b/src/ui/FuzzPanelController.ts
@@ -961,13 +961,13 @@ export class FuzzPanel {
     // vvvvvvv Language-specific logic vvvvvvv
     const skelGenerators = {
       typescript: {
-        inputMapper: (argDef: fuzzer.ArgDef<fuzzer.ArgType>, i: number) => {
+        inputMapper: (argDef: fuzzer.ArgDef, i: number) => {
           return `  const ${argDef.getName()}: ${fuzzer.TypescriptProgram.getTypeAnnotation(argDef)} = ${
             validatorArgs.resultArgName
           }.in[${i}];`;
         },
         outputMapper: (
-          inArgs: fuzzer.ArgDef<fuzzer.ArgType>[],
+          inArgs: fuzzer.ArgDef[],
           resultArgName: string,
           returnType?: string
         ): string => {
@@ -1004,13 +1004,13 @@ ${inArgConsts}
         getTypeAnnotation: fuzzer.TypescriptProgram.getTypeAnnotation,
       },
       python: {
-        inputMapper: (argDef: fuzzer.ArgDef<fuzzer.ArgType>, i: number) => {
+        inputMapper: (argDef: fuzzer.ArgDef, i: number) => {
           return `  ${argDef.getName()}: ${PythonProgram.getTypeAnnotation(argDef)} = ${
             validatorArgs.resultArgName
           }['in'][${i}]`;
         },
         outputMapper: (
-          inArgs: fuzzer.ArgDef<fuzzer.ArgType>[],
+          inArgs: fuzzer.ArgDef[],
           resultArgName: string,
           returnType?: string
         ): string => {
@@ -1150,7 +1150,7 @@ ${inArgConsts}
    */
   private _getIdentifierNameAvoidingConflicts(
     // The input arguments
-    inArgs: fuzzer.ArgDef<fuzzer.ArgType>[],
+    inArgs: fuzzer.ArgDef[],
     // The candidate names to choose from
     candidateNames: string[],
     // The maximum suffix to use when generating a new name
@@ -1193,7 +1193,7 @@ ${inArgConsts}
    * @param inArgs The input arguments
    * @returns An object containing the above information
    */
-  private _getValidatorArgs(inArgs: fuzzer.ArgDef<fuzzer.ArgType>[]): {
+  private _getValidatorArgs(inArgs: fuzzer.ArgDef[]): {
     str: string;
     resultArgName: string;
   } {
@@ -2897,7 +2897,7 @@ ${inArgConsts}
    * @returns html string of the argument definition form
    */
   private _argDefToHtmlForm(
-    arg: fuzzer.ArgDef<fuzzer.ArgType>,
+    arg: fuzzer.ArgDef,
     counter: { id: number }, // pass counter by reference
     beginSep: string,
     endSep: string,
@@ -3168,7 +3168,7 @@ ${inArgConsts}
    * @returns html string representing an argument's array form
    */
   private _argDefArrayToHtmlForm(
-    arg: fuzzer.ArgDef<fuzzer.ArgType>,
+    arg: fuzzer.ArgDef,
     idBase: string,
     disabledFlag: string
   ): string {
@@ -3550,7 +3550,7 @@ function _applyArgOverrides(
   // Apply argument option changes
   for (const i in argOverrides) {
     const thisOverride = argOverrides[i];
-    const thisArg: fuzzer.ArgDef<fuzzer.ArgType> = argsFlat[i];
+    const thisArg: fuzzer.ArgDef = argsFlat[i];
     if (Number(i) + 1 > argsFlat.length) {
       break; // exit the for loop
     }


### PR DESCRIPTION
`ArgDef` has a generic type parameter `T extends ArgType` and a `type: ArgTag` field, but these types are not aligned. This adds a lookup from `ArgTag` to the actual `ArgType` variants so the callsites do not have to pass in the generic parameter.