### PR TITLE
fix: filter leaders during `onRunStart` for `MutationInputGenerator`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ dist
 /telemetry
 
 # Python residue
+/.venv/
 __pycache__/
 
 # direnv files

--- a/src/fuzzer/generators/AbstractInputGenerator.ts
+++ b/src/fuzzer/generators/AbstractInputGenerator.ts
@@ -43,7 +43,12 @@ export abstract class AbstractInputGenerator {
 
   /**
    * Returns true If the generator has inputs available for use
-   * and false otherwise.
+   * and false otherwise. If it returns true, the next `next()` call
+   * should not fail.
+   *
+   * Note: since generators can have asynchronous behavior, `next()` could
+   * still succeed even when `nextable()` is false. E.g., AiInputGenerator
+   * could receive a response between `nextable()` and `next()`.
    */
   public nextable(): boolean {
     return true;

--- a/src/fuzzer/generators/Leaderboard.ts
+++ b/src/fuzzer/generators/Leaderboard.ts
@@ -138,4 +138,15 @@ export class Leaderboard<T> {
   public getLeaders(): { leader: T; score: number }[] {
     return structuredClone(this._leaders);
   } // fn: getLeaders
+
+  /**
+   * Filter all the leaders in the leaderboard using `fn`.
+   *
+   * @param fn the predicated used for filtering
+   */
+  filter(fn: (leader: { leader: T }) => boolean) {
+    if (this._leaders.length) {
+      this._leaders = this._leaders.filter(fn);
+    }
+  } // fn: validate
 } // class: Leaderboard

--- a/src/fuzzer/generators/MutationInputGenerator.test.ts
+++ b/src/fuzzer/generators/MutationInputGenerator.test.ts
@@ -1,0 +1,90 @@
+import * as ProgramFactory from "../analysis/ProgramFactory";
+import { MutationInputGenerator } from "./MutationInputGenerator";
+import { Leaderboard } from "./Leaderboard";
+import { InputAndSource } from "../Types";
+
+/**
+ * Provide a seed to ensure tests are deterministic.
+ */
+const seed: string = "qwertyuiop";
+
+describe("fuzzer/generator/MutationInputGenerator:", () => {
+  /**
+   * Regression tests for https://github.com/nanofuzz/nanofuzz/issues/351.
+   */
+  describe("onRunStart() validates the leaderboard", () => {
+    const tsFnWithNumberArrayInput = `function test(nums: number[]):void {0;}`;
+    const intervals = [{ min: 0, max: 1 }];
+    const dimLength = [{ min: 1, max: 2 }];
+    const nonCompliantValue = {
+      tag: "ArgValueTypeWrapped" as const,
+      value: [6],
+    };
+    const compliantValue = {
+      tag: "ArgValueTypeWrapped" as const,
+      value: [1, 1],
+    };
+    const program = ProgramFactory.fromSource(
+      () => tsFnWithNumberArrayInput,
+      "typescript"
+    );
+    const arg = program.functions["test"].getArgDefs();
+    const nums = arg[0];
+    nums.setIntervals(intervals);
+    nums.setOptions({ dimLength });
+
+    it(`Filters out specs noncompliant values after onRunStart()`, () => {
+      const leaderboard = new Leaderboard<InputAndSource>();
+      leaderboard.postScore(
+        {
+          tick: 1,
+          value: [nonCompliantValue],
+          source: {
+            type: "user",
+          },
+        },
+        1
+      );
+      const gen = new MutationInputGenerator(arg, seed, leaderboard);
+      gen.onRunStart(true);
+      expect(gen.nextable()).toBeFalse();
+    });
+
+    it(`Generate specs compliant values after onRunStart()`, () => {
+      const leaderboard = new Leaderboard<InputAndSource>();
+      leaderboard.postScore(
+        {
+          tick: 1,
+          value: [compliantValue],
+          source: {
+            type: "user",
+          },
+        },
+        1
+      );
+      leaderboard.postScore(
+        {
+          tick: 1,
+          value: [nonCompliantValue],
+          source: {
+            type: "user",
+          },
+        },
+        1
+      );
+      const gen = new MutationInputGenerator(arg, seed, leaderboard);
+      gen.onRunStart(true);
+      expect(gen.nextable()).toBeTrue();
+
+      for (let i = 0; i < 1000; i++) {
+        const { value: inputs } = gen.next();
+        const input = inputs[0].value;
+        expect(typeof input === "object" && Array.isArray(input)).toBeTruthy();
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        const inputArray = input as number[];
+        expect([1, 2].includes(inputArray.length)).toBeTrue();
+        expect(inputArray.every((n) => [0, 1].includes(n))).toBeTrue();
+      }
+    });
+  });
+});

--- a/src/fuzzer/generators/MutationInputGenerator.ts
+++ b/src/fuzzer/generators/MutationInputGenerator.ts
@@ -4,12 +4,13 @@ import { ArgType } from "../analysis/Types";
 import { Leaderboard } from "./Leaderboard";
 import { InputAndSource } from "../Types";
 import { ArgDefMutator } from "../analysis/ArgDefMutator";
+import { ArgDefValidator } from "../analysis/ArgDefValidator";
 
 /**
  * Generates new inputs by mutating prior "interesting" inputs
  */
 export class MutationInputGenerator extends AbstractInputGenerator {
-  private _leaderboard; // List of "interesting" inputs
+  private _leaderboard: Leaderboard<InputAndSource>; // List of "interesting" inputs
   private _maxMutations = 2; // Max mutations to apply to interesting inputs
 
   /**
@@ -92,4 +93,16 @@ export class MutationInputGenerator extends AbstractInputGenerator {
       },
     };
   } // fn: next
+
+  /**
+   * Clear any now-invalid items out of the leaderboard at the
+   * start of each run.
+   */
+  public onRunStart(_active: boolean): void {
+    // Input generation options may have changed, so filter the leaderboard
+    const validator = new ArgDefValidator(this._specs);
+    this._leaderboard.filter((leader: { leader: InputAndSource }) => {
+      return validator.validate(leader.leader.value);
+    });
+  } // fn: onRunStart
 } // class: MutationInputGenerator


### PR DESCRIPTION
Fixes #351.

Filters all specs noncompliant values during `onRunStart`. Since the `Leaderboard` class is generic the actual predicate has to be owned by `MutationInputGenerator`.