### PR TITLE
feat: add NaNofuzz version to output file

### DIFF
--- a/src/ToolVersion.test.ts
+++ b/src/ToolVersion.test.ts
@@ -1,0 +1,30 @@
+import pkg from "../package.json";
+import * as Config from "./Config";
+import { getToolVersion } from "./ToolVersion";
+
+describe("getToolVersion", () => {
+  const originalName = Config.get("nanofuzz.name", "NaNofuzz");
+  const originalVersion = process.env.NANOFUZZ_VERSION;
+
+  afterEach(() => {
+    Config.override("nanofuzz.name", originalName);
+    if (originalVersion === undefined) {
+      delete process.env.NANOFUZZ_VERSION;
+    } else {
+      process.env.NANOFUZZ_VERSION = originalVersion;
+    }
+  });
+
+  it("uses the configured tool name and build-time version", () => {
+    Config.override("nanofuzz.name", "StudyFuzz");
+    process.env.NANOFUZZ_VERSION = "9.8.7";
+
+    expect(getToolVersion()).toBe("StudyFuzz v9.8.7");
+  });
+
+  it("falls back to the package version outside a build", () => {
+    delete process.env.NANOFUZZ_VERSION;
+
+    expect(getToolVersion()).toBe(`${originalName} v${pkg.version}`);
+  });
+});

--- a/src/ToolVersion.ts
+++ b/src/ToolVersion.ts
@@ -1,0 +1,14 @@
+import pkg from "../package.json";
+import * as Config from "./Config";
+
+/**
+ * Returns the configured tool name and current NaNofuzz version.
+ *
+ * Builds inject `NANOFUZZ_VERSION`; source-only callers such as tests fall
+ * back to the package version.
+ */
+export function getToolVersion(): string {
+  const name = Config.get("nanofuzz.name", "NaNofuzz");
+  const version = process.env.NANOFUZZ_VERSION ?? pkg.version;
+  return `${name} v${version}`;
+}

--- a/src/fuzzer/Fuzzer.test.ts
+++ b/src/fuzzer/Fuzzer.test.ts
@@ -4,6 +4,11 @@ import * as CompilerFactory from "./compilers/CompilerFactory";
 import * as ValueMapper from "./mappers/ValueMapper";
 import { ArgDefValidator } from "./analysis/ArgDefValidator";
 import * as Parser from "./adapters/ParserAdapter";
+import { getToolVersion } from "../ToolVersion";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as JSONN from "../Jsonn";
 
 // Extend default test timeout to 60s
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
@@ -77,6 +82,27 @@ const floatOptions: FuzzOptions = {
 describe("fuzzer:", () => {
   beforeAll(async () => {
     await Parser.init();
+  });
+
+  it("includes the tool version in initialized and persisted results", async () => {
+    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "nanofuzz-version-"));
+    const outputFile = path.join(tmpdir, "results.json5");
+
+    try {
+      const results = await new Tester(
+        "nanofuzz-study/examples/1.ts",
+        "minValue",
+        { ...intOptions, maxTests: 1, outputFile }
+      ).testSync();
+      const persisted = JSONN.parse(fs.readFileSync(outputFile, "utf8"));
+
+      expect(results.toolVersion).toBe(getToolVersion());
+      expect(persisted).toEqual(
+        jasmine.objectContaining({ toolVersion: getToolVersion() })
+      );
+    } finally {
+      fs.rmSync(tmpdir, { recursive: true });
+    }
   });
 
   it("Fuzz example 01 - minValue", async () => {

--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -30,6 +30,7 @@ import { PropertyOracle } from "./oracles/PropertyOracle";
 import { AbstractProgram } from "./analysis/AbstractProgram";
 import { RunnerResult } from "./runners/AbstractRunner";
 import { CompilerStaleness } from "./compilers/Types";
+import { getToolVersion } from "../ToolVersion";
 
 export class Tester {
   protected _module: string; // module filename
@@ -177,6 +178,7 @@ export class Tester {
    */
   protected _getInitializedResults(): FuzzTestResults {
     return {
+      toolVersion: getToolVersion(),
       env: {
         options: structuredClone(this._options),
         function: this._function,
@@ -1116,6 +1118,7 @@ export type FuzzEnv = {
  * Fuzzer Test Result
  */
 export type FuzzTestResults = {
+  toolVersion: string; // NaNofuzz name and version that generated the results
   env: FuzzEnv; // fuzzer environment
   stopReason: FuzzStopReason; // why the fuzzer stopped
   stats: FuzzTestStats; // fuzzer statistics


### PR DESCRIPTION
## Summary

- add a shared tool-version helper that uses the configured study name and build-injected version
- fall back to the package version for source-only callers
- persist the mandatory `toolVersion` field in every `FuzzTestResults` output
- cover configured-name, version-fallback, initialized-result, and serialized JSON5 behavior

## Testing

- `npx --yes yarn@1.22.22 test` — build/typecheck and ESLint complete with 0 errors; Jasmine 235 specs, 0 failures
- `.venv/bin/pytest -q` — 3 passed
- built CLI smoke — output contains `toolVersion: "NaNofuzz v0.3.6"`
- `git diff --check`

Closes #451