### PR TITLE
feat: run some hypothesis tests

### DIFF
--- a/src/fuzzer/analysis/python/PythonProgram.test.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.test.ts
@@ -816,14 +816,8 @@ def func(tdclass: TypedDictClass, tdFunc: TypedDictFunc):
       program.types["TypedDictClass"]
     );
   });
-});
 
-describe("hypothesis @given: ", () => {
-  beforeAll(async () => {
-    await Parser.init();
-  });
-
-  it("primitives and strings with options", () => {
+  it("hypothesis @given primitives with options", () => {
     const fn = ProgramFactory.fromSource(
       () => `
 @given(
@@ -856,7 +850,7 @@ def test_example(trigger, dep, trigger_val):
     expect(args[2].getIntervals()).toEqual([{ min: 0, max: 100 }]);
   });
 
-  it("positional arguments", () => {
+  it("hypothesis @given positional arguments", () => {
     const fn = ProgramFactory.fromSource(
       () => `
 @given(
@@ -874,7 +868,7 @@ def test_dates(year, month):
     expect(args[1].getIntervals()).toEqual([{ min: 1, max: 12 }]);
   });
 
-  it("nested lists and fixed_dictionaries", () => {
+  it("hypothesis @given nested lists and fixed_dictionaries", () => {
     const fn = ProgramFactory.fromSource(
       () => `
 @given(
@@ -911,7 +905,7 @@ def test_nested(complex_data):
     expect(tagsField?.getDim()).toEqual(1); // st.lists(st.text()) nested inside dict
   });
 
-  it("sampled_from", () => {
+  it("hypothesis @given sampled_from", () => {
     const fn = ProgramFactory.fromSource(
       () => `
 @given(
@@ -935,7 +929,7 @@ def test_sampled(status):
     ).toBeTrue();
   });
 
-  it("fixed_dictionaries with optional keys", () => {
+  it("hypothesis @given fixed_dictionaries with optional keys", () => {
     const fn = ProgramFactory.fromSource(
       () => `
 @given(
@@ -961,7 +955,7 @@ def test_optional_dict(payload):
     expect(optField?.isOptional()).toBeTrue();
   });
 
-  it("@givens take precedence over native type annotations", () => {
+  it("hypothesis @given takes precedence over native type annotations", () => {
     const fn = ProgramFactory.fromSource(
       () => `
 @given(
@@ -977,5 +971,82 @@ def test_precedence(val: float):
     expect(arg.getType()).toEqual(ArgTag.NUMBER);
     expect(arg.getOptions().numInteger).toBeTrue();
     expect(arg.getIntervals()).toEqual([{ min: 50, max: 60 }]);
+  });
+
+  it("isVoid===true for functions lacking return statements", () => {
+    const fns = ProgramFactory.fromSource(
+      () => `
+def no_return():
+    x = 1
+    y = 2
+`,
+      "python"
+    ).functionsExported;
+
+    expect(fns["no_return"].isVoid()).toBeTrue();
+  });
+
+  it("isVoid===true for functions with empty return statements", () => {
+    const fns = ProgramFactory.fromSource(
+      () => `
+def bare_return():
+    return
+`,
+      "python"
+    ).functionsExported;
+
+    expect(fns["bare_return"].isVoid()).toBeTrue();
+  });
+
+  it("isVoid===true for functions with only `return None`", () => {
+    const fns = ProgramFactory.fromSource(
+      () => `
+def return_none():
+    return None
+`,
+      "python"
+    ).functionsExported;
+
+    expect(fns["return_none"].isVoid()).toBeTrue();
+  });
+
+  it("isVoid===true for functions where all branches return no value", () => {
+    const fns = ProgramFactory.fromSource(
+      () => `
+def multi_none_returns(cond: bool):
+    if cond:
+        return None
+    else:
+        return
+`,
+      "python"
+    ).functionsExported;
+
+    expect(fns["multi_none_returns"].isVoid()).toBeTrue();
+  });
+
+  it("isVoid===false for functions with return <value>", () => {
+    const fns = ProgramFactory.fromSource(
+      () => `
+def returns_value():
+    return 42
+`,
+      "python"
+    ).functionsExported;
+
+    expect(fns["returns_value"].isVoid()).toBeFalse();
+  });
+
+  it("isVoid===true for lambdas returning None", () => {
+    const fns = ProgramFactory.fromSource(
+      () => `x=5
+lam_none = lambda: None
+lam_val = lambda: x+1
+`,
+      "python"
+    ).functionsExported;
+
+    expect(fns["lam_none"].isVoid()).toBeTrue();
+    expect(fns["lam_val"].isVoid()).toBeFalse();
   });
 });

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -989,7 +989,8 @@ export class PythonProgram extends AbstractProgram {
 
     // Determine if this a `void` function
     const bodyNode = defNode.node.childForFieldName("body");
-    const bodyIsVoid = !!bodyNode && PythonProgram._isFunctionVoid(bodyNode);
+    const bodyIsVoid =
+      !!bodyNode && PythonProgram._isFunctionBodyVoid(bodyNode);
     try {
       if (typeNode) {
         isVoid = typeNode.node.namedChild(0)?.type === "none";
@@ -1566,7 +1567,7 @@ export class PythonProgram extends AbstractProgram {
    * @param `node` AST node of function
    * @returns `true` if implicitly `void`; false, otherwise
    */
-  protected static _isFunctionVoid(node: Parser.SyntaxNode): boolean {
+  protected static _isFunctionBodyVoid(node: Parser.SyntaxNode): boolean {
     const returnStatements: Parser.SyntaxNode[] = [];
 
     const collectReturns = (node: Parser.SyntaxNode) => {

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -841,12 +841,21 @@ export class PythonProgram extends AbstractProgram {
     captures: Parser.QueryCapture[]
   ): FunctionRef | undefined {
     const nameNode = captures.find((c) => c.name === "function.name");
-    const bodyNode = captures.find((c) => c.name === "function.body");
     const defNode = captures.find((c) => c.name === "function.def");
-    const argsNode = captures.find((c) => c.name === "function.params");
-    if (!nameNode || !bodyNode || !defNode) {
+    if (!nameNode || !defNode) {
       return undefined;
     }
+    const argsNode = defNode.node.namedChildren.find(
+      (c) => c.type === "lambda_parameters" || c.type === "parameters"
+    );
+    const bodyNode = defNode.node.lastNamedChild;
+    if (!bodyNode) {
+      return undefined;
+    }
+
+    // A lambda is only `void` if its single expression body is 'none' (e.g. lambda: None)
+    const isVoid = bodyNode.type === "none";
+
     return {
       module: this._filename,
       name: nameNode.node.text,
@@ -855,15 +864,17 @@ export class PythonProgram extends AbstractProgram {
       startOffset: defNode.node.startIndex,
       endOffset: defNode.node.endIndex,
       isExported: true,
-      isVoid: false,
-      args: argsNode?.node.namedChildren
-        .filter(
-          (arg) =>
-            arg.type === "identifier" ||
-            arg.type === "typed_parameter" ||
-            arg.type === "typed_default_parameter"
-        )
-        .map((arg) => this._getTypeRefFromAstNode(arg)),
+      isVoid,
+      args: argsNode
+        ? argsNode.namedChildren
+            .filter(
+              (arg) =>
+                arg.type === "identifier" ||
+                arg.type === "typed_parameter" ||
+                arg.type === "typed_default_parameter"
+            )
+            .map((arg) => this._getTypeRefFromAstNode(arg))
+        : [], // e.g., `lambda: None`
       returnType: undefined,
       cmt: undefined,
     };
@@ -975,12 +986,18 @@ export class PythonProgram extends AbstractProgram {
       )
         ? docstringNode?.text
         : undefined;
+
+    // Determine if this a `void` function
+    const bodyNode = defNode.node.childForFieldName("body");
+    const bodyIsVoid = !!bodyNode && PythonProgram._isFunctionVoid(bodyNode);
     try {
       if (typeNode) {
         isVoid = typeNode.node.namedChild(0)?.type === "none";
         if (!isVoid) {
           returnType = this._getTypeRefFromAstNode(typeNode.node);
         }
+      } else {
+        isVoid = bodyIsVoid;
       }
     } catch {
       if (!isVoid) {
@@ -988,6 +1005,7 @@ export class PythonProgram extends AbstractProgram {
         // what can i say
       }
     }
+
     return {
       module: this._filename,
       name: nameNode.node.text,
@@ -1500,9 +1518,7 @@ export class PythonProgram extends AbstractProgram {
       `
 (assignment
   left: (identifier) @function.name
-  right: (lambda
-    parameters: (lambda_parameters)? @function.params
-    body: (_)) @function.def)
+  right: (lambda) @function.def)
 `
     );
     const lambdaMatches = lambdaQuery.matches(this._ast.rootNode);
@@ -1541,6 +1557,52 @@ export class PythonProgram extends AbstractProgram {
    */
   protected _findDefaultTypeExport(): TypeRef | undefined {
     return undefined;
+  }
+
+  /**
+   * Determines whether a function body lacks return statements or
+   * if all return statements return None or no data.
+   *
+   * @param `node` AST node of function
+   * @returns `true` if implicitly `void`; false, otherwise
+   */
+  protected static _isFunctionVoid(node: Parser.SyntaxNode): boolean {
+    const returnStatements: Parser.SyntaxNode[] = [];
+
+    const collectReturns = (node: Parser.SyntaxNode) => {
+      // Ignore nested functions and lambdas
+      if (node.type === "function_definition" || node.type === "lambda") {
+        return;
+      }
+      if (node.type === "return_statement") {
+        returnStatements.push(node);
+      }
+      for (const child of node.children) {
+        collectReturns(child);
+      }
+    };
+
+    collectReturns(node);
+
+    // No return statements -> void
+    if (returnStatements.length === 0) {
+      return true;
+    }
+
+    // Check if ALL return statements return nothing or `None`
+    for (const ret of returnStatements) {
+      const namedChildren = ret.namedChildren;
+      if (namedChildren.length > 0) {
+        const expr = namedChildren[0];
+        // If any return statement returns something other than 'none', it is not void
+        if (expr.type !== "none") {
+          return false;
+        }
+      }
+    }
+
+    // No return statements with a value found
+    return true;
   }
 
   public resolveTypeRef(typeRef: TypeRef): TypeRef {

--- a/src/fuzzer/oracles/ImplicitOracle.ts
+++ b/src/fuzzer/oracles/ImplicitOracle.ts
@@ -5,7 +5,7 @@ import { Judgment } from "./Types";
  * The implicit oracle only passes when:
  *  - the value contains no nulls, undefineds, NaNs, or Infinity values
  *  - the function did not throw an exception or timeout
- *  - if a void return function, output is `undefined`
+ *  - if a void return function, output is `undefined` or `null`
  */
 export class ImplicitOracle {
   public static judge(
@@ -18,8 +18,10 @@ export class ImplicitOracle {
       // Exceptions and timeouts fail the implicit oracle
       return "fail";
     } else if (isVoidFn) {
-      // Functions with a void return type should only return undefined
-      return outputValue.some((e) => e.value !== undefined) ? "fail" : "pass";
+      // Functions with a void return type may return undefined or null
+      return outputValue.some((e) => e.value !== undefined && e.value !== null)
+        ? "fail"
+        : "pass";
     } else {
       // Non-void functions should not output disallowed values
       return outputValue.some((e) => !implicitOracle(e.value))

--- a/src/fuzzer/runners/PythonRunnerHost.py
+++ b/src/fuzzer/runners/PythonRunnerHost.py
@@ -279,9 +279,18 @@ def run_put(input: RunnerInput, filename: str, cov: coverage.Coverage) -> Runner
     value = None
     try:
         with redirect_stdout(io.StringIO()) as f:
-            value = fn(*input["args"])
+            # If fn is a Hypothesis-wrapped test, bypass Hypothesis
+            # and call the original underlying function
+            if hasattr(fn, 'hypothesis') and hasattr(fn.hypothesis, 'inner_test'):
+                # Unwrap Hypothesis test function
+                value = fn.hypothesis.inner_test(*input["args"])
+            else:
+                # Not Hypothesis; call directly
+                value = fn(*input["args"])
     except Exception as e:
-        error = e
+        # Hypothesis `assume` failures are not errors
+        if e.__class__.__name__ != "UnsatisfiedAssumption":
+            error = e
     finally:
         cov.stop()
 


### PR DESCRIPTION
This PR adds two bits of functionality that allow NaNofuzz to run some Hypothesis tests directly:
1. Call the original, unwrapped test function rather than wrapped Hypothesis version
2. Do not consider `assume()` failures to be an failures even though they throw exceptions

For `assume()` failures, NaNofuzz does not do anything special and at the moment simply returns `None`. If the function return type is not `void` and the heuristic oracle is enabled, then a test failure might be incidentally reported. This limited support might be improved in the future.

Related to the above, NaNofuzz now analyzes the function body of Python programs without a declared return type to infer whether or not they, in effect, have a `void` return type (e.g., `None`).