### PR TITLE
feat: unique array elements

### DIFF
--- a/src/fuzzer/Types.ts
+++ b/src/fuzzer/Types.ts
@@ -222,6 +222,7 @@ export type FuzzArgOverride = {
   };
   array?: {
     dimLength: { min: number; max: number }[];
+    dimsUnique: boolean;
   };
   isNoInput?: boolean;
 };

--- a/src/fuzzer/adapters/jest/JestAdapter.test.ts
+++ b/src/fuzzer/adapters/jest/JestAdapter.test.ts
@@ -10,6 +10,7 @@ const argDefaults: ArgOptions = {
   anyDims: 0,
   dftDimLength: { min: 0, max: 1 },
   dimLength: [],
+  dimsUnique: false,
 };
 
 const baseOptions: Omit<

--- a/src/fuzzer/adapters/pytest/PytestAdapter.test.ts
+++ b/src/fuzzer/adapters/pytest/PytestAdapter.test.ts
@@ -10,6 +10,7 @@ const argDefaults: ArgOptions = {
   anyDims: 0,
   dftDimLength: { min: 0, max: 1 },
   dimLength: [],
+  dimsUnique: false,
 };
 
 const baseOptions: Omit<

--- a/src/fuzzer/analysis/ArgDef.test.ts
+++ b/src/fuzzer/analysis/ArgDef.test.ts
@@ -417,6 +417,78 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
     expect(val.validate(input)).toBeTrue();
   });
 
+  it("dimsUnique: generates unique outer-dimension values", () => {
+    const spec = makeArgDef(
+      dummyModule,
+      "uniqueNumbers",
+      0,
+      ArgTag.NUMBER,
+      {
+        ...argOptions,
+        dimsUnique: true,
+        dimLength: [{ min: 5, max: 5 }],
+      },
+      1
+    );
+    const generated = ArgDefGenerator.gen(spec, seedrandom("dimsUnique"));
+
+    expect(ArgDefValidator.validate(generated, spec)).toBeTrue();
+    if (!Array.isArray(generated)) {
+      throw new Error("Expected an array");
+    }
+    expect(new Set(generated).size).toEqual(5);
+  });
+
+  it("dimsUnique: can give up at the minimum dimension length", () => {
+    const spec = makeArgDef(
+      dummyModule,
+      "uniqueLiteral",
+      0,
+      ArgTag.LITERAL,
+      {
+        ...argOptions,
+        dimsUnique: true,
+        dimLength: [{ min: 1, max: 2 }],
+      },
+      1,
+      false,
+      [],
+      undefined,
+      1
+    );
+    const generated = ArgDefGenerator.gen(spec, seedrandom("uniqueLiteral"));
+
+    if (!Array.isArray(generated)) {
+      throw new Error("Expected an array");
+    }
+    expect(generated.length).toEqual(1);
+    expect(generated[0] === 1).toBeTrue();
+    expect(ArgDefValidator.validate(generated, spec)).toBeTrue();
+  });
+
+  it("dimsUnique: fails when constraints seem impossible", () => {
+    const spec = makeArgDef(
+      dummyModule,
+      "uniqueLiteral",
+      0,
+      ArgTag.LITERAL,
+      {
+        ...argOptions,
+        dimsUnique: true,
+        dimLength: [{ min: 2, max: 2 }],
+      },
+      1,
+      false,
+      [],
+      undefined,
+      1
+    );
+
+    expect(() =>
+      ArgDefGenerator.gen(spec, seedrandom("uniqueLiteral"))
+    ).toThrowError("Unable to generate a unique array element");
+  });
+
   /**
    * This test generates random ArgDef specs, generates
    * and mutates inputs from those specs, and validates

--- a/src/fuzzer/analysis/ArgDef.test.ts
+++ b/src/fuzzer/analysis/ArgDef.test.ts
@@ -638,7 +638,7 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
     const failingMutators: { [k: string]: number } = {};
     const dupeMutators: { [k: string]: number } = {};
     let uniqueDimensionSpecs = 0;
-    let i = 50;
+    let i = 100;
     while (i--) {
       const spec = [getRandomArgDef(prng, Math.floor(prng() * 2))];
       if (spec[0].getDim() > 0 && spec[0].getOptions().dimsUnique) {
@@ -670,7 +670,7 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
             const inputStringBefore = JSONN.stringify(input);
             const muts = ArgDefMutator.getMutators(spec, input, prng);
             if (muts.length) {
-              const index = Math.floor(prng() * (muts.length - 1));
+              const index = Math.floor(prng() * muts.length);
               const mut = muts[index];
               mut.fn(); // mutate the input
               const inputStringAfter = JSONN.stringify(input);

--- a/src/fuzzer/analysis/ArgDef.test.ts
+++ b/src/fuzzer/analysis/ArgDef.test.ts
@@ -580,6 +580,42 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
     }
   });
 
+  it("mutates optional tuple members to undefined", () => {
+    const spec = makeArgDef(
+      dummyModule,
+      "tuple",
+      0,
+      ArgTag.TUPLE,
+      argOptions,
+      0,
+      false,
+      [
+        makeTypeRef(dummyModule, "required", ArgTag.NUMBER, 0),
+        makeTypeRef(
+          dummyModule,
+          "optional",
+          ArgTag.LITERAL,
+          0,
+          true,
+          [],
+          undefined,
+          1
+        ),
+      ]
+    );
+    const input = [{ tag: "ArgValueTypeWrapped" as const, value: [1, 1] }];
+    const mutator = ArgDefMutator.getMutators(
+      [spec],
+      input,
+      seedrandom("optionalTuple")
+    ).find((candidate) => candidate.name === "optional-delete");
+
+    expect(mutator).toBeDefined();
+    mutator?.fn();
+    expect(input[0].value[1]).toBeUndefined();
+    expect(new ArgDefValidator([spec]).validate(input)).toBeTrue();
+  });
+
   /**
    * This test generates random ArgDef specs, generates
    * and mutates inputs from those specs, and validates

--- a/src/fuzzer/analysis/ArgDef.test.ts
+++ b/src/fuzzer/analysis/ArgDef.test.ts
@@ -486,7 +486,9 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
 
     expect(() =>
       ArgDefGenerator.gen(spec, seedrandom("uniqueLiteral"))
-    ).toThrowError("Unable to generate a unique array element");
+    ).toThrowError(
+      "Unable to generate enough unique array element. Are constraints possible to meet?"
+    );
   });
 
   it("dimsUnique: mutators preserve outer-dimension uniqueness", () => {

--- a/src/fuzzer/analysis/ArgDef.test.ts
+++ b/src/fuzzer/analysis/ArgDef.test.ts
@@ -489,6 +489,95 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
     ).toThrowError("Unable to generate a unique array element");
   });
 
+  it("dimsUnique: mutators preserve outer-dimension uniqueness", () => {
+    const spec = new ArgDef(
+      "uniqueNumbers",
+      0,
+      ArgTag.NUMBER,
+      {
+        ...argOptions,
+        dimsUnique: true,
+        dimLength: [{ min: 2, max: 2 }],
+      },
+      1,
+      false,
+      [{ min: 1, max: 2 }]
+    );
+    const input = [{ tag: "ArgValueTypeWrapped" as const, value: [1, 2] }];
+    const validator = new ArgDefValidator([spec]);
+    const mutations = ArgDefMutator.getMutators(
+      [spec],
+      input,
+      seedrandom("dimsUniqueMutations")
+    );
+
+    expect(mutations.length).toBeGreaterThan(0);
+    for (let index = 0; index < mutations.length; index++) {
+      // Mutator functions may run only once per set, so rebuild the same
+      // proposal set for a fresh candidate before testing each mutation.
+      const candidate = JSONN.parse<typeof input>(JSONN.stringify(input));
+      const candidateMutations = ArgDefMutator.getMutators(
+        [spec],
+        candidate,
+        seedrandom("dimsUniqueMutations")
+      );
+      candidateMutations[index].fn();
+      expect(validator.validate(candidate)).toBeTrue();
+    }
+  });
+
+  it("dimsUnique: mutators preserve uniqueness for nested arrays", () => {
+    const spec = new ArgDef(
+      "settings",
+      0,
+      ArgTag.OBJECT,
+      {
+        ...argOptions,
+        dimsUnique: true,
+        dimLength: [{ min: 2, max: 2 }],
+      },
+      0,
+      false,
+      undefined,
+      [
+        new ArgDef(
+          "values",
+          0,
+          ArgTag.NUMBER,
+          {
+            ...argOptions,
+            dimsUnique: true,
+            dimLength: [{ min: 2, max: 2 }],
+          },
+          1
+        ),
+      ]
+    );
+    const input = [
+      { tag: "ArgValueTypeWrapped" as const, value: { values: [1, 2] } },
+    ];
+    const validator = new ArgDefValidator([spec]);
+    const mutations = ArgDefMutator.getMutators(
+      [spec],
+      input,
+      seedrandom("nestedDimsUniqueMutations")
+    );
+
+    expect(mutations.length).toBeGreaterThan(0);
+    for (let index = 0; index < mutations.length; index++) {
+      // Mutator functions may run only once per set, so rebuild the same
+      // proposal set for a fresh candidate before testing each mutation.
+      const candidate = JSONN.parse<typeof input>(JSONN.stringify(input));
+      const candidateMutations = ArgDefMutator.getMutators(
+        [spec],
+        candidate,
+        seedrandom("nestedDimsUniqueMutations")
+      );
+      candidateMutations[index].fn();
+      expect(validator.validate(candidate)).toBeTrue();
+    }
+  });
+
   /**
    * This test generates random ArgDef specs, generates
    * and mutates inputs from those specs, and validates
@@ -510,9 +599,13 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
     const failingSpecs: string[] = [];
     const failingMutators: { [k: string]: number } = {};
     const dupeMutators: { [k: string]: number } = {};
+    let uniqueDimensionSpecs = 0;
     let i = 50;
     while (i--) {
       const spec = [getRandomArgDef(prng, Math.floor(prng() * 2))];
+      if (spec[0].getDim() > 0 && spec[0].getOptions().dimsUnique) {
+        uniqueDimensionSpecs++;
+      }
       const stxt = abbrSpec(spec[0]).join("\r\n");
       const gen = new ArgDefGenerator(spec, prng);
       const val = new ArgDefValidator(spec);
@@ -611,6 +704,7 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
 
     expect(stats.gens.valid).not.toBe(0);
     expect(stats.gens.invalid).toBe(0);
+    expect(uniqueDimensionSpecs).not.toBe(0);
 
     expect(stats.muts.valid).not.toBe(0);
     expect(stats.muts.dupe).toBe(0);
@@ -625,6 +719,7 @@ function abbrSpec(spec: ArgDef, indents = 0): string[] {
   line.push(space);
   line.push(`${spec.getName()}:${TypescriptProgram.getTypeAnnotation(spec)}`);
   line.push(`dims: ${JSONN.stringify(spec.getOptions().dimLength)}`);
+  if (spec.getOptions().dimsUnique) line.push(`DIMS_UNIQUE`);
   if (spec.isNoInput()) line.push(`NOINPUT`);
   if (spec.isOptional()) line.push(`OPTIONAL`);
   if (spec.getType() === ArgTag.NUMBER && spec.getOptions().numInteger)
@@ -732,6 +827,7 @@ function getRandomArgDef(
   const name = "abcdefghijklmnopqrstuvwxyz".split("")[Math.floor(prng() * 25)];
   let options: ArgOptions = {
     ...argOptions,
+    dimsUnique: dims.dims > 0 && prng() > 0.5,
     isNoInput:
       (parentType === ArgTag.OBJECT || parentType === ArgTag.UNION) &&
       prng() > 0.5,

--- a/src/fuzzer/analysis/ArgDef.ts
+++ b/src/fuzzer/analysis/ArgDef.ts
@@ -516,6 +516,7 @@ export class ArgDef<Tag extends ArgTag = ArgTag> {
         ),
       },
       dimLength: [],
+      dimsUnique: false,
     };
   } // fn: getDefaultOptions()
 

--- a/src/fuzzer/analysis/ArgDefGenerator.ts
+++ b/src/fuzzer/analysis/ArgDefGenerator.ts
@@ -386,6 +386,7 @@ const nArray = (
     elementLoop: for (let i = 0; i < thisDim; i++) {
       let attempts = 0;
       while (true) {
+        // TODO: generate unique by construction when dims>0 && dimUnique
         const value = nArray(prng, genFn, rest, options, currDepth + 1);
         if (!seen) {
           newArray[i] = value;
@@ -399,10 +400,9 @@ const nArray = (
           continue elementLoop;
         }
 
-        attempts++;
-        if (attempts > 100) {
+        if (++attempts > 100) {
           if (newArray.length >= dim.min) {
-            break elementLoop;
+            break elementLoop; // return if it satisfies the min length constraint
           }
           throw new Error("Unable to generate a unique array element");
         }

--- a/src/fuzzer/analysis/ArgDefGenerator.ts
+++ b/src/fuzzer/analysis/ArgDefGenerator.ts
@@ -1,5 +1,6 @@
 import seedrandom from "seedrandom";
 import { ArgDef } from "./ArgDef";
+import * as JSONN from "../../Jsonn";
 import {
   ArgTag,
   ArgValueType,
@@ -358,25 +359,54 @@ const getRandomString: PrivateRandFn = (
  * @param `genFn` generator for array element inputs
  * @param `dimLength` array of lengths for each n-dimension
  * @param `options` argument option set
+ * @param `currDepth` current depth of recursion (default: 0)
  * @returns n-dimensional array of random values
  */
 const nArray = (
   prng: seedrandom.prng,
   genFn: PublicRandFn,
   dimLength: Interval<number>[],
-  options: ArgOptions
+  options: ArgOptions,
+  currDepth = 0
 ): ArgValueType => {
   if (dimLength.length) {
     const [dim, ...rest] = dimLength; // split the array: head, tail
     const newArray: ArgValueType[] = []; // output array
+    const seen =
+      currDepth === 0 && options.dimsUnique ? new Set<string>() : undefined;
     const thisDim = getRandomNumber(
       prng,
       dim.min,
       dim.max,
       ArgDef.getDefaultOptions()
     );
-    for (let i = 0; i < thisDim; i++) {
-      newArray[i] = nArray(prng, genFn, rest, options);
+    // Only outer elements must be unique; nested dimensions may repeat. When
+    // a finite value domain is exhausted, keep the generated prefix if it
+    // already satisfies the minimum dimension length, or fail if it cannot.
+    elementLoop: for (let i = 0; i < thisDim; i++) {
+      let attempts = 0;
+      while (true) {
+        const value = nArray(prng, genFn, rest, options, currDepth + 1);
+        if (!seen) {
+          newArray[i] = value;
+          continue elementLoop;
+        }
+
+        const serializedValue = JSONN.stringify(value);
+        if (!seen.has(serializedValue)) {
+          seen.add(serializedValue);
+          newArray[i] = value;
+          continue elementLoop;
+        }
+
+        attempts++;
+        if (attempts > 100) {
+          if (newArray.length >= dim.min) {
+            break elementLoop;
+          }
+          throw new Error("Unable to generate a unique array element");
+        }
+      }
     }
     return newArray;
   } else {

--- a/src/fuzzer/analysis/ArgDefGenerator.ts
+++ b/src/fuzzer/analysis/ArgDefGenerator.ts
@@ -46,14 +46,18 @@ export class ArgDefGenerator {
    * @param `spec` ArgDef spec that describes the shape of the values
    * @param `prng` pseudo random number generator
    * @param `genDims` generate array dimensions? (default: `true`)
+   * @param `allowOptional` permit optional arguments to generate undefined? (default: `true`)
+   *        E.g., ArgDefMutator sets this to `false` to force generation of a new value
+   *        for an optional object member that was previously missing.
    * @returns value that conforms to the ArgDef specs
    */
   public static gen(
     spec: ArgDef,
     prng: seedrandom.prng,
-    genDims = true
+    genDims = true,
+    allowOptional = true
   ): ArgValueType {
-    return generateRandomInputFn(spec, prng, genDims)();
+    return generateRandomInputFn(spec, prng, genDims, allowOptional)();
   }
 } // class: ArgDefGenerator
 
@@ -74,6 +78,8 @@ type PublicRandFn = () => ArgValueType;
  *
  * @param `arg` the argument definition for which to generate an input
  * @param `prng` pseudo-random number generator
+ * @param `genDims` whether to generate dimensions for array arguments
+ * @param `allowOptional` whether optional arguments may generate undefined
  * @returns a function that generates pseudo-random input values
  *
  * Throws an exception if the argument type is not supported.
@@ -83,8 +89,9 @@ type PublicRandFn = () => ArgValueType;
 function generateRandomInputFn(
   arg: ArgDef,
   prng: seedrandom.prng,
-  genDims = true /* true=generate array dimensions if present;
+  genDims = true, /* true=generate array dimensions if present;
                     false=generate only the value */
+  allowOptional = true
 ): PublicRandFn {
   let randFn: PrivateRandFn;
 
@@ -214,7 +221,7 @@ function generateRandomInputFn(
 
   // Inject undefined values into arg only if it is optional
   // and we are not generating values inside an array
-  return isOptional && genDims
+  return isOptional && genDims && allowOptional
     ? () => {
         if (prng() >= 0.5) return undefined;
         else return randArgValueWrapper();

--- a/src/fuzzer/analysis/ArgDefGenerator.ts
+++ b/src/fuzzer/analysis/ArgDefGenerator.ts
@@ -400,11 +400,13 @@ const nArray = (
           continue elementLoop;
         }
 
-        if (++attempts > 100) {
+        if (++attempts > 50) {
           if (newArray.length >= dim.min) {
             break elementLoop; // return if it satisfies the min length constraint
           }
-          throw new Error("Unable to generate a unique array element");
+          throw new Error(
+            "Unable to generate enough unique array element. Are constraints possible to meet?"
+          );
         }
       }
     }

--- a/src/fuzzer/analysis/ArgDefMutator.ts
+++ b/src/fuzzer/analysis/ArgDefMutator.ts
@@ -37,11 +37,13 @@ export class ArgDefMutator {
     }
 
     // Running list of mutator functions
-    const mutations: {
+    type MutationProposal = {
       name: string;
       value: ArgValueType;
       path: (string | number)[];
-    }[] = [];
+      deleteProperty?: boolean;
+    };
+    const mutations: MutationProposal[] = [];
     type UniqueDimensionContext = {
       siblings: ArgValueType[];
       index: number;
@@ -60,24 +62,33 @@ export class ArgDefMutator {
     function replaceInOuterElement(
       outerElement: ArgValueType,
       path: (string | number)[],
-      replacement: ArgValueType
+      replacement: ArgValueType,
+      deleteProperty = false
     ): ArgValueType {
       if (!path.length) return replacement;
       const clone = structuredClone(outerElement);
-      ArgDefMutator._mutateValueInPlace(
-        [{ tag: "ArgValueTypeWrapped", value: clone }],
-        [0, "value", ...path],
-        replacement
-      );
+      const wrappedClone = [
+        { tag: "ArgValueTypeWrapped" as const, value: clone },
+      ];
+      if (deleteProperty) {
+        ArgDefMutator._deleteObjectPropertyInPlace(wrappedClone, [
+          0,
+          "value",
+          ...path,
+        ]);
+      } else {
+        ArgDefMutator._mutateValueInPlace(
+          wrappedClone,
+          [0, "value", ...path],
+          replacement
+        );
+      }
       return clone;
     }
 
     // Reject proposals that duplicate an element in this or any enclosing
     // dimsUnique array tracked while descending through mutateArray.
-    function preservesUniqueDimensions(mutation: {
-      value: ArgValueType;
-      path: (string | number)[];
-    }): boolean {
+    function preservesUniqueDimensions(mutation: MutationProposal): boolean {
       const context = mutationContexts.get(JSONN.stringify(mutation.path));
       if (!context) return true;
 
@@ -95,7 +106,8 @@ export class ArgDefMutator {
         const outerElement = replaceInOuterElement(
           uniqueContext.siblings[uniqueContext.index],
           uniqueContext.pathFromOuter,
-          mutation.value
+          mutation.value,
+          mutation.deleteProperty
         );
         const serializedOuterElement = JSONN.stringify(outerElement);
         return !uniqueContext.siblings.some(
@@ -106,13 +118,7 @@ export class ArgDefMutator {
       });
     }
 
-    function addMutations(
-      proposedMutations: {
-        name: string;
-        value: ArgValueType;
-        path: (string | number)[];
-      }[]
-    ): void {
+    function addMutations(proposedMutations: MutationProposal[]): void {
       mutations.push(...proposedMutations.filter(preservesUniqueDimensions));
     }
 
@@ -392,6 +398,17 @@ export class ArgDefMutator {
               const children = spec.getChildren().filter((c) => !c.isNoInput());
               for (const c of children) {
                 const name = c.getName();
+                const childPath = [...subInput.subPath, name];
+                const childUniqueContexts = subInput.uniqueContexts.map(
+                  (context) => ({
+                    ...context,
+                    pathFromOuter: [...context.pathFromOuter, name],
+                  })
+                );
+                mutationContexts.set(JSONN.stringify(childPath), {
+                  uniqueContexts: childUniqueContexts,
+                  requiresUniqueElements: false,
+                });
 
                 // Mutator to generate optional member if missing
                 if (c.isOptional()) {
@@ -402,7 +419,7 @@ export class ArgDefMutator {
                         {
                           name: `optional-genMember`,
                           value: ArgDefGenerator.gen(c, prng),
-                          path: [...subInput.subPath, name],
+                          path: childPath,
                         },
                       ].filter(
                         (e) =>
@@ -414,8 +431,9 @@ export class ArgDefMutator {
                     addMutations([
                       {
                         name: "optional-delete",
-                        value: undefined, // !!!!!!! should delete if parent is object
-                        path: [...subInput.subPath, name],
+                        value: undefined,
+                        path: childPath,
+                        deleteProperty: true,
                       },
                     ]);
                   }
@@ -423,14 +441,11 @@ export class ArgDefMutator {
 
                 // Mutators for object member value
                 subInputs.push({
-                  subPath: [...subInput.subPath, name],
+                  subPath: childPath,
                   subElement: value[name],
                   subSpec: c,
                   inArray: false,
-                  uniqueContexts: subInput.uniqueContexts.map((context) => ({
-                    ...context,
-                    pathFromOuter: [...context.pathFromOuter, name],
-                  })),
+                  uniqueContexts: childUniqueContexts,
                 });
               }
             }
@@ -490,9 +505,21 @@ export class ArgDefMutator {
 
           case ArgTag.TUPLE: {
             const value = subInput.subElement;
-            if (typeof value === "object" && !Array.isArray(value)) {
+            if (Array.isArray(value)) {
               const children = spec.getChildren().filter((c) => !c.isNoInput());
               for (const [i, c] of children.entries()) {
+                const childPath = [...subInput.subPath, i];
+                const childUniqueContexts = subInput.uniqueContexts.map(
+                  (context) => ({
+                    ...context,
+                    pathFromOuter: [...context.pathFromOuter, i],
+                  })
+                );
+                mutationContexts.set(JSONN.stringify(childPath), {
+                  uniqueContexts: childUniqueContexts,
+                  requiresUniqueElements: false,
+                });
+
                 // Mutator to generate optional member if missing
                 if (c.isOptional()) {
                   const oldValue = value[i];
@@ -502,7 +529,7 @@ export class ArgDefMutator {
                         {
                           name: `optional-genMember`,
                           value: ArgDefGenerator.gen(c, prng),
-                          path: [...subInput.subPath, i],
+                          path: childPath,
                         },
                       ].filter(
                         (e) =>
@@ -514,7 +541,7 @@ export class ArgDefMutator {
                     addMutations([
                       {
                         name: "optional-delete",
-                        value: undefined, // !!!!!!! should delete if parent is object
+                        value: undefined,
                         path: [...subInput.subPath, i],
                       },
                     ]);
@@ -523,16 +550,11 @@ export class ArgDefMutator {
 
                 // Mutators for tuple member value
                 subInputs.push({
-                  subPath: [...subInput.subPath, i],
+                  subPath: childPath,
                   subElement: value[i],
                   subSpec: c,
                   inArray: false,
-                  // Preserve the route from each unique outer element to this
-                  // tuple member for descendant mutation comparisons.
-                  uniqueContexts: subInput.uniqueContexts.map((context) => ({
-                    ...context,
-                    pathFromOuter: [...context.pathFromOuter, i],
-                  })),
+                  uniqueContexts: childUniqueContexts,
                 });
               }
             }
@@ -562,6 +584,9 @@ export class ArgDefMutator {
             );
           } else {
             wasMutated = true;
+            if (e.deleteProperty) {
+              return this._deleteObjectPropertyInPlace(value, e.path);
+            }
             return this._mutateValueInPlace(value, e.path, e.value);
           }
         },
@@ -622,6 +647,46 @@ export class ArgDefMutator {
     }
     return value;
   } // fn: mutateValueInPlace
+
+  /**
+   * Removes an object member in place by following a path to its parent.
+   *
+   * @param `value` input value containing the object member to delete
+   * @param `path` path to the object member
+   * @returns the mutated input value
+   */
+  protected static _deleteObjectPropertyInPlace(
+    value: ArgValueTypeWrapped[],
+    path: (number | string)[]
+  ): ArgValueType {
+    let element: ArgValueType = value;
+
+    for (const step in path) {
+      const key = path[step];
+      if (Number(step) < path.length - 1) {
+        if (Array.isArray(element)) {
+          element = element[Number(key)];
+        } else if (element !== null && typeof element === "object") {
+          element = element[String(key)];
+        } else {
+          throw new Error(
+            `Cannot follow path through non-array / non-object: ${JSONN.stringify(path)}`
+          );
+        }
+      } else if (
+        element !== null &&
+        typeof element === "object" &&
+        !Array.isArray(element)
+      ) {
+        delete element[String(key)];
+      } else {
+        throw new Error(
+          `Cannot delete a non-object member: ${JSONN.stringify(path)}`
+        );
+      }
+    }
+    return value;
+  } // fn: deleteObjectPropertyInPlace
 
   /**
    * Checks for `null` without raising type warnings.

--- a/src/fuzzer/analysis/ArgDefMutator.ts
+++ b/src/fuzzer/analysis/ArgDefMutator.ts
@@ -42,6 +42,7 @@ export class ArgDefMutator {
       value: ArgValueType;
       path: (string | number)[];
       deleteProperty?: boolean;
+      objectKeyOrder?: string[];
     };
     const mutations: MutationProposal[] = [];
     type UniqueDimensionContext = {
@@ -63,7 +64,8 @@ export class ArgDefMutator {
       outerElement: ArgValueType,
       path: (string | number)[],
       replacement: ArgValueType,
-      deleteProperty = false
+      deleteProperty = false,
+      objectKeyOrder?: string[]
     ): ArgValueType {
       if (!path.length) return replacement;
       const clone = structuredClone(outerElement);
@@ -82,6 +84,13 @@ export class ArgDefMutator {
           [0, "value", ...path],
           replacement
         );
+        if (objectKeyOrder) {
+          ArgDefMutator._orderObjectPropertiesInPlace(
+            wrappedClone,
+            [0, "value", ...path],
+            objectKeyOrder
+          );
+        }
       }
       return clone;
     }
@@ -107,7 +116,8 @@ export class ArgDefMutator {
           uniqueContext.siblings[uniqueContext.index],
           uniqueContext.pathFromOuter,
           mutation.value,
-          mutation.deleteProperty
+          mutation.deleteProperty,
+          mutation.objectKeyOrder
         );
         const serializedOuterElement = JSONN.stringify(outerElement);
         return !uniqueContext.siblings.some(
@@ -399,6 +409,7 @@ export class ArgDefMutator {
               for (const c of children) {
                 const name = c.getName();
                 const childPath = [...subInput.subPath, name];
+                const childKeyOrder = children.map((child) => child.getName());
                 const childUniqueContexts = subInput.uniqueContexts.map(
                   (context) => ({
                     ...context,
@@ -418,8 +429,9 @@ export class ArgDefMutator {
                       [
                         {
                           name: `optional-genMember`,
-                          value: ArgDefGenerator.gen(c, prng),
+                          value: ArgDefGenerator.gen(c, prng, true, false),
                           path: childPath,
+                          objectKeyOrder: childKeyOrder,
                         },
                       ].filter(
                         (e) =>
@@ -528,7 +540,7 @@ export class ArgDefMutator {
                       [
                         {
                           name: `optional-genMember`,
-                          value: ArgDefGenerator.gen(c, prng),
+                          value: ArgDefGenerator.gen(c, prng, true, false),
                           path: childPath,
                         },
                       ].filter(
@@ -587,7 +599,15 @@ export class ArgDefMutator {
             if (e.deleteProperty) {
               return this._deleteObjectPropertyInPlace(value, e.path);
             }
-            return this._mutateValueInPlace(value, e.path, e.value);
+            const result = this._mutateValueInPlace(value, e.path, e.value);
+            if (e.objectKeyOrder) {
+              this._orderObjectPropertiesInPlace(
+                value,
+                e.path,
+                e.objectKeyOrder
+              );
+            }
+            return result;
           }
         },
       };
@@ -687,6 +707,39 @@ export class ArgDefMutator {
     }
     return value;
   } // fn: deleteObjectPropertyInPlace
+
+  /** Reorders an object's existing keys to match the defining ArgDef order. */
+  protected static _orderObjectPropertiesInPlace(
+    value: ArgValueTypeWrapped[],
+    path: (number | string)[],
+    keyOrder: string[]
+  ): void {
+    let parent: ArgValueType = value;
+    for (const step in path.slice(0, -1)) {
+      const key = path[Number(step)];
+      if (Array.isArray(parent)) {
+        parent = parent[Number(key)];
+      } else if (parent !== null && typeof parent === "object") {
+        parent = parent[String(key)];
+      } else {
+        throw new Error(`Cannot order object properties: ${JSONN.stringify(path)}`);
+      }
+    }
+    if (parent === null || typeof parent !== "object" || Array.isArray(parent)) {
+      throw new Error(`Cannot order non-object properties: ${JSONN.stringify(path)}`);
+    }
+
+    const values = new Map(
+      Object.entries(parent).map(([key, propertyValue]) => [key, propertyValue])
+    );
+    for (const key of Object.keys(parent)) delete parent[key];
+    for (const key of keyOrder) {
+      if (values.has(key)) parent[key] = values.get(key);
+    }
+    for (const [key, propertyValue] of values) {
+      if (!(key in parent)) parent[key] = propertyValue;
+    }
+  } // fn: orderObjectPropertiesInPlace
 
   /**
    * Checks for `null` without raising type warnings.

--- a/src/fuzzer/analysis/ArgDefMutator.ts
+++ b/src/fuzzer/analysis/ArgDefMutator.ts
@@ -42,6 +42,79 @@ export class ArgDefMutator {
       value: ArgValueType;
       path: (string | number)[];
     }[] = [];
+    type UniqueDimensionContext = {
+      siblings: ArgValueType[];
+      index: number;
+      pathFromOuter: (string | number)[];
+    };
+    const mutationContexts = new Map<
+      string,
+      {
+        uniqueContexts: UniqueDimensionContext[];
+        requiresUniqueElements: boolean;
+      }
+    >();
+
+    // Clones one unique-array element and applies a descendant replacement
+    // relative to it, leaving the original input untouched for comparison.
+    function replaceInOuterElement(
+      outerElement: ArgValueType,
+      path: (string | number)[],
+      replacement: ArgValueType
+    ): ArgValueType {
+      if (!path.length) return replacement;
+      const clone = structuredClone(outerElement);
+      ArgDefMutator._mutateValueInPlace(
+        [{ tag: "ArgValueTypeWrapped", value: clone }],
+        [0, "value", ...path],
+        replacement
+      );
+      return clone;
+    }
+
+    // Reject proposals that duplicate an element in this or any enclosing
+    // dimsUnique array tracked while descending through mutateArray.
+    function preservesUniqueDimensions(mutation: {
+      value: ArgValueType;
+      path: (string | number)[];
+    }): boolean {
+      const context = mutationContexts.get(JSONN.stringify(mutation.path));
+      if (!context) return true;
+
+      if (context.requiresUniqueElements) {
+        if (!Array.isArray(mutation.value)) return false;
+        const serializedValues = mutation.value.map((element) =>
+          JSONN.stringify(element)
+        );
+        if (new Set(serializedValues).size !== serializedValues.length) {
+          return false;
+        }
+      }
+
+      return context.uniqueContexts.every((uniqueContext) => {
+        const outerElement = replaceInOuterElement(
+          uniqueContext.siblings[uniqueContext.index],
+          uniqueContext.pathFromOuter,
+          mutation.value
+        );
+        const serializedOuterElement = JSONN.stringify(outerElement);
+        return !uniqueContext.siblings.some(
+          (sibling, index) =>
+            index !== uniqueContext.index &&
+            JSONN.stringify(sibling) === serializedOuterElement
+        );
+      });
+    }
+
+    function addMutations(
+      proposedMutations: {
+        name: string;
+        value: ArgValueType;
+        path: (string | number)[];
+      }[]
+    ): void {
+      mutations.push(...proposedMutations.filter(preservesUniqueDimensions));
+    }
 
     // Utility function that determines mutators appropriate
     // for a given array of values and ArgDef spec.
@@ -49,14 +122,19 @@ export class ArgDefMutator {
       a: Array<ArgValueType>,
       path: (string | number)[],
       spec: ArgDef,
-      level = 1
+      level = 1,
+      uniqueContexts: UniqueDimensionContext[] = []
     ): void => {
       const options = spec.getOptions();
+      mutationContexts.set(JSONN.stringify(path), {
+        uniqueContexts,
+        requiresUniqueElements: level === 1 && options.dimsUnique,
+      });
 
       // Re-arrange elements if multiple elements are present
       if (a.length > 1) {
-        mutations.push(
-          ...[
+        addMutations(
+          [
             {
               name: "array-jumble",
               value: [...a].sort(() => 0.5 - prng()),
@@ -77,8 +155,8 @@ export class ArgDefMutator {
         // when that terminal dimension is not full
         if (level === spec.getDim()) {
           // terminal dimension: add a value
-          mutations.push(
-            ...[
+          addMutations(
+            [
               {
                 name: "array-appendNewElement",
                 value: [
@@ -100,11 +178,23 @@ export class ArgDefMutator {
 
       // Process each element in this level of the array
       for (const i in a) {
-        mutations.push(
-          ...[
+        const index = Number(i);
+        const childUniqueContexts = uniqueContexts.map((context) => ({
+          ...context,
+          pathFromOuter: [...context.pathFromOuter, index],
+        }));
+        if (level === 1 && options.dimsUnique) {
+          childUniqueContexts.push({
+            siblings: a,
+            index,
+            pathFromOuter: [],
+          });
+        }
+        addMutations(
+          [
             {
               name: `array-deleteElement${i}`,
-              value: [...a.filter((v, j) => Number(i) !== j)],
+              value: [...a.filter((_v, j) => index !== j)],
               path: [...path],
             },
           ].filter(
@@ -115,13 +205,20 @@ export class ArgDefMutator {
         );
 
         if (Array.isArray(a[i]) && level < spec.getDim()) {
-          mutateArray(a[i], [...path, Number(i)], spec, level + 1);
+          mutateArray(
+            a[i],
+            [...path, index],
+            spec,
+            level + 1,
+            childUniqueContexts
+          );
         } else {
           subInputs.push({
             subPath: [...path, Number(i)],
             subElement: a[i],
             subSpec: spec,
             inArray: true,
+            uniqueContexts: childUniqueContexts,
           });
         }
       }
@@ -133,12 +230,14 @@ export class ArgDefMutator {
       subElement: ArgValueType;
       subSpec: ArgDef;
       inArray: boolean;
+      uniqueContexts: UniqueDimensionContext[];
     }[] = value.map((e, i) => {
       return {
         subPath: [Number(i), "value"],
         subElement: e.value,
         subSpec: specs[i],
         inArray: false,
+        uniqueContexts: [],
       };
     }); // fn: subInputs
 
@@ -147,19 +246,29 @@ export class ArgDefMutator {
       const subInput = subInputs[i];
       const spec = subInput.subSpec;
       const options = spec.getOptions();
+      mutationContexts.set(JSONN.stringify(subInput.subPath), {
+        uniqueContexts: subInput.uniqueContexts,
+        requiresUniqueElements: false,
+      });
 
       // Handle array dimensions
       if (spec.getDim() && !subInput.inArray) {
         if (Array.isArray(subInput.subElement)) {
-          mutateArray(subInput.subElement, [...subInput.subPath], spec);
+          mutateArray(
+            subInput.subElement,
+            [...subInput.subPath],
+            spec,
+            1,
+            subInput.uniqueContexts
+          );
         }
       } else if (!spec.isNoInput()) {
         // Determine mutations according to ArgDef types
         switch (spec.getType()) {
           case ArgTag.NUMBER: {
             const value = Number(subInput.subElement);
-            mutations.push(
-              ...[
+            addMutations(
+              [
                 {
                   name: "number-plusOne",
                   value: value + 1,
@@ -211,8 +320,8 @@ export class ArgDefMutator {
             const charSet = options.strCharset;
             const rChar = charSet[Math.floor(prng() * (charSet.length - 1))];
 
-            mutations.push(
-              ...[
+            addMutations(
+              [
                 {
                   name: "string-deleteOneChar",
                   value: `${value.slice(0, rPos)}${value.slice(rPos + 1)}`,
@@ -256,8 +365,8 @@ export class ArgDefMutator {
           }
           case ArgTag.BOOLEAN: {
             const value = subInput.subElement;
-            mutations.push(
-              ...[
+            addMutations(
+              [
                 {
                   name: "boolean-setTrue",
                   value: true,
@@ -288,8 +397,8 @@ export class ArgDefMutator {
                 if (c.isOptional()) {
                   const oldValue = value[name];
                   if (value[name] === undefined) {
-                    mutations.push(
-                      ...[
+                    addMutations(
+                      [
                         {
                           name: `optional-genMember`,
                           value: ArgDefGenerator.gen(c, prng),
@@ -302,11 +411,13 @@ export class ArgDefMutator {
                     );
                   } else {
                     // Mutator to delete optional input
-                    mutations.push({
-                      name: "optional-delete",
-                      value: undefined, // !!!!!!! should delete if parent is object
-                      path: [...subInput.subPath, name],
-                    });
+                    addMutations([
+                      {
+                        name: "optional-delete",
+                        value: undefined, // !!!!!!! should delete if parent is object
+                        path: [...subInput.subPath, name],
+                      },
+                    ]);
                   }
                 }
 
@@ -316,6 +427,10 @@ export class ArgDefMutator {
                   subElement: value[name],
                   subSpec: c,
                   inArray: false,
+                  uniqueContexts: subInput.uniqueContexts.map((context) => ({
+                    ...context,
+                    pathFromOuter: [...context.pathFromOuter, name],
+                  })),
                 });
               }
             }
@@ -342,6 +457,7 @@ export class ArgDefMutator {
                 subSpec:
                   validChildren[Math.floor(prng() * validChildren.length)],
                 inArray: false,
+                uniqueContexts: subInput.uniqueContexts,
               });
             }
 
@@ -355,8 +471,8 @@ export class ArgDefMutator {
                 inputOkChildren[Math.floor(prng() * inputOkChildren.length)],
                 prng
               );
-              mutations.push(
-                ...[
+              addMutations(
+                [
                   {
                     name: `union-regenFromSpec`,
                     value: newValue,
@@ -381,8 +497,8 @@ export class ArgDefMutator {
                 if (c.isOptional()) {
                   const oldValue = value[i];
                   if (value[i] === undefined) {
-                    mutations.push(
-                      ...[
+                    addMutations(
+                      [
                         {
                           name: `optional-genMember`,
                           value: ArgDefGenerator.gen(c, prng),
@@ -395,11 +511,13 @@ export class ArgDefMutator {
                     );
                   } else {
                     // Mutator to delete optional input
-                    mutations.push({
-                      name: "optional-delete",
-                      value: undefined, // !!!!!!! should delete if parent is object
-                      path: [...subInput.subPath, i],
-                    });
+                    addMutations([
+                      {
+                        name: "optional-delete",
+                        value: undefined, // !!!!!!! should delete if parent is object
+                        path: [...subInput.subPath, i],
+                      },
+                    ]);
                   }
                 }
 
@@ -409,6 +527,12 @@ export class ArgDefMutator {
                   subElement: value[i],
                   subSpec: c,
                   inArray: false,
+                  // Preserve the route from each unique outer element to this
+                  // tuple member for descendant mutation comparisons.
+                  uniqueContexts: subInput.uniqueContexts.map((context) => ({
+                    ...context,
+                    pathFromOuter: [...context.pathFromOuter, i],
+                  })),
                 });
               }
             }

--- a/src/fuzzer/analysis/ArgDefValidator.test.ts
+++ b/src/fuzzer/analysis/ArgDefValidator.test.ts
@@ -96,4 +96,46 @@ describe("fuzzer/analysis/typescript/ArgDefValidator:", () => {
     ).toBe(true);
     expect(ArgDefValidator.validate([[1], [1]], uniqueMatrixDef)).toBe(false);
   });
+
+  it("rejects duplicate object array elements when dimsUnique is enabled", () => {
+    const uniqueObjects = makeArgDef(
+      dummyModule,
+      "objects",
+      0,
+      ArgTag.OBJECT,
+      {
+        ...argOptions,
+        dimsUnique: true,
+        dimLength: [{ min: 2, max: 2 }],
+      },
+      1,
+      false,
+      [makeTypeRef(dummyModule, "a", ArgTag.LITERAL, 0, true, [], undefined, 1)]
+    );
+
+    expect(ArgDefValidator.validate([{ a: 1 }, { a: 1 }], uniqueObjects)).toBe(
+      false
+    );
+  });
+
+  it("rejects present but undefined optional object members", () => {
+    const uniqueObjects = makeArgDef(
+      dummyModule,
+      "objects",
+      0,
+      ArgTag.OBJECT,
+      {
+        ...argOptions,
+        dimsUnique: true,
+        dimLength: [{ min: 2, max: 2 }],
+      },
+      1,
+      false,
+      [makeTypeRef(dummyModule, "a", ArgTag.LITERAL, 0, true, [], undefined, 1)]
+    );
+
+    expect(
+      ArgDefValidator.validate([{ a: undefined }, {}], uniqueObjects)
+    ).toBe(false);
+  });
 });

--- a/src/fuzzer/analysis/ArgDefValidator.test.ts
+++ b/src/fuzzer/analysis/ArgDefValidator.test.ts
@@ -60,4 +60,40 @@ describe("fuzzer/analysis/typescript/ArgDefValidator:", () => {
       expect(ArgDefValidator.validate(arr, arrayDef)).toBe(true);
     }
   });
+
+  it("Validates outer dimension uniqueness when dimsUnique===true", () => {
+    const uniqueArrayDef = makeArgDef(
+      dummyModule,
+      "test",
+      0,
+      ArgTag.NUMBER,
+      { ...argOptions, dimsUnique: true },
+      1
+    );
+
+    expect(ArgDefValidator.validate([1, 2], uniqueArrayDef)).toBe(true);
+    expect(ArgDefValidator.validate([1, 1], uniqueArrayDef)).toBe(false);
+  });
+
+  it("Does not validate inner dimension uniqueness when dimsUnique===true", () => {
+    const uniqueMatrixDef = makeArgDef(
+      dummyModule,
+      "test",
+      0,
+      ArgTag.NUMBER,
+      { ...argOptions, dimsUnique: true },
+      2
+    );
+
+    expect(
+      ArgDefValidator.validate(
+        [
+          [1, 1],
+          [2, 2],
+        ],
+        uniqueMatrixDef
+      )
+    ).toBe(true);
+    expect(ArgDefValidator.validate([[1], [1]], uniqueMatrixDef)).toBe(false);
+  });
 });

--- a/src/fuzzer/analysis/ArgDefValidator.ts
+++ b/src/fuzzer/analysis/ArgDefValidator.ts
@@ -1,5 +1,6 @@
 import { ArgDef } from "./ArgDef";
 import { ArgTag, ArgValueType, ArgValueTypeWrapped } from "./Types";
+import * as JSONN from "../../Jsonn";
 
 /**
  * Valides values against their corresponding ArgDef specs
@@ -190,6 +191,13 @@ const traverse = (
     a.length > levelSizes[currDepth].max
   ) {
     return false;
+  }
+
+  if (currDepth === 0 && spec.getOptions().dimsUnique) {
+    const values = new Set(a.map((value) => JSONN.stringify(value)));
+    if (values.size !== a.length) {
+      return false;
+    }
   }
 
   // Traverse the array and validate its contents

--- a/src/fuzzer/analysis/ArgDefValidator.ts
+++ b/src/fuzzer/analysis/ArgDefValidator.ts
@@ -89,13 +89,14 @@ export class ArgDefValidator {
             for (const c of children) {
               const name = c.getName();
               const childValue = value[name];
+              const hasChildValue = Object.hasOwn(value, name);
               const isNoInput = c.isNoInput();
               const isOptional = c.isOptional();
               let valid = false; // assume invalid & look for cases of validity
-              if (isNoInput && childValue === undefined) {
+              if (isNoInput && !hasChildValue) {
                 valid = true;
               }
-              if (!valid && isOptional && childValue === undefined) {
+              if (!valid && isOptional && !hasChildValue) {
                 valid = true;
               }
               if (

--- a/src/fuzzer/analysis/Types.ts
+++ b/src/fuzzer/analysis/Types.ts
@@ -141,6 +141,7 @@ export type ArgOptions = {
   // for number[][]: dimLength[0] = length of 1st dimension
   // and dimLength[1] = length of 2nd dimension.
   dftDimLength: Interval<number>; // Length of any dimension not specified in dimLength.
+  dimsUnique: boolean; // true = generated dimension values must be unique.
 
   // For members of a union, suppress input generation
   isNoInput?: boolean; // true=do not generate inputs (unions only)
@@ -160,6 +161,7 @@ export type ArgOptionOverride = {
   numInteger?: boolean;
   numIntervals?: Interval<number>[];
   dimLength?: Interval<number>[];
+  dimsUnique?: boolean;
   strLength?: Interval<number>;
   strCharset?: string;
   children?: ArgOptionOverrides;

--- a/src/fuzzer/analysis/python/PythonProgram.test.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.test.ts
@@ -668,7 +668,9 @@ from .schemas import *`,
 
     expect(program.functionsExported["x"]).toBeUndefined();
     expect(program.unsupportedFunctions["x"]).toEqual(
-      jasmine.objectContaining({ reason: jasmine.stringMatching("Missing type annotation") })
+      jasmine.objectContaining({
+        reason: jasmine.stringMatching("Missing type annotation"),
+      })
     );
   });
 
@@ -973,6 +975,31 @@ def test_sampled(status):
     expect(
       arg.getChildren().every((c) => c.getType() === ArgTag.LITERAL)
     ).toBeTrue();
+  });
+
+  it("hypothesis @given sampled_from module-level constants", () => {
+    const fn = ProgramFactory.fromSource(
+      () => `
+_KEYWORDS = ["if", "else", "while", "return", "def", "class"]
+
+@settings(max_examples=500, deadline=None)
+@given(kw=st.sampled_from(_KEYWORDS))
+def test_terminal_priority_keyword_wins(kw):
+    print("test")
+        `,
+      "python"
+    ).functionsExported["test_terminal_priority_keyword_wins"];
+
+    const arg = fn.getArgDefs()[0];
+    expect(arg.getType()).toEqual(ArgTag.UNION);
+    expect(arg.getChildren().map((child) => child.getConstantValue())).toEqual([
+      "if",
+      "else",
+      "while",
+      "return",
+      "def",
+      "class",
+    ]);
   });
 
   it("hypothesis @given sampled_from tuples", () => {

--- a/src/fuzzer/analysis/python/PythonProgram.test.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.test.ts
@@ -953,6 +953,31 @@ def test_nested(complex_data):
     expect(tagsField?.getDim()).toEqual(1); // st.lists(st.text()) nested inside dict
   });
 
+  it("maps Hypothesis list uniqueness to ArgDef option", () => {
+    const fn = ProgramFactory.fromSource(
+      () => `
+USE_UNIQUE_VALUES = True
+
+@given(
+    unique_values=st.lists(st.one_of(st.integers(), st.text()), unique=True),
+    duplicate_values=st.lists(st.integers(), unique=False),
+    unconstrained_values=st.lists(st.integers()),
+    referenced_unique_values=st.lists(st.integers(), unique=USE_UNIQUE_VALUES)
+)
+def test_lists(unique_values, duplicate_values, unconstrained_values, referenced_unique_values):
+    pass
+        `,
+      "python"
+    ).functionsExported["test_lists"];
+
+    expect(fn.getArgDefs().map((arg) => arg.getOptions().dimsUnique)).toEqual([
+      true,
+      false,
+      false,
+      true,
+    ]);
+  });
+
   it("hypothesis @given sampled_from", () => {
     const fn = ProgramFactory.fromSource(
       () => `

--- a/src/fuzzer/analysis/python/PythonProgram.test.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.test.ts
@@ -947,6 +947,28 @@ def test_sampled(status):
     ).toBeTrue();
   });
 
+  it("hypothesis @given sampled_from tuples", () => {
+    const fn = ProgramFactory.fromSource(
+      () => `
+@given(st.sampled_from([("input", "disabled")]))
+def test_sampled_tuple(elem_attr):
+    pass
+        `,
+      "python"
+    ).functionsExported["test_sampled_tuple"];
+
+    const arg = fn.getArgDefs()[0];
+    expect(arg.getType()).toEqual(ArgTag.UNION);
+    expect(arg.getChildren().length).toEqual(1);
+    expect(arg.getChildren()[0].getType()).toEqual(ArgTag.TUPLE);
+    expect(
+      arg
+        .getChildren()[0]
+        .getChildren()
+        .map((child) => child.getConstantValue())
+    ).toEqual(["input", "disabled"]);
+  });
+
   it("hypothesis @given fixed_dictionaries with optional keys", () => {
     const fn = ProgramFactory.fromSource(
       () => `

--- a/src/fuzzer/analysis/python/PythonProgram.test.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.test.ts
@@ -658,6 +658,20 @@ from .schemas import *`,
     expect(fn.isVoid()).toBeTrue();
   });
 
+  it("rejects unannotated default parameters", () => {
+    spyOn(console, "debug");
+    const program = new InspectablePythonProgram(
+      () => `def x(y=22000):
+    print("hi")`,
+      "default_parameter.py"
+    );
+
+    expect(program.functionsExported["x"]).toBeUndefined();
+    expect(program.unsupportedFunctions["x"]).toEqual(
+      jasmine.objectContaining({ reason: jasmine.stringMatching("Missing type annotation") })
+    );
+  });
+
   it("keeps PEP 604 union members as function argument children", () => {
     const fn = ProgramFactory.fromSource(
       () => `def parse(value: int | str) -> int | str:

--- a/src/fuzzer/analysis/python/PythonProgram.test.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.test.ts
@@ -201,6 +201,15 @@ type MixedColumn = list[int | str]`,
     ).toEqual([ArgTag.NUMBER, ArgTag.STRING]);
   });
 
+  it("collapses singleton annotation unions", () => {
+    const types = ProgramFactory.fromSource(
+      () => "type MaybeCount = Optional[int]",
+      "python"
+    ).types;
+
+    expect(types["MaybeCount"].type?.type).toEqual(ArgTag.NUMBER);
+  });
+
   it("extracts TypedDict annotations as fixed objects", () => {
     const types = ProgramFactory.fromSource(
       () => `class Player(TypedDict):

--- a/src/fuzzer/analysis/python/PythonProgram.test.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.test.ts
@@ -854,8 +854,8 @@ def test_example(trigger, dep, trigger_val):
     const fn = ProgramFactory.fromSource(
       () => `
 @given(
-    year=st.integers(2000, 2030),
-    month=st.integers(1, 12)
+    st.integers(2000, 2030),
+    st.integers(1, 12)
 )
 def test_dates(year, month):
     pass
@@ -866,6 +866,24 @@ def test_dates(year, month):
     const args = fn.getArgDefs();
     expect(args[0].getIntervals()).toEqual([{ min: 2000, max: 2030 }]);
     expect(args[1].getIntervals()).toEqual([{ min: 1, max: 12 }]);
+  });
+
+  it("hypothesis @given negative numeric values", () => {
+    const fn = ProgramFactory.fromSource(
+      () => `
+@given(
+    integer=st.integers(min_value=-10, max_value=200),
+    decimal=st.floats(min_value=-1.5, max_value=2.5)
+)
+def test_bounds(integer, decimal):
+    pass
+        `,
+      "python"
+    ).functionsExported["test_bounds"];
+
+    const args = fn.getArgDefs();
+    expect(args[0].getIntervals()).toEqual([{ min: -10, max: 200 }]);
+    expect(args[1].getIntervals()).toEqual([{ min: -1.5, max: 2.5 }]);
   });
 
   it("hypothesis @given nested lists and fixed_dictionaries", () => {

--- a/src/fuzzer/analysis/python/PythonProgram.test.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.test.ts
@@ -247,6 +247,11 @@ type MixedColumn = list[int | str]`,
     expect(types["Settings"].type?.children[0].type?.type).toEqual(
       ArgTag.UNION
     );
+    expect(
+      types["Settings"].type?.children[0].type?.children.map(
+        (child) => child.type?.type
+      )
+    ).toEqual([ArgTag.NUMBER, ArgTag.LITERAL]);
     expect(types["Settings"].type?.children[1].type?.type).toEqual(
       ArgTag.TUPLE
     );

--- a/src/fuzzer/analysis/python/PythonProgram.test.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.test.ts
@@ -958,15 +958,33 @@ def test_sampled_tuple(elem_attr):
     ).functionsExported["test_sampled_tuple"];
 
     const arg = fn.getArgDefs()[0];
-    expect(arg.getType()).toEqual(ArgTag.UNION);
-    expect(arg.getChildren().length).toEqual(1);
-    expect(arg.getChildren()[0].getType()).toEqual(ArgTag.TUPLE);
-    expect(
-      arg
-        .getChildren()[0]
-        .getChildren()
-        .map((child) => child.getConstantValue())
-    ).toEqual(["input", "disabled"]);
+    expect(arg.getType()).toEqual(ArgTag.TUPLE);
+    expect(arg.getChildren().map((child) => child.getConstantValue())).toEqual([
+      "input",
+      "disabled",
+    ]);
+  });
+
+  it("hypothesis @given sampled_from dictionaries", () => {
+    const fn = ProgramFactory.fromSource(
+      () => `
+@given(st.sampled_from([{"mode": "disabled", "retry": 0}]))
+def test_sampled_dictionary(config):
+    pass
+        `,
+      "python"
+    ).functionsExported["test_sampled_dictionary"];
+
+    const arg = fn.getArgDefs()[0];
+    expect(arg.getType()).toEqual(ArgTag.OBJECT);
+    expect(arg.getChildren().map((child) => child.getName())).toEqual([
+      "mode",
+      "retry",
+    ]);
+    expect(arg.getChildren().map((child) => child.getConstantValue())).toEqual([
+      "disabled",
+      0,
+    ]);
   });
 
   it("hypothesis @given fixed_dictionaries with optional keys", () => {

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -1370,6 +1370,34 @@ export class PythonProgram extends AbstractProgram {
               };
             }
           }
+          if (valueNode.type === "dictionary") {
+            const children: TypeRef[] = [];
+            for (const pair of valueNode.namedChildren) {
+              if (pair.type !== "pair") return undefined;
+              const key = parseLiteral(
+                pair.childForFieldName("key") ?? undefined
+              );
+              const value = pair.childForFieldName("value");
+              const child = value ? getSampledType(value) : undefined;
+              if (typeof key !== "string" || child === undefined) {
+                return undefined;
+              }
+              child.name = key;
+              children.push(child);
+            }
+            return {
+              module: this._filename,
+              dims: 0,
+              optional: false,
+              isExported: false,
+              type: {
+                type: ArgTag.OBJECT,
+                dims: 0,
+                children,
+                resolved: true,
+              },
+            };
+          }
           return undefined;
         };
 
@@ -1386,7 +1414,11 @@ export class PythonProgram extends AbstractProgram {
           }
         }
 
-        // Represent sampled_from as a UNION of LITERALs
+        if (sampledTypes.length === 1) {
+          return sampledTypes[0];
+        }
+
+        // Represent multiple sampled values as a union.
         thisType.type = {
           type: ArgTag.UNION,
           dims: 0,

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -896,6 +896,7 @@ export class PythonProgram extends AbstractProgram {
 
     // Extract for Hypothesis @given(...) first
     const hypothesisArgMap: Record<string, TypeRef> = {};
+    const hypothesisPositionalArgs: (TypeRef | undefined)[] = [];
     const currentNode: Parser.Node | null = defNode.node.parent;
     if (currentNode?.type === "decorated_definition") {
       for (const child of currentNode.namedChildren) {
@@ -922,6 +923,12 @@ export class PythonProgram extends AbstractProgram {
                       hypothesisArgMap[paramName] = hypothesisTypeRef;
                     }
                   }
+                } else {
+                  hypothesisPositionalArgs.push(
+                    argChild.type === "call"
+                      ? this._getTypeRefFromStrategy(argChild)
+                      : undefined
+                  );
                 }
               }
             }
@@ -941,7 +948,7 @@ export class PythonProgram extends AbstractProgram {
 
     // Hypothesis strategies have precedence over native type annotations
     const finalArgs: TypeRef[] = [];
-    for (const paramNode of parameterNodes) {
+    for (const [paramIndex, paramNode] of parameterNodes.entries()) {
       // Get parameter name
       let paramName: string | undefined;
       if (paramNode.type === "identifier") {
@@ -959,8 +966,10 @@ export class PythonProgram extends AbstractProgram {
 
       // If a hypothesis strategy exists for this parameter, use it.
       // Otherwise, parse the native type annotation
-      if (paramName && paramName in hypothesisArgMap) {
-        const hypType = hypothesisArgMap[paramName];
+      const hypType = paramName
+        ? (hypothesisArgMap[paramName] ?? hypothesisPositionalArgs[paramIndex])
+        : hypothesisPositionalArgs[paramIndex];
+      if (hypType !== undefined) {
         hypType.name = paramName;
         finalArgs.push(hypType);
       } else {
@@ -1075,6 +1084,12 @@ export class PythonProgram extends AbstractProgram {
       if (!valNode) return undefined;
       if (valNode.type === "integer" || valNode.type === "float") {
         return Number(valNode.text.replace(/_/g, ""));
+      }
+      if (valNode.type === "unary_operator") {
+        const operand = parseLiteral(valNode.lastNamedChild ?? undefined);
+        if (typeof operand === "number") {
+          return valNode.text.startsWith("-") ? -operand : operand;
+        }
       }
       if (valNode.type === "true") return true;
       if (valNode.type === "false") return false;

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -819,10 +819,20 @@ export class PythonProgram extends AbstractProgram {
       }
       case ArgTag.UNION:
       case ArgTag.TUPLE: {
+        const children = this._getChildrenFromNode(typeNode);
+        // Collapse unions of a single value 
+        if (type === ArgTag.UNION && children.length === 1) {
+          const child = children[0];
+          thisType.dims = child.dims;
+          thisType.optional = child.optional;
+          thisType.type = child.type;
+          thisType.typeRefName = child.typeRefName;
+          break;
+        }
         thisType.type = {
           dims: dims,
           type: type,
-          children: this._getChildrenFromNode(typeNode),
+          children,
         };
         break;
       }
@@ -1518,6 +1528,10 @@ export class PythonProgram extends AbstractProgram {
               return undefined;
             }
           }
+        }
+
+        if (children.length === 1) {
+          return children[0];
         }
 
         thisType.type = {

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -1062,6 +1062,44 @@ export class PythonProgram extends AbstractProgram {
       isExported: false,
     };
 
+    // Best-effort attempt to resolve a reference to a module-level constant. This is.
+    //
+    // Resolve a module-level constant assigned before the strategy reference.
+    // Decorators execute while defining the following function, so assignments
+    // after that point are intentionally ignored.
+    //
+    // This very simple logic does not at all address:
+    // - imports, aliases
+    // - assignments in conditional blocks
+    // - mutations such as <array>.append(...)
+    // - destructuring, global, or scope shadowing
+    // - values computed from other identifiers
+    const resolveReference = (
+      valueNode: Parser.Node | undefined
+    ): Parser.Node | undefined => {
+      if (valueNode?.type !== "identifier" || this._ast === undefined) {
+        return valueNode;
+      }
+
+      let resolved: Parser.Node | undefined;
+      for (const statement of this._ast.rootNode.namedChildren) {
+        if (statement.startIndex >= valueNode.startIndex) break;
+        const assignment = statement.namedChildren.find(
+          (child) => child.type === "assignment"
+        );
+        const left = assignment?.childForFieldName("left");
+        const right = assignment?.childForFieldName("right");
+        if (
+          left?.type === "identifier" &&
+          left.text === valueNode.text &&
+          right
+        ) {
+          resolved = right;
+        }
+      }
+      return resolved ?? valueNode;
+    };
+
     // Helper to extract keyword argument values from a call expression
     const getKwdArg = (
       callNode: Parser.Node,
@@ -1076,12 +1114,14 @@ export class PythonProgram extends AbstractProgram {
           // Find by name
           const kwdName = child.childForFieldName("name")?.text;
           if (kwdName === name) {
-            return child.childForFieldName("value") ?? undefined;
+            return resolveReference(
+              child.childForFieldName("value") ?? undefined
+            );
           }
         } else {
           // Find by position
           if (currentPos === pos) {
-            return child;
+            return resolveReference(child);
           }
           currentPos++;
         }
@@ -1343,7 +1383,7 @@ export class PythonProgram extends AbstractProgram {
 
       case "sampled_from": {
         const argsNode = node.childForFieldName("arguments");
-        const listArg = argsNode?.namedChildren[0];
+        const listArg = resolveReference(argsNode?.namedChildren[0]);
         const sampledTypes: TypeRef[] = [];
 
         const getSampledType = (

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -1293,11 +1293,9 @@ export class PythonProgram extends AbstractProgram {
 
       case "sets":
       case "lists": {
-        ["unique", "unique_by"].forEach((kwd) => {
-          if (getKwdArg(node, kwd, -1)) {
-            console.warn(`The '${kwd}' property is not yet supported.`);
-          }
-        });
+        if (getKwdArg(node, "unique_by", -1)) {
+          console.warn("The 'unique_by' property is not yet supported.");
+        }
 
         const elementsArg = getKwdArg(node, "elements", 0);
         let innerTypeRef: TypeRef | undefined;
@@ -1340,6 +1338,10 @@ export class PythonProgram extends AbstractProgram {
         }
         if (innerResolvedType.options.dimLength === undefined) {
           innerResolvedType.options.dimLength = [];
+        }
+        const dimsUnique = parseLiteral(getKwdArg(node, "unique", -1));
+        if (funcName === "lists" && typeof dimsUnique === "boolean") {
+          innerResolvedType.options.dimsUnique = dimsUnique;
         }
         innerResolvedType.options.dimLength.push({
           min: Number(minSize ?? dftInterval.min),

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -876,6 +876,7 @@ export class PythonProgram extends AbstractProgram {
             .filter(
               (arg) =>
                 arg.type === "identifier" ||
+                arg.type === "default_parameter" ||
                 arg.type === "typed_parameter" ||
                 arg.type === "typed_default_parameter"
             )
@@ -948,6 +949,7 @@ export class PythonProgram extends AbstractProgram {
       argsNode?.node.namedChildren.filter(
         (arg) =>
           arg.type === "identifier" ||
+          arg.type === "default_parameter" ||
           arg.type === "typed_parameter" ||
           arg.type === "typed_default_parameter"
       ) ?? [];

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -816,7 +816,7 @@ export class PythonProgram extends AbstractProgram {
       case ArgTag.UNION:
       case ArgTag.TUPLE: {
         const children = this._getChildrenFromNode(typeNode);
-        // Collapse unions of a single value 
+        // Collapse unions of a single value
         if (type === ArgTag.UNION && children.length === 1) {
           const child = children[0];
           thisType.dims = child.dims;
@@ -1344,7 +1344,9 @@ export class PythonProgram extends AbstractProgram {
         const listArg = argsNode?.namedChildren[0];
         const sampledTypes: TypeRef[] = [];
 
-        const getSampledType = (valueNode: Parser.Node): TypeRef | undefined => {
+        const getSampledType = (
+          valueNode: Parser.Node
+        ): TypeRef | undefined => {
           const literalValue = parseLiteral(valueNode);
           if (isArgType(literalValue)) {
             return {
@@ -1363,7 +1365,9 @@ export class PythonProgram extends AbstractProgram {
           }
           if (valueNode.type === "tuple") {
             const children = valueNode.namedChildren.map(getSampledType);
-            if (children.every((child): child is TypeRef => child !== undefined)) {
+            if (
+              children.every((child): child is TypeRef => child !== undefined)
+            ) {
               return {
                 module: this._filename,
                 dims: 0,
@@ -1415,9 +1419,7 @@ export class PythonProgram extends AbstractProgram {
             if (sampledType !== undefined) {
               sampledTypes.push(sampledType);
             } else {
-              console.warn(
-                `Unsupported value in '${funcName}': ${item.text}.`
-              );
+              console.warn(`Unsupported value in '${funcName}': ${item.text}.`);
             }
           }
         }

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -688,16 +688,12 @@ export class PythonProgram extends AbstractProgram {
         return [];
 
       // PEP 604 `A | B` parses to `binary_operator`; `union_type` is handled
-      // defensively. Each operand is a child; drop `None` arms, whose
-      // nullability is carried by `TypeRef.optional` instead.
+      // defensively. Keep every arm to match `Union[A, B]`, including None.
       case "binary_operator":
       case "union_type":
-        return node.namedChildren
-          .filter(
-            (arm) =>
-              (arm.type === "type" ? arm.firstNamedChild : arm)?.type !== "none"
-          )
-          .map((arm) => this._getTypeRefFromAstNode(arm));
+        return node.namedChildren.map((arm) =>
+          this._getTypeRefFromAstNode(arm)
+        );
 
       case "generic_type":
       case "subscript": {

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -756,6 +756,8 @@ export class PythonProgram extends AbstractProgram {
         }
         break; // type-position identifier: classify below (typeNode = node)
       }
+      case "default_parameter":
+        throw new Error(`Missing type annotation: ${node.toString()}`);
       case "type": {
         break;
       }

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -1149,18 +1149,15 @@ export class PythonProgram extends AbstractProgram {
       }
 
       case "floats": {
-        [
-          "allow_nan",
-          "allow_infinity",
-          "allow_subnormal",
-          "width",
-          "exclude_min",
-          "exclude_max",
-        ].forEach((kwd) => {
-          if (getKwdArg(node, kwd, -1)) {
-            console.warn(`The '${kwd}' property is not yet supported.`);
+        // Note: we ignore "allow_nan" and "allow_infinity" because\
+        //       we don't presently generate those values
+        ["allow_subnormal", "width", "exclude_min", "exclude_max"].forEach(
+          (kwd) => {
+            if (getKwdArg(node, kwd, -1)) {
+              console.warn(`The '${kwd}' property is not yet supported.`);
+            }
           }
-        });
+        );
 
         const minVal = parseLiteral(getKwdArg(node, "min_value", 0));
         const maxVal = parseLiteral(getKwdArg(node, "max_value", 1));

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -1235,7 +1235,7 @@ export class PythonProgram extends AbstractProgram {
           };
         } else {
           console.warn(
-            `Unsupported literal in 'sampled_from': ${JSONN.stringify(lit)}.`
+            `Unsupported literal in '${funcName}': ${lit === undefined ? "undefined" : JSONN.stringify(lit)}.`
           );
         }
         break;
@@ -1334,16 +1334,53 @@ export class PythonProgram extends AbstractProgram {
       case "sampled_from": {
         const argsNode = node.childForFieldName("arguments");
         const listArg = argsNode?.namedChildren[0];
-        const literalValues: ArgType[] = [];
+        const sampledTypes: TypeRef[] = [];
+
+        const getSampledType = (valueNode: Parser.Node): TypeRef | undefined => {
+          const literalValue = parseLiteral(valueNode);
+          if (isArgType(literalValue)) {
+            return {
+              module: this._filename,
+              dims: 0,
+              optional: false,
+              isExported: false,
+              type: {
+                type: ArgTag.LITERAL,
+                dims: 0,
+                children: [],
+                value: literalValue,
+                resolved: true,
+              },
+            };
+          }
+          if (valueNode.type === "tuple") {
+            const children = valueNode.namedChildren.map(getSampledType);
+            if (children.every((child): child is TypeRef => child !== undefined)) {
+              return {
+                module: this._filename,
+                dims: 0,
+                optional: false,
+                isExported: false,
+                type: {
+                  type: ArgTag.TUPLE,
+                  dims: 0,
+                  children,
+                  resolved: true,
+                },
+              };
+            }
+          }
+          return undefined;
+        };
 
         if (listArg && (listArg.type === "list" || listArg.type === "tuple")) {
           for (const item of listArg.namedChildren) {
-            const lit = parseLiteral(item);
-            if (isArgType(lit)) {
-              literalValues.push(lit);
+            const sampledType = getSampledType(item);
+            if (sampledType !== undefined) {
+              sampledTypes.push(sampledType);
             } else {
               console.warn(
-                `Unsupported literal in 'sampled_from': ${JSONN.stringify(lit)}.`
+                `Unsupported value in '${funcName}': ${item.text}.`
               );
             }
           }
@@ -1353,19 +1390,7 @@ export class PythonProgram extends AbstractProgram {
         thisType.type = {
           type: ArgTag.UNION,
           dims: 0,
-          children: literalValues.map((val) => ({
-            module: this._filename,
-            dims: 0,
-            optional: false,
-            isExported: false,
-            type: {
-              type: ArgTag.LITERAL,
-              dims: 0,
-              children: [],
-              value: val,
-              resolved: true,
-            },
-          })),
+          children: sampledTypes,
           resolved: true,
         };
         break;

--- a/src/fuzzer/generators/MutationInputGenerator.test.ts
+++ b/src/fuzzer/generators/MutationInputGenerator.test.ts
@@ -1,9 +1,13 @@
 import * as ProgramFactory from "../analysis/ProgramFactory";
+import seedrandom from "seedrandom";
 import { RandomInputGenerator } from "./RandomInputGenerator";
 import { MutationInputGenerator } from "./MutationInputGenerator";
 import { Leaderboard } from "./Leaderboard";
 import { InputAndSource } from "../Types";
 import { ArgDefValidator } from "../analysis/ArgDefValidator";
+import { ArgDefMutator } from "../analysis/ArgDefMutator";
+import { ArgDef } from "../analysis/ArgDef";
+import { ArgTag } from "../analysis/Types";
 import * as JSONN from "../../Jsonn";
 
 /**
@@ -56,6 +60,67 @@ describe("fuzzer/generator/MutationInputGenerator:", () => {
         }
       }
     }
+  });
+
+  it("maintains spec order when re-adding optional object members", () => {
+    // `a` must be inserted before `b` when it is re-added, regardless of
+    // insertion history, so that we can do simple comparisons by serialization.
+    const optionalA = new ArgDef(
+      "a",
+      0,
+      ArgTag.NUMBER,
+      ArgDef.getDefaultOptions(),
+      0,
+      true,
+      [{ min: 1, max: 1 }]
+    );
+    const optionalB = new ArgDef(
+      "b",
+      1,
+      ArgTag.NUMBER,
+      ArgDef.getDefaultOptions(),
+      0,
+      true,
+      [{ min: 1, max: 1 }]
+    );
+    const specs = [
+      new ArgDef(
+        "obj",
+        0,
+        ArgTag.OBJECT,
+        {
+          ...ArgDef.getDefaultOptions(),
+          dimLength: [{ min: 2, max: 2 }],
+          dimsUnique: false,
+        },
+        1,
+        false,
+        undefined,
+        [optionalA, optionalB]
+      ),
+    ];
+    // Re-adding `a` to the second object would otherwise append it after `b`.
+    const input = [
+      {
+        tag: "ArgValueTypeWrapped" as const,
+        value: [{ a: 1, b: 1 }, { b: 1 }],
+      },
+    ];
+    const mutators = ArgDefMutator.getMutators(specs, input, seedrandom(seed));
+    const mutation = mutators.find(
+      (candidate) => candidate.name === "optional-genMember"
+    );
+
+    expect(mutation).toBeDefined();
+    mutation?.fn();
+    const array = input[0].value;
+    expect(Array.isArray(array)).toBeTrue();
+    if (!Array.isArray(array)) return;
+    // The mutator must restore the declaration order, not append `a` after `b`.
+    expect(Object.keys(array[1])).toEqual(["a", "b"]);
+    // With canonical key order, the duplicate object is visible to dimsUnique.
+    specs[0].setOptions({ dimsUnique: true });
+    expect(new ArgDefValidator(specs).validate(input)).toBeFalse();
   });
 
   /**

--- a/src/fuzzer/generators/MutationInputGenerator.test.ts
+++ b/src/fuzzer/generators/MutationInputGenerator.test.ts
@@ -1,7 +1,10 @@
 import * as ProgramFactory from "../analysis/ProgramFactory";
+import { RandomInputGenerator } from "./RandomInputGenerator";
 import { MutationInputGenerator } from "./MutationInputGenerator";
 import { Leaderboard } from "./Leaderboard";
 import { InputAndSource } from "../Types";
+import { ArgDefValidator } from "../analysis/ArgDefValidator";
+import * as JSONN from "../../Jsonn";
 
 /**
  * Provide a seed to ensure tests are deterministic.
@@ -9,6 +12,52 @@ import { InputAndSource } from "../Types";
 const seed: string = "qwertyuiop";
 
 describe("fuzzer/generator/MutationInputGenerator:", () => {
+  it("dimsUnique object arrays for random and mutation generators", () => {
+    const program = ProgramFactory.fromSource(
+      () => `export function x(obj: { a?: 1 }[]): number { return 1; }`,
+      "typescript"
+    );
+    const specs = program.functionsExported["x"].getArgDefs();
+    specs[0].setOptions({
+      dimLength: [{ min: 2, max: 2 }],
+      dimsUnique: true,
+    });
+    const validator = new ArgDefValidator(specs);
+    const initialInput = [
+      {
+        tag: "ArgValueTypeWrapped" as const,
+        value: [{ a: 1 }, {}],
+      },
+    ];
+    const leaderboard = new Leaderboard<InputAndSource>();
+    leaderboard.postScore(
+      {
+        tick: 1,
+        value: initialInput,
+        source: { type: "user" },
+      },
+      1
+    );
+
+    const generators = [
+      new RandomInputGenerator(specs, seed),
+      new MutationInputGenerator(specs, seed, leaderboard),
+    ];
+    for (const generator of generators) {
+      for (let index = 0; index < 100; index++) {
+        const input = generator.next().value;
+        expect(validator.validate(input)).toBeTrue();
+        const array = input[0].value;
+        expect(Array.isArray(array)).toBeTrue();
+        if (Array.isArray(array)) {
+          expect(
+            new Set(array.map((element) => JSONN.stringify(element))).size
+          ).toEqual(array.length);
+        }
+      }
+    }
+  });
+
   /**
    * Regression tests for https://github.com/nanofuzz/nanofuzz/issues/351.
    */

--- a/src/ui/FuzzPanelController.ts
+++ b/src/ui/FuzzPanelController.ts
@@ -3198,6 +3198,16 @@ ${inArgConsts}
             maxValue.toString()
           )}">Max length
           </vscode-text-field>
+          ${
+            dim === 0
+              ? /*html*/ `
+                <span class="tooltipped tooltipped-n" aria-label="Fill array with unique values?">
+                  <vscode-checkbox ${disabledFlag} id="${arrayBase}-unique" ${argOptions.dimsUnique === true ? "checked" : ""}>
+                    Unique?
+                  </vscode-checkbox>
+                </span>`
+              : ""
+          }
         </div>`;
     }
 
@@ -3617,6 +3627,7 @@ function _applyArgOverrides(
       });
       thisArg.setOptions({
         dimLength: thisOverride.array.dimLength,
+        dimsUnique: !!thisOverride.array.dimsUnique,
       });
     }
   } // for: each argument

--- a/src/ui/FuzzPanelController.ts
+++ b/src/ui/FuzzPanelController.ts
@@ -3517,7 +3517,7 @@ export function provideCodeLenses(
   } catch (e: unknown) {
     const msg = isError(e) ? e.message : JSON.stringify(e);
     console.error(
-      `Error parsing typescript file: ${document.fileName} error: ${msg}`
+      `Error parsing source file: ${document.fileName} error: ${msg}`
     );
   }
 

--- a/src/ui/FuzzPanelView.ts
+++ b/src/ui/FuzzPanelView.ts
@@ -2351,13 +2351,15 @@ function getConfigFromUi(): FuzzPanelFuzzRunMessage {
 
     // Process array dimension overrides
     const dimLength = [];
+    let dimsUnique = false;
     let dim = 0;
     let arrayBase = `${idBase}-array-${dim}`;
     while (document.getElementById(`${arrayBase}-min`) !== null) {
       const min = document.getElementById(`${arrayBase}-min`);
       const max = document.getElementById(`${arrayBase}-max`);
+      const unique = document.getElementById(`${arrayBase}-unique`);
       if (min !== null && max !== null) {
-        disableArr.push(min, max);
+        disableArr.push(min, max, ...(unique ? [unique] : []));
         const minVal = min.getAttribute("current-value");
         const maxVal = max.getAttribute("current-value");
         if (minVal !== null && maxVal !== null) {
@@ -2367,11 +2369,18 @@ function getConfigFromUi(): FuzzPanelFuzzRunMessage {
           });
         }
       }
+      if (dim === 0 && unique !== null) {
+        dimsUnique =
+          "checked" in unique && typeof unique.checked === "boolean"
+            ? unique.checked
+            : false;
+      }
       arrayBase = `${idBase}-array-${++dim}`;
     }
     if (dimLength.length > 0) {
       thisOverride.array = {
         dimLength: dimLength,
+        dimsUnique: dimsUnique,
       };
     }
   }


### PR DESCRIPTION
This PR implements support so that, if desired, arrays may be constrained so as to only include unique members.

This functionality is exposed via a new "Unique?" checkbox on the FuzzPanel, and we also now ingest the `unique` property of the `lists` strategy in Hypothesis.

<img width="834" height="802" alt="image" src="https://github.com/user-attachments/assets/e5abd937-9dc5-448b-831b-2758b9ce18e4" />
