### PR TITLE
chore: externalize `CompositeInputGenerator` and `Leaderboard` parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -257,6 +257,47 @@
             "default": "",
             "description": "Regex of files for NaNofuzz to ignore"
           },
+          "nanofuzz.generators.compositeLookbackWindow": {
+            "title": "Composite generator lookback window size for history",
+            "type": "integer",
+            "default": 500,
+            "minimum": 1,
+            "description": "Composite generator lookback window size for history"
+          },
+          "nanofuzz.generators.compositeChunkSize": {
+            "title": "Re-evaluate the composite generator's subgens after _chunkSize inputs generated",
+            "type": "integer",
+            "default": 20,
+            "minimum": 1,
+            "description": "Re-evaluate the composite generator's subgens after _chunkSize inputs generated"
+          },
+          "nanofuzz.generators.compositeExplorationChance": {
+            "title": "Composite generator additional chance of subgen exploration",
+            "type": "number",
+            "default": 0.1,
+            "minimum": 0,
+            "description": "Composite generator additional chance of subgen exploration"
+          },
+          "nanofuzz.generators.leaderboardMinScore": {
+            "title": "Leaderboard initial minimum score",
+            "type": "number",
+            "default": 0.9999,
+            "description": "Leaderboard initial minimum score"
+          },
+          "nanofuzz.generators.leaderboardInitialFocus": {
+            "title": "Leaderboard initial focus",
+            "type": "integer",
+            "default": 200,
+            "minimum": 1,
+            "description": "Amount of focus for new leaders"
+          },
+          "nanofuzz.generators.leaderboardFocusDecay": {
+            "title": "Leaderboard focus decay",
+            "type": "integer",
+            "default": 1,
+            "minimum": 0,
+            "description": "Amount of focus to decrement on each random leader selection"
+          },
           "telemetry.active": {
             "title": "Activate telemetry? (requires restart)",
             "type": "boolean",

--- a/src/fuzzer/generators/CompositeInputGenerator.ts
+++ b/src/fuzzer/generators/CompositeInputGenerator.ts
@@ -1,3 +1,4 @@
+import * as Config from "../../Config";
 import { AbstractInputGenerator } from "./AbstractInputGenerator";
 import { AbstractMeasure, BaseMeasurement } from "../measures/AbstractMeasure";
 import { Leaderboard } from "./Leaderboard";
@@ -36,15 +37,15 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
     progress: (number | undefined)[][]; // progress by measure and input tick (of L)
     cost: (number | undefined)[]; // cost by input tick (of L)
     currentIndex: number; // current index (of L) into last dimension of progress and cost
-  }[]; // history for each input generator
+  }[] = []; // history for each input generator
   private _scoredInputs: ScoredInput[] = []; // List of scored inputs
   private _injectedInputs: Omit<InputAndSource, "tick">[] = []; // Inputs to force generate first
   private _selectedSubgenIndex = -1; // Selected subordinate input generator (e.g., by efficiency)
   private _leaderboard; // Interesting inputs
   private _lastInput?: InputAndSource; // Last input generated
-  private readonly _L = 500; // Lookback window size for history !!!!!!! externalize
-  private readonly _chunkSize = 20; // Re-evaluate subgen after _chunkSize inputs generated !!!!!!! externalize
-  private readonly _P = 0.1; // Additional chance of subgen exploration !!!!!!! externalize
+  private _L = 500; // Lookback window size for history
+  private _chunkSize = 20; // Re-evaluate subgen after _chunkSize inputs generated
+  private _P = 0.1; // Additional chance of subgen exploration
   private _permitSubgens = true; // Allow generators to produce inputs
   private _genStats: FuzzTestStats["generators"]; // Generator statistics
   public static readonly INJECTED = "injected";
@@ -82,15 +83,40 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
     this._leaderboard = leaderboard;
     this._genStats = genStats;
 
-    // Initialize measure history
-    this._history = this._subgens.map(() => ({
-      progress: measures.map(() => Array(this._L).fill(undefined)),
-      cost: Array(this._L).fill(undefined),
-      currentIndex: 0,
-    }));
+    this._loadConfig();
 
     this.options = options;
   } // fn: constructor
+
+  /**
+   * Loads any configurable parameters using `Config`.
+   *
+   * If the lookback window size changes, the measure history is reset with
+   * the new window size.
+   */
+  private _loadConfig(): void {
+    const L = Config.get<number>(
+      "nanofuzz.generators.compositeLookbackWindow",
+      500
+    );
+    this._chunkSize = Config.get<number>(
+      "nanofuzz.generators.compositeChunkSize",
+      20
+    );
+    this._P = Config.get<number>(
+      "nanofuzz.generators.compositeExplorationChance",
+      0.1
+    );
+
+    if (L !== this._L || !this._history.length) {
+      this._L = L;
+      this._history = this._subgens.map(() => ({
+        progress: this._measures.map(() => Array(this._L).fill(undefined)),
+        cost: Array(this._L).fill(undefined),
+        currentIndex: 0,
+      }));
+    }
+  } // fn: _loadConfig
 
   /**
    * Returns true if further inputs may be produced, false otherwise.
@@ -368,6 +394,8 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
    * Startup when the test run begins
    */
   public onRunStart(gen: boolean): void {
+    this._loadConfig();
+    this._leaderboard.loadConfig();
     for (const subgen in this._subgens) {
       this._subgens[subgen].onRunStart(gen && this._activeSubgens[subgen]);
     }

--- a/src/fuzzer/generators/Leaderboard.ts
+++ b/src/fuzzer/generators/Leaderboard.ts
@@ -1,13 +1,15 @@
+import * as Config from "../../Config";
+
 /**
  * Running list of "interesting" inputs.
  */
 export class Leaderboard<T> {
   private _leaders: { leader: T; score: number; focus: number }[] = []; // List of leaders
-  private _minScore = 0.9999; // initial minimum score !!!!!!! externalize
+  private _minScore = 0.9999; // initial minimum score
   private _minScoreIdx = -1; // index of leader with the minimum score
   private _slots = 200; // maximum number of slots in leaderboard
-  private _initialFocus = 200; // Amount of focus for new leaders !!!!!!! externalize
-  private _focusDecay = 1; // Amount of focus to decrement on each random leader selection !!!!!!! externalize
+  private _initialFocus = 200; // Amount of focus for new leaders
+  private _focusDecay = 1; // Amount of focus to decrement on each random leader selection
 
   /**
    * Create a new list of interesting inputs
@@ -21,7 +23,27 @@ export class Leaderboard<T> {
     if (slots !== undefined) {
       this._slots = slots;
     }
+    this.loadConfig();
   } // fn: constructor
+
+  /**
+   * (Re)loads the leaderboard's configurable parameters from the
+   * `nanofuzz.generators.*` configuration.
+   */
+  public loadConfig(): void {
+    this._minScore = Config.get<number>(
+      "nanofuzz.generators.leaderboardMinScore",
+      0.9999
+    );
+    this._initialFocus = Config.get<number>(
+      "nanofuzz.generators.leaderboardInitialFocus",
+      200
+    );
+    this._focusDecay = Config.get<number>(
+      "nanofuzz.generators.leaderboardFocusDecay",
+      1
+    );
+  } // fn: loadConfig
 
   /**
    * Returns the leaderboard's name (currently just the constructor name)


### PR DESCRIPTION
Fixes #436.

In addition to externalizing the parameters, `CompositeInputGenerator` now would reload config during `onRunStart` to use the latest config values.