### PR TITLE
fix: python hypothesis strategy ingestion

### DIFF
--- a/src/fuzzer/analysis/python/PythonProgram.test.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.test.ts
@@ -947,6 +947,28 @@ def test_sampled(status):
     ).toBeTrue();
   });
 
+  it("hypothesis @given sampled_from tuples", () => {
+    const fn = ProgramFactory.fromSource(
+      () => `
+@given(st.sampled_from([("input", "disabled")]))
+def test_sampled_tuple(elem_attr):
+    pass
+        `,
+      "python"
+    ).functionsExported["test_sampled_tuple"];
+
+    const arg = fn.getArgDefs()[0];
+    expect(arg.getType()).toEqual(ArgTag.UNION);
+    expect(arg.getChildren().length).toEqual(1);
+    expect(arg.getChildren()[0].getType()).toEqual(ArgTag.TUPLE);
+    expect(
+      arg
+        .getChildren()[0]
+        .getChildren()
+        .map((child) => child.getConstantValue())
+    ).toEqual(["input", "disabled"]);
+  });
+
   it("hypothesis @given fixed_dictionaries with optional keys", () => {
     const fn = ProgramFactory.fromSource(
       () => `

--- a/src/fuzzer/analysis/python/PythonProgram.test.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.test.ts
@@ -658,6 +658,20 @@ from .schemas import *`,
     expect(fn.isVoid()).toBeTrue();
   });
 
+  it("rejects unannotated default parameters", () => {
+    spyOn(console, "debug");
+    const program = new InspectablePythonProgram(
+      () => `def x(y=22000):
+    print("hi")`,
+      "default_parameter.py"
+    );
+
+    expect(program.functionsExported["x"]).toBeUndefined();
+    expect(program.unsupportedFunctions["x"]).toEqual(
+      jasmine.objectContaining({ reason: jasmine.stringMatching("Missing type annotation") })
+    );
+  });
+
   it("keeps PEP 604 union members as function argument children", () => {
     const fn = ProgramFactory.fromSource(
       () => `def parse(value: int | str) -> int | str:

--- a/src/fuzzer/analysis/python/PythonProgram.test.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.test.ts
@@ -201,6 +201,15 @@ type MixedColumn = list[int | str]`,
     ).toEqual([ArgTag.NUMBER, ArgTag.STRING]);
   });
 
+  it("collapses singleton annotation unions", () => {
+    const types = ProgramFactory.fromSource(
+      () => "type MaybeCount = Optional[int]",
+      "python"
+    ).types;
+
+    expect(types["MaybeCount"].type?.type).toEqual(ArgTag.NUMBER);
+  });
+
   it("extracts TypedDict annotations as fixed objects", () => {
     const types = ProgramFactory.fromSource(
       () => `class Player(TypedDict):

--- a/src/fuzzer/analysis/python/PythonProgram.test.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.test.ts
@@ -854,8 +854,8 @@ def test_example(trigger, dep, trigger_val):
     const fn = ProgramFactory.fromSource(
       () => `
 @given(
-    year=st.integers(2000, 2030),
-    month=st.integers(1, 12)
+    st.integers(2000, 2030),
+    st.integers(1, 12)
 )
 def test_dates(year, month):
     pass
@@ -866,6 +866,24 @@ def test_dates(year, month):
     const args = fn.getArgDefs();
     expect(args[0].getIntervals()).toEqual([{ min: 2000, max: 2030 }]);
     expect(args[1].getIntervals()).toEqual([{ min: 1, max: 12 }]);
+  });
+
+  it("hypothesis @given negative numeric values", () => {
+    const fn = ProgramFactory.fromSource(
+      () => `
+@given(
+    integer=st.integers(min_value=-10, max_value=200),
+    decimal=st.floats(min_value=-1.5, max_value=2.5)
+)
+def test_bounds(integer, decimal):
+    pass
+        `,
+      "python"
+    ).functionsExported["test_bounds"];
+
+    const args = fn.getArgDefs();
+    expect(args[0].getIntervals()).toEqual([{ min: -10, max: 200 }]);
+    expect(args[1].getIntervals()).toEqual([{ min: -1.5, max: 2.5 }]);
   });
 
   it("hypothesis @given nested lists and fixed_dictionaries", () => {

--- a/src/fuzzer/analysis/python/PythonProgram.test.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.test.ts
@@ -247,6 +247,11 @@ type MixedColumn = list[int | str]`,
     expect(types["Settings"].type?.children[0].type?.type).toEqual(
       ArgTag.UNION
     );
+    expect(
+      types["Settings"].type?.children[0].type?.children.map(
+        (child) => child.type?.type
+      )
+    ).toEqual([ArgTag.NUMBER, ArgTag.LITERAL]);
     expect(types["Settings"].type?.children[1].type?.type).toEqual(
       ArgTag.TUPLE
     );

--- a/src/fuzzer/analysis/python/PythonProgram.test.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.test.ts
@@ -958,15 +958,33 @@ def test_sampled_tuple(elem_attr):
     ).functionsExported["test_sampled_tuple"];
 
     const arg = fn.getArgDefs()[0];
-    expect(arg.getType()).toEqual(ArgTag.UNION);
-    expect(arg.getChildren().length).toEqual(1);
-    expect(arg.getChildren()[0].getType()).toEqual(ArgTag.TUPLE);
-    expect(
-      arg
-        .getChildren()[0]
-        .getChildren()
-        .map((child) => child.getConstantValue())
-    ).toEqual(["input", "disabled"]);
+    expect(arg.getType()).toEqual(ArgTag.TUPLE);
+    expect(arg.getChildren().map((child) => child.getConstantValue())).toEqual([
+      "input",
+      "disabled",
+    ]);
+  });
+
+  it("hypothesis @given sampled_from dictionaries", () => {
+    const fn = ProgramFactory.fromSource(
+      () => `
+@given(st.sampled_from([{"mode": "disabled", "retry": 0}]))
+def test_sampled_dictionary(config):
+    pass
+        `,
+      "python"
+    ).functionsExported["test_sampled_dictionary"];
+
+    const arg = fn.getArgDefs()[0];
+    expect(arg.getType()).toEqual(ArgTag.OBJECT);
+    expect(arg.getChildren().map((child) => child.getName())).toEqual([
+      "mode",
+      "retry",
+    ]);
+    expect(arg.getChildren().map((child) => child.getConstantValue())).toEqual([
+      "disabled",
+      0,
+    ]);
   });
 
   it("hypothesis @given fixed_dictionaries with optional keys", () => {

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -1370,6 +1370,34 @@ export class PythonProgram extends AbstractProgram {
               };
             }
           }
+          if (valueNode.type === "dictionary") {
+            const children: TypeRef[] = [];
+            for (const pair of valueNode.namedChildren) {
+              if (pair.type !== "pair") return undefined;
+              const key = parseLiteral(
+                pair.childForFieldName("key") ?? undefined
+              );
+              const value = pair.childForFieldName("value");
+              const child = value ? getSampledType(value) : undefined;
+              if (typeof key !== "string" || child === undefined) {
+                return undefined;
+              }
+              child.name = key;
+              children.push(child);
+            }
+            return {
+              module: this._filename,
+              dims: 0,
+              optional: false,
+              isExported: false,
+              type: {
+                type: ArgTag.OBJECT,
+                dims: 0,
+                children,
+                resolved: true,
+              },
+            };
+          }
           return undefined;
         };
 
@@ -1386,7 +1414,11 @@ export class PythonProgram extends AbstractProgram {
           }
         }
 
-        // Represent sampled_from as a UNION of LITERALs
+        if (sampledTypes.length === 1) {
+          return sampledTypes[0];
+        }
+
+        // Represent multiple sampled values as a union.
         thisType.type = {
           type: ArgTag.UNION,
           dims: 0,

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -896,6 +896,7 @@ export class PythonProgram extends AbstractProgram {
 
     // Extract for Hypothesis @given(...) first
     const hypothesisArgMap: Record<string, TypeRef> = {};
+    const hypothesisPositionalArgs: (TypeRef | undefined)[] = [];
     const currentNode: Parser.Node | null = defNode.node.parent;
     if (currentNode?.type === "decorated_definition") {
       for (const child of currentNode.namedChildren) {
@@ -922,6 +923,12 @@ export class PythonProgram extends AbstractProgram {
                       hypothesisArgMap[paramName] = hypothesisTypeRef;
                     }
                   }
+                } else {
+                  hypothesisPositionalArgs.push(
+                    argChild.type === "call"
+                      ? this._getTypeRefFromStrategy(argChild)
+                      : undefined
+                  );
                 }
               }
             }
@@ -941,7 +948,7 @@ export class PythonProgram extends AbstractProgram {
 
     // Hypothesis strategies have precedence over native type annotations
     const finalArgs: TypeRef[] = [];
-    for (const paramNode of parameterNodes) {
+    for (const [paramIndex, paramNode] of parameterNodes.entries()) {
       // Get parameter name
       let paramName: string | undefined;
       if (paramNode.type === "identifier") {
@@ -959,8 +966,10 @@ export class PythonProgram extends AbstractProgram {
 
       // If a hypothesis strategy exists for this parameter, use it.
       // Otherwise, parse the native type annotation
-      if (paramName && paramName in hypothesisArgMap) {
-        const hypType = hypothesisArgMap[paramName];
+      const hypType = paramName
+        ? (hypothesisArgMap[paramName] ?? hypothesisPositionalArgs[paramIndex])
+        : hypothesisPositionalArgs[paramIndex];
+      if (hypType !== undefined) {
         hypType.name = paramName;
         finalArgs.push(hypType);
       } else {
@@ -1075,6 +1084,12 @@ export class PythonProgram extends AbstractProgram {
       if (!valNode) return undefined;
       if (valNode.type === "integer" || valNode.type === "float") {
         return Number(valNode.text.replace(/_/g, ""));
+      }
+      if (valNode.type === "unary_operator") {
+        const operand = parseLiteral(valNode.lastNamedChild ?? undefined);
+        if (typeof operand === "number") {
+          return valNode.text.startsWith("-") ? -operand : operand;
+        }
       }
       if (valNode.type === "true") return true;
       if (valNode.type === "false") return false;

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -819,10 +819,20 @@ export class PythonProgram extends AbstractProgram {
       }
       case ArgTag.UNION:
       case ArgTag.TUPLE: {
+        const children = this._getChildrenFromNode(typeNode);
+        // Collapse unions of a single value 
+        if (type === ArgTag.UNION && children.length === 1) {
+          const child = children[0];
+          thisType.dims = child.dims;
+          thisType.optional = child.optional;
+          thisType.type = child.type;
+          thisType.typeRefName = child.typeRefName;
+          break;
+        }
         thisType.type = {
           dims: dims,
           type: type,
-          children: this._getChildrenFromNode(typeNode),
+          children,
         };
         break;
       }
@@ -1518,6 +1528,10 @@ export class PythonProgram extends AbstractProgram {
               return undefined;
             }
           }
+        }
+
+        if (children.length === 1) {
+          return children[0];
         }
 
         thisType.type = {

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -876,6 +876,7 @@ export class PythonProgram extends AbstractProgram {
             .filter(
               (arg) =>
                 arg.type === "identifier" ||
+                arg.type === "default_parameter" ||
                 arg.type === "typed_parameter" ||
                 arg.type === "typed_default_parameter"
             )
@@ -948,6 +949,7 @@ export class PythonProgram extends AbstractProgram {
       argsNode?.node.namedChildren.filter(
         (arg) =>
           arg.type === "identifier" ||
+          arg.type === "default_parameter" ||
           arg.type === "typed_parameter" ||
           arg.type === "typed_default_parameter"
       ) ?? [];

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -816,7 +816,7 @@ export class PythonProgram extends AbstractProgram {
       case ArgTag.UNION:
       case ArgTag.TUPLE: {
         const children = this._getChildrenFromNode(typeNode);
-        // Collapse unions of a single value 
+        // Collapse unions of a single value
         if (type === ArgTag.UNION && children.length === 1) {
           const child = children[0];
           thisType.dims = child.dims;
@@ -1344,7 +1344,9 @@ export class PythonProgram extends AbstractProgram {
         const listArg = argsNode?.namedChildren[0];
         const sampledTypes: TypeRef[] = [];
 
-        const getSampledType = (valueNode: Parser.Node): TypeRef | undefined => {
+        const getSampledType = (
+          valueNode: Parser.Node
+        ): TypeRef | undefined => {
           const literalValue = parseLiteral(valueNode);
           if (isArgType(literalValue)) {
             return {
@@ -1363,7 +1365,9 @@ export class PythonProgram extends AbstractProgram {
           }
           if (valueNode.type === "tuple") {
             const children = valueNode.namedChildren.map(getSampledType);
-            if (children.every((child): child is TypeRef => child !== undefined)) {
+            if (
+              children.every((child): child is TypeRef => child !== undefined)
+            ) {
               return {
                 module: this._filename,
                 dims: 0,
@@ -1415,9 +1419,7 @@ export class PythonProgram extends AbstractProgram {
             if (sampledType !== undefined) {
               sampledTypes.push(sampledType);
             } else {
-              console.warn(
-                `Unsupported value in '${funcName}': ${item.text}.`
-              );
+              console.warn(`Unsupported value in '${funcName}': ${item.text}.`);
             }
           }
         }

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -688,16 +688,12 @@ export class PythonProgram extends AbstractProgram {
         return [];
 
       // PEP 604 `A | B` parses to `binary_operator`; `union_type` is handled
-      // defensively. Each operand is a child; drop `None` arms, whose
-      // nullability is carried by `TypeRef.optional` instead.
+      // defensively. Keep every arm to match `Union[A, B]`, including None.
       case "binary_operator":
       case "union_type":
-        return node.namedChildren
-          .filter(
-            (arm) =>
-              (arm.type === "type" ? arm.firstNamedChild : arm)?.type !== "none"
-          )
-          .map((arm) => this._getTypeRefFromAstNode(arm));
+        return node.namedChildren.map((arm) =>
+          this._getTypeRefFromAstNode(arm)
+        );
 
       case "generic_type":
       case "subscript": {

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -756,6 +756,8 @@ export class PythonProgram extends AbstractProgram {
         }
         break; // type-position identifier: classify below (typeNode = node)
       }
+      case "default_parameter":
+        throw new Error(`Missing type annotation: ${node.toString()}`);
       case "type": {
         break;
       }

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -1149,18 +1149,15 @@ export class PythonProgram extends AbstractProgram {
       }
 
       case "floats": {
-        [
-          "allow_nan",
-          "allow_infinity",
-          "allow_subnormal",
-          "width",
-          "exclude_min",
-          "exclude_max",
-        ].forEach((kwd) => {
-          if (getKwdArg(node, kwd, -1)) {
-            console.warn(`The '${kwd}' property is not yet supported.`);
+        // Note: we ignore "allow_nan" and "allow_infinity" because\
+        //       we don't presently generate those values
+        ["allow_subnormal", "width", "exclude_min", "exclude_max"].forEach(
+          (kwd) => {
+            if (getKwdArg(node, kwd, -1)) {
+              console.warn(`The '${kwd}' property is not yet supported.`);
+            }
           }
-        });
+        );
 
         const minVal = parseLiteral(getKwdArg(node, "min_value", 0));
         const maxVal = parseLiteral(getKwdArg(node, "max_value", 1));

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -1235,7 +1235,7 @@ export class PythonProgram extends AbstractProgram {
           };
         } else {
           console.warn(
-            `Unsupported literal in 'sampled_from': ${JSONN.stringify(lit)}.`
+            `Unsupported literal in '${funcName}': ${lit === undefined ? "undefined" : JSONN.stringify(lit)}.`
           );
         }
         break;
@@ -1334,16 +1334,53 @@ export class PythonProgram extends AbstractProgram {
       case "sampled_from": {
         const argsNode = node.childForFieldName("arguments");
         const listArg = argsNode?.namedChildren[0];
-        const literalValues: ArgType[] = [];
+        const sampledTypes: TypeRef[] = [];
+
+        const getSampledType = (valueNode: Parser.Node): TypeRef | undefined => {
+          const literalValue = parseLiteral(valueNode);
+          if (isArgType(literalValue)) {
+            return {
+              module: this._filename,
+              dims: 0,
+              optional: false,
+              isExported: false,
+              type: {
+                type: ArgTag.LITERAL,
+                dims: 0,
+                children: [],
+                value: literalValue,
+                resolved: true,
+              },
+            };
+          }
+          if (valueNode.type === "tuple") {
+            const children = valueNode.namedChildren.map(getSampledType);
+            if (children.every((child): child is TypeRef => child !== undefined)) {
+              return {
+                module: this._filename,
+                dims: 0,
+                optional: false,
+                isExported: false,
+                type: {
+                  type: ArgTag.TUPLE,
+                  dims: 0,
+                  children,
+                  resolved: true,
+                },
+              };
+            }
+          }
+          return undefined;
+        };
 
         if (listArg && (listArg.type === "list" || listArg.type === "tuple")) {
           for (const item of listArg.namedChildren) {
-            const lit = parseLiteral(item);
-            if (isArgType(lit)) {
-              literalValues.push(lit);
+            const sampledType = getSampledType(item);
+            if (sampledType !== undefined) {
+              sampledTypes.push(sampledType);
             } else {
               console.warn(
-                `Unsupported literal in 'sampled_from': ${JSONN.stringify(lit)}.`
+                `Unsupported value in '${funcName}': ${item.text}.`
               );
             }
           }
@@ -1353,19 +1390,7 @@ export class PythonProgram extends AbstractProgram {
         thisType.type = {
           type: ArgTag.UNION,
           dims: 0,
-          children: literalValues.map((val) => ({
-            module: this._filename,
-            dims: 0,
-            optional: false,
-            isExported: false,
-            type: {
-              type: ArgTag.LITERAL,
-              dims: 0,
-              children: [],
-              value: val,
-              resolved: true,
-            },
-          })),
+          children: sampledTypes,
           resolved: true,
         };
         break;

--- a/src/ui/FuzzPanelController.ts
+++ b/src/ui/FuzzPanelController.ts
@@ -3517,7 +3517,7 @@ export function provideCodeLenses(
   } catch (e: unknown) {
     const msg = isError(e) ? e.message : JSON.stringify(e);
     console.error(
-      `Error parsing typescript file: ${document.fileName} error: ${msg}`
+      `Error parsing source file: ${document.fileName} error: ${msg}`
     );
   }
 


### PR DESCRIPTION
A bundle of bugfixes related to ingesting a subset of Hypothesis strategies.

Also fixes #462.