### PR TITLE
feat: string regex

### DIFF
--- a/src/fuzzer/Types.ts
+++ b/src/fuzzer/Types.ts
@@ -219,6 +219,7 @@ export type FuzzArgOverride = {
     minStrLen: number;
     maxStrLen: number;
     strCharset: string;
+    strRegex?: string;
   };
   array?: {
     dimLength: { min: number; max: number }[];

--- a/src/fuzzer/adapters/jest/JestAdapter.test.ts
+++ b/src/fuzzer/adapters/jest/JestAdapter.test.ts
@@ -5,6 +5,7 @@ import { ArgOptions, ArgTag } from "../../analysis/Types";
 const argDefaults: ArgOptions = {
   strCharset: "abc",
   strLength: { min: 0, max: 3 },
+  strRegex: undefined,
   numInteger: true,
   anyType: ArgTag.NUMBER,
   anyDims: 0,

--- a/src/fuzzer/adapters/pytest/PytestAdapter.test.ts
+++ b/src/fuzzer/adapters/pytest/PytestAdapter.test.ts
@@ -5,6 +5,7 @@ import { ArgOptions, ArgTag } from "../../analysis/Types";
 const argDefaults: ArgOptions = {
   strCharset: "abc",
   strLength: { min: 0, max: 3 },
+  strRegex: undefined,
   numInteger: true,
   anyType: ArgTag.NUMBER,
   anyDims: 0,

--- a/src/fuzzer/analysis/ArgDef.test.ts
+++ b/src/fuzzer/analysis/ArgDef.test.ts
@@ -616,6 +616,30 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
     expect(new ArgDefValidator([spec]).validate(input)).toBeTrue();
   });
 
+  it("mutates regex strings", () => {
+    const spec = makeArgDef(
+      dummyModule,
+      "identifier",
+      0,
+      ArgTag.STRING,
+      { ...argOptions, strRegex: "\\A[a-z]{2}\\Z" },
+      0
+    );
+    const input = [{ tag: "ArgValueTypeWrapped" as const, value: "zz" }];
+    const mutations = ArgDefMutator.getMutators(
+      [spec],
+      input,
+      seedrandom("regex-regenerate")
+    );
+
+    expect(mutations.map((mutation) => mutation.name)).toEqual([
+      "regex-regenerate",
+    ]);
+    mutations[0].fn();
+    expect(input[0].value).not.toEqual("zz");
+    expect(new ArgDefValidator([spec]).validate(input)).toBeTrue();
+  });
+
   /**
    * This test generates random ArgDef specs, generates
    * and mutates inputs from those specs, and validates

--- a/src/fuzzer/analysis/ArgDef.test.ts
+++ b/src/fuzzer/analysis/ArgDef.test.ts
@@ -662,12 +662,16 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
     const failingMutators: { [k: string]: number } = {};
     const dupeMutators: { [k: string]: number } = {};
     let uniqueDimensionSpecs = 0;
+    let regexStringSpecs = 0;
     let i = 100;
     while (i--) {
       const spec = [getRandomArgDef(prng, Math.floor(prng() * 2))];
       if (spec[0].getDim() > 0 && spec[0].getOptions().dimsUnique) {
         uniqueDimensionSpecs++;
       }
+      regexStringSpecs += [spec[0], ...spec[0].getChildrenFlat()].filter(
+        (argument) => argument.getOptions().strRegex !== undefined
+      ).length;
       const stxt = abbrSpec(spec[0]).join("\r\n");
       const gen = new ArgDefGenerator(spec, prng);
       const val = new ArgDefValidator(spec);
@@ -767,6 +771,7 @@ describe("fuzzer/analysis/typescript/getTypeAnnotation: ", () => {
     expect(stats.gens.valid).not.toBe(0);
     expect(stats.gens.invalid).toBe(0);
     expect(uniqueDimensionSpecs).not.toBe(0);
+    expect(regexStringSpecs).not.toBe(0);
 
     expect(stats.muts.valid).not.toBe(0);
     expect(stats.muts.dupe).toBe(0);
@@ -782,6 +787,7 @@ function abbrSpec(spec: ArgDef, indents = 0): string[] {
   line.push(`${spec.getName()}:${TypescriptProgram.getTypeAnnotation(spec)}`);
   line.push(`dims: ${JSONN.stringify(spec.getOptions().dimLength)}`);
   if (spec.getOptions().dimsUnique) line.push(`DIMS_UNIQUE`);
+  if (spec.getOptions().strRegex) line.push(`STR_REGEX`);
   if (spec.isNoInput()) line.push(`NOINPUT`);
   if (spec.isOptional()) line.push(`OPTIONAL`);
   if (spec.getType() === ArgTag.NUMBER && spec.getOptions().numInteger)
@@ -916,6 +922,12 @@ function getRandomArgDef(
       options = {
         ...options,
         strLength: { min: Math.floor(prng() * 2), max: 2 },
+        strRegex:
+          prng() < 0.5
+            ? undefined
+            : ["\\A[a-z]{1,2}\\Z", "\\A\\d{2}\\Z", "\\A(a|b)\\Z"][
+                Math.floor(prng() * 3)
+              ],
       };
       break;
     }

--- a/src/fuzzer/analysis/ArgDef.ts
+++ b/src/fuzzer/analysis/ArgDef.ts
@@ -496,6 +496,7 @@ export class ArgDef<Tag extends ArgTag = ArgTag> {
         min: Config.get("nanofuzz.argdef.strLength.min", DFT_STR_LENGTH.min),
         max: Config.get("nanofuzz.argdef.strLength.max", DFT_STR_LENGTH.max),
       },
+      strRegex: undefined,
 
       // Numeric defaults
       numInteger: Config.get<boolean>("nanofuzz.argdef.numInteger", true),

--- a/src/fuzzer/analysis/ArgDefGenerator.ts
+++ b/src/fuzzer/analysis/ArgDefGenerator.ts
@@ -1,5 +1,6 @@
 import seedrandom from "seedrandom";
 import { ArgDef } from "./ArgDef";
+import * as RegexStringBuilder from "./RegexStringBuilder";
 import * as JSONN from "../../Jsonn";
 import {
   ArgTag,
@@ -89,8 +90,8 @@ type PublicRandFn = () => ArgValueType;
 function generateRandomInputFn(
   arg: ArgDef,
   prng: seedrandom.prng,
-  genDims = true, /* true=generate array dimensions if present;
-                    false=generate only the value */
+  genDims = true /* true=generate array dimensions if present;
+                    false=generate only the value */,
   allowOptional = true
 ): PublicRandFn {
   let randFn: PrivateRandFn;
@@ -184,6 +185,10 @@ function generateRandomInputFn(
   const options = arg.getOptions();
   const dimLength = arg.getOptions().dimLength;
   const isOptional = arg.isOptional();
+  const regexGenerator =
+    type === ArgTag.STRING && options.strRegex !== undefined
+      ? RegexStringBuilder.create(options.strRegex, prng, options)
+      : undefined;
 
   // Callback fn to generate value
   const randFnWrapper: PublicRandFn = () => {
@@ -199,6 +204,7 @@ function generateRandomInputFn(
       }
     }
     if (type === ArgTag.LITERAL && !intervals.length) return undefined;
+    if (regexGenerator) return regexGenerator();
 
     // TODO: weight interval selection based on the size of the interval !!!
     const interval =

--- a/src/fuzzer/analysis/ArgDefMutator.ts
+++ b/src/fuzzer/analysis/ArgDefMutator.ts
@@ -1,6 +1,7 @@
 import { ArgDef } from "./ArgDef";
 import { ArgDefGenerator } from "./ArgDefGenerator";
 import { ArgDefValidator } from "./ArgDefValidator";
+import * as RegexStringBuilder from "./RegexStringBuilder";
 import { ArgTag, ArgValueType, ArgValueTypeWrapped } from "./Types";
 import * as JSONN from "../../Jsonn";
 
@@ -332,6 +333,31 @@ export class ArgDefMutator {
           }
           case ArgTag.STRING: {
             const value = String(subInput.subElement);
+            if (options.strRegex !== undefined) {
+              const regenerated = RegexStringBuilder.create(
+                options.strRegex,
+                prng,
+                options
+              )();
+              addMutations(
+                [
+                  {
+                    name: "regex-regenerate",
+                    value: regenerated,
+                    path: [...subInput.subPath],
+                  },
+                ].filter(
+                  (proposal) =>
+                    proposal.value !== value &&
+                    proposal.value.length <= options.strLength.max &&
+                    proposal.value.length >= options.strLength.min &&
+                    proposal.value
+                      .split("")
+                      .every((char) => options.strCharset.includes(char))
+                )
+              );
+              break;
+            }
             const rPos = Math.floor(prng() * Math.max(0, value.length - 1));
             const charSet = options.strCharset;
             const rChar = charSet[Math.floor(prng() * (charSet.length - 1))];

--- a/src/fuzzer/analysis/ArgDefValidator.test.ts
+++ b/src/fuzzer/analysis/ArgDefValidator.test.ts
@@ -61,6 +61,21 @@ describe("fuzzer/analysis/typescript/ArgDefValidator:", () => {
     }
   });
 
+  it("Validates strings against strRegex", () => {
+    const regexString = makeArgDef(
+      dummyModule,
+      "identifier",
+      0,
+      ArgTag.STRING,
+      { ...argOptions, strRegex: "\\A[a-z]{2}\\Z" },
+      0
+    );
+
+    expect(ArgDefValidator.validate("ab", regexString)).toBe(true);
+    expect(ArgDefValidator.validate("a", regexString)).toBe(false);
+    expect(ArgDefValidator.validate("a1", regexString)).toBe(false);
+  });
+
   it("Validates outer dimension uniqueness when dimsUnique===true", () => {
     const uniqueArrayDef = makeArgDef(
       dummyModule,

--- a/src/fuzzer/analysis/ArgDefValidator.ts
+++ b/src/fuzzer/analysis/ArgDefValidator.ts
@@ -66,11 +66,18 @@ export class ArgDefValidator {
           );
         }
         case ArgTag.STRING: {
+          const regex =
+            options.strRegex === undefined
+              ? undefined
+              : new RegExp(
+                  options.strRegex.replace(/^\\A/, "^").replace(/\\Z$/, "$")
+                );
           return (
             typeof value === "string" &&
             value.length <= options.strLength.max &&
             value.length >= options.strLength.min &&
-            value.split("").every((e) => options.strCharset.includes(e))
+            value.split("").every((e) => options.strCharset.includes(e)) &&
+            (regex === undefined || regex.test(value))
           );
         }
         case ArgTag.BOOLEAN: {

--- a/src/fuzzer/analysis/RegexStringBuilder.test.ts
+++ b/src/fuzzer/analysis/RegexStringBuilder.test.ts
@@ -14,16 +14,24 @@ describe("fuzzer/analysis/RegexStringBuilder:", () => {
       "\\A[a-zA-Z_][a-zA-Z0-9_]{0,4}\\Z",
       // Animal label
       "\\A(cat|dog)-\\d{2}\\Z",
+      // Whole word
+      "\\A\\b[a-z]+\\b\\Z",
+      // Whole non-word character
+      "\\A\\B \\B\\Z",
       // Hexadecimal CSS color
       "\\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\\Z",
       // IPv4-like address
       "\\A\\d+\\.\\d+\\.\\d+\\.\\d+\\Z",
-      // GitHub profile URL
-      "\\Ahttps?://(www\\.)?github\\.com/[A-Za-z0-9]+\\Z",
-      // Twitter status URL
-      "\\Ahttps?://twitter\\.com/[A-Za-z0-9_]+/status/[0-9]+\\Z",
+      // Precise IPv4 address
+      "\\A((?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))*\\Z",
+      // GitHubris profile URL
+      "\\Ahttps?://(www\\.)?githubris\\.com/[A-Za-z0-9]+\\Z",
+      // Jitter status URL
+      "\\Ahttps?://jitter\\.com/[A-Za-z0-9_]+/status/[0-9]+\\Z",
       // Simplified email address
       "\\A[a-zA-Z0-9._-]+@[a-zA-Z0-9-]+\\.[a-zA-Z]{2,}\\Z",
+      // RFC-1123 email address
+      "\\A[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\\Z",
       // RGB CSS color
       "\\Argb\\(\\s*(\\d|[1-9]\\d|1\\d\\d|2[0-5])\\s*,\\s*(\\d|[1-9]\\d|1\\d\\d|2[0-5])\\s*,\\s*(\\d|[1-9]\\d|1\\d\\d|2[0-5])\\s*\\)\\Z",
     ];
@@ -33,12 +41,23 @@ describe("fuzzer/analysis/RegexStringBuilder:", () => {
      * until their regex features are supported by NaNofuzz's structural
      * builder:
      *
-     * // CSS color and precise IPv4: unsupported non-capturing groups (?:...).
-     * // IPv6: unsupported non-capturing groups and word-boundary assertions.
-     * // RFC-1123 email: unsupported non-capturing groups (?:...).
-     * // RFC-5322 email: unsupported negated character classes [^...].
-     * // General URL: unsupported character-class forms.
-     * // Emojis and non-emojis: unsupported Unicode property escapes \p and \P.
+    * // CSS color: /^(?:#|0x)(?:[a-f0-9]{3}|[a-f0-9]{6})$|^(?:rgb|hsl)a?\([^)]*\)$/
+    * // Unsupported: negated character classes [^...].
+    *
+    * // IPv6: /^((([0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4})|...|(([0-9A-Fa-f]{1,4}:){1,7}:))$/
+    * // Unsupported: the full fast-check IPv6 expression requires additional
+    * // structural features beyond the currently supported subset.
+    *
+    * // RFC-5322 email: /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+    * // Unsupported: negated character classes [^...].
+    *
+    * // General URL: /^(((http|https|ftp):\/\/)?([[a-zA-Z0-9]-\.])+(\.)([[a-zA-Z0-9]]){2,4}([[a-zA-Z0-9]\/+%&_\.~?-]*))*$/
+    * // Unsupported: the original uses character-class forms outside the
+    * // currently supported parser subset.
+    *
+    * // Emojis: /^\p{Emoji}+$/u
+    * // Non-emojis: /^\P{Emoji}+$/u
+    * // Unsupported: Unicode property escapes.
      */
 
     for (const regex of regexes) {

--- a/src/fuzzer/analysis/RegexStringBuilder.test.ts
+++ b/src/fuzzer/analysis/RegexStringBuilder.test.ts
@@ -9,6 +9,10 @@ const options = ArgDef.getDefaultOptions();
 // (We aspire to be as broadly compatible as fast-check.)
 describe("fuzzer/analysis/RegexStringBuilder:", () => {
   it("generates strings matching supported real-world patterns", () => {
+    const realWorldOptions = {
+      ...options,
+      strLength: { min: 0, max: 256 },
+    };
     const regexes = [
       // Identifier
       "\\A[a-zA-Z_][a-zA-Z0-9_]{0,4}\\Z",
@@ -63,7 +67,11 @@ describe("fuzzer/analysis/RegexStringBuilder:", () => {
     for (const regex of regexes) {
       const matcher = new RegExp(regex.replace("\\A", "^").replace("\\Z", "$"));
       for (let index = 0; index < 50; index++) {
-        const builder = create(regex, seedrandom(`${regex}:${index}`), options);
+        const builder = create(
+          regex,
+          seedrandom(`${regex}:${index}`),
+          realWorldOptions
+        );
         expect(matcher.test(builder())).toBeTrue();
       }
     }
@@ -73,5 +81,28 @@ describe("fuzzer/analysis/RegexStringBuilder:", () => {
     expect(() =>
       create("\\A(?=a)a\\Z", seedrandom("unsupported"), options)
     ).toThrowError(/Unsupported string regex/);
+  });
+
+  it("intersects strLength with regex length bounds", () => {
+    const boundedOptions = {
+      ...options,
+      strLength: { min: 3, max: 5 },
+    };
+    const builder = create("\\A[a-z]+\\Z", seedrandom("lengths"), boundedOptions);
+    for (let index = 0; index < 50; index++) {
+      const value = builder();
+      expect(value.length).toBeGreaterThanOrEqual(3);
+      expect(value.length).toBeLessThanOrEqual(5);
+    }
+  });
+
+  it("fails fast for incompatible regex and strLength bounds", () => {
+    expect(() =>
+      create(
+        "\\A[a-z]{6}\\Z",
+        seedrandom("impossible-lengths"),
+        { ...options, strLength: { min: 0, max: 5 } }
+      )
+    ).toThrowError(/conflicts with regex length/);
   });
 });

--- a/src/fuzzer/analysis/RegexStringBuilder.test.ts
+++ b/src/fuzzer/analysis/RegexStringBuilder.test.ts
@@ -1,0 +1,58 @@
+import seedrandom from "seedrandom";
+import { ArgDef } from "./ArgDef";
+import { create } from "./RegexStringBuilder";
+
+const options = ArgDef.getDefaultOptions();
+
+// Adapted from fast-check's stringMatching tests:
+// https://github.com/dubzzz/fast-check/blob/main/packages/fast-check/test/unit/arbitrary/stringMatching.spec.ts
+// (We aspire to be as broadly compatible as fast-check.)
+describe("fuzzer/analysis/RegexStringBuilder:", () => {
+  it("generates strings matching supported real-world patterns", () => {
+    const regexes = [
+      // Identifier
+      "\\A[a-zA-Z_][a-zA-Z0-9_]{0,4}\\Z",
+      // Animal label
+      "\\A(cat|dog)-\\d{2}\\Z",
+      // Hexadecimal CSS color
+      "\\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\\Z",
+      // IPv4-like address
+      "\\A\\d+\\.\\d+\\.\\d+\\.\\d+\\Z",
+      // GitHub profile URL
+      "\\Ahttps?://(www\\.)?github\\.com/[A-Za-z0-9]+\\Z",
+      // Twitter status URL
+      "\\Ahttps?://twitter\\.com/[A-Za-z0-9_]+/status/[0-9]+\\Z",
+      // Simplified email address
+      "\\A[a-zA-Z0-9._-]+@[a-zA-Z0-9-]+\\.[a-zA-Z]{2,}\\Z",
+      // RGB CSS color
+      "\\Argb\\(\\s*(\\d|[1-9]\\d|1\\d\\d|2[0-5])\\s*,\\s*(\\d|[1-9]\\d|1\\d\\d|2[0-5])\\s*,\\s*(\\d|[1-9]\\d|1\\d\\d|2[0-5])\\s*\\)\\Z",
+    ];
+
+    /*
+     * Remaining hardcoded fast-check examples are intentionally commented out
+     * until their regex features are supported by NaNofuzz's structural
+     * builder:
+     *
+     * // CSS color and precise IPv4: unsupported non-capturing groups (?:...).
+     * // IPv6: unsupported non-capturing groups and word-boundary assertions.
+     * // RFC-1123 email: unsupported non-capturing groups (?:...).
+     * // RFC-5322 email: unsupported negated character classes [^...].
+     * // General URL: unsupported character-class forms.
+     * // Emojis and non-emojis: unsupported Unicode property escapes \p and \P.
+     */
+
+    for (const regex of regexes) {
+      const matcher = new RegExp(regex.replace("\\A", "^").replace("\\Z", "$"));
+      for (let index = 0; index < 50; index++) {
+        const builder = create(regex, seedrandom(`${regex}:${index}`), options);
+        expect(matcher.test(builder())).toBeTrue();
+      }
+    }
+  });
+
+  it("fails fast for unsupported regexes", () => {
+    expect(() =>
+      create("\\A(?=a)a\\Z", seedrandom("unsupported"), options)
+    ).toThrowError(/Unsupported string regex/);
+  });
+});

--- a/src/fuzzer/analysis/RegexStringBuilder.ts
+++ b/src/fuzzer/analysis/RegexStringBuilder.ts
@@ -5,7 +5,8 @@ type RegexNode =
   | { type: "chars"; chars: string[] }
   | { type: "sequence"; nodes: RegexNode[] }
   | { type: "choice"; nodes: RegexNode[] }
-  | { type: "repeat"; node: RegexNode; min: number; max: number };
+  | { type: "repeat"; node: RegexNode; min: number; max: number }
+  | { type: "assertion"; kind: "wordBoundary" | "nonWordBoundary" };
 
 /**
  * Builds a structural string generator for the supported regular-expression
@@ -79,13 +80,27 @@ export const create = (
       return parseClass();
     }
     if (char === "(") {
-      if (source[index] === "?") fail("special group");
+      // Capturing and non-capturing groups have identical generation
+      // semantics. Other `(?...)` forms remain unsupported because they
+      // affect matching without consuming text.
+      if (source[index] === "?") {
+        if (source[index + 1] !== ":") fail("special group");
+        index += 2;
+      }
       const node = parseChoice();
       if (source[index++] !== ")") fail("unclosed group");
       return node;
     }
-    if (char === "\\")
-      return { type: "chars", chars: charsForEscape(source[index++]) };
+    if (char === "\\") {
+      const escaped = source[index++];
+      if (escaped === "b") {
+        return { type: "assertion", kind: "wordBoundary" };
+      }
+      if (escaped === "B") {
+        return { type: "assertion", kind: "nonWordBoundary" };
+      }
+      return { type: "chars", chars: charsForEscape(escaped) };
+    }
     if (char === ".")
       return { type: "chars", chars: options.strCharset.split("") };
     if ("^$|)*+?{}]".includes(char)) fail(`token '${char}'`);
@@ -152,6 +167,7 @@ export const create = (
         return node.nodes.map(generate).join("");
       case "choice":
         return generate(node.nodes[Math.floor(prng() * node.nodes.length)]);
+      case "assertion": return "";
       case "repeat": {
         const count = node.min + Math.floor(prng() * (node.max - node.min + 1));
         return Array.from({ length: count }, () => generate(node.node)).join(

--- a/src/fuzzer/analysis/RegexStringBuilder.ts
+++ b/src/fuzzer/analysis/RegexStringBuilder.ts
@@ -1,0 +1,171 @@
+import seedrandom from "seedrandom";
+import { ArgOptions } from "./Types";
+
+type RegexNode =
+  | { type: "chars"; chars: string[] }
+  | { type: "sequence"; nodes: RegexNode[] }
+  | { type: "choice"; nodes: RegexNode[] }
+  | { type: "repeat"; node: RegexNode; min: number; max: number };
+
+/**
+ * Builds a structural string generator for the supported regular-expression
+ * subset. Unsupported constructs throw before any client input is made.
+ *
+ * @param regex regular expression to satisfy
+ * @param prng pseudo-random number generator
+ * @param options string generation options
+ * @returns a generator that produces strings matching the regex
+ */
+export const create = (
+  regex: string,
+  prng: seedrandom.prng,
+  options: ArgOptions
+): (() => string) => {
+  const source = regex.replace(/^\\A/, "^").replace(/\\Z$/, "$");
+  let index = 0;
+
+  const fail = (message: string): never => {
+    throw new Error(`Unsupported string regex '${regex}': ${message}`);
+  };
+  const charsForEscape = (escape: string): string[] => {
+    switch (escape) {
+      case "d":
+        return "0123456789".split("");
+      case "w":
+        return "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_".split(
+          ""
+        );
+      case "s":
+        return [" ", "\t", "\n", "\r"];
+      default:
+        if ("\\.^$|?*+()[]{}".includes(escape)) return [escape];
+        return fail(`escape \\${escape}`);
+    }
+  };
+  const parseClass = (): RegexNode => {
+    index++;
+    if (source[index] === "^") fail("negated character class");
+    const chars: string[] = [];
+    while (index < source.length && source[index] !== "]") {
+      const start = source[index++];
+      if (start === "\\") {
+        chars.push(...charsForEscape(source[index++]));
+        continue;
+      }
+      if (source[index] === "-" && source[index + 1] !== "]") {
+        index++;
+        const end = source[index++];
+        if (
+          end === "\\" ||
+          start.codePointAt(0) === undefined ||
+          end.codePointAt(0) === undefined
+        )
+          fail("character class range");
+        for (
+          let code = start.codePointAt(0)!;
+          code <= end.codePointAt(0)!;
+          code++
+        )
+          chars.push(String.fromCodePoint(code));
+      } else chars.push(start);
+    }
+    if (source[index++] !== "]" || !chars.length) fail("character class");
+    return { type: "chars", chars };
+  };
+  const parseAtom = (): RegexNode => {
+    const char = source[index++];
+    if (char === "[") {
+      index--;
+      return parseClass();
+    }
+    if (char === "(") {
+      if (source[index] === "?") fail("special group");
+      const node = parseChoice();
+      if (source[index++] !== ")") fail("unclosed group");
+      return node;
+    }
+    if (char === "\\")
+      return { type: "chars", chars: charsForEscape(source[index++]) };
+    if (char === ".")
+      return { type: "chars", chars: options.strCharset.split("") };
+    if ("^$|)*+?{}]".includes(char)) fail(`token '${char}'`);
+    return { type: "chars", chars: [char] };
+  };
+  const parseQuantifier = (node: RegexNode): RegexNode => {
+    const char = source[index];
+    if (char === "?") {
+      index++;
+      return { type: "repeat", node, min: 0, max: 1 };
+    }
+    if (char === "*") {
+      index++;
+      return { type: "repeat", node, min: 0, max: options.strLength.max };
+    }
+    if (char === "+") {
+      index++;
+      return {
+        type: "repeat",
+        node,
+        min: 1,
+        max: Math.max(1, options.strLength.max),
+      };
+    }
+    if (char !== "{") return node;
+    const match = source.slice(index).match(/^\{(\d+)(?:,(\d*)?)?\}/);
+    if (match === null) return fail("quantifier");
+    index += match[0].length;
+    const min = Number(match[1]);
+    const max =
+      match[2] === undefined
+        ? min
+        : match[2] === ""
+          ? options.strLength.max
+          : Number(match[2]);
+    if (min > max) fail("quantifier range");
+    return { type: "repeat", node, min, max };
+  };
+  const parseSequence = (): RegexNode => {
+    const nodes: RegexNode[] = [];
+    while (index < source.length && !"|)$".includes(source[index]))
+      nodes.push(parseQuantifier(parseAtom()));
+    return { type: "sequence", nodes };
+  };
+  const parseChoice = (): RegexNode => {
+    const nodes = [parseSequence()];
+    while (source[index] === "|") {
+      index++;
+      nodes.push(parseSequence());
+    }
+    return nodes.length === 1 ? nodes[0] : { type: "choice", nodes };
+  };
+
+  if (source[index] === "^") index++;
+  const root = parseChoice();
+  if (source[index] === "$") index++;
+  if (index !== source.length) fail("trailing input");
+  const matcher = new RegExp(source);
+  const generate = (node: RegexNode): string => {
+    switch (node.type) {
+      case "chars":
+        return node.chars[Math.floor(prng() * node.chars.length)];
+      case "sequence":
+        return node.nodes.map(generate).join("");
+      case "choice":
+        return generate(node.nodes[Math.floor(prng() * node.nodes.length)]);
+      case "repeat": {
+        const count = node.min + Math.floor(prng() * (node.max - node.min + 1));
+        return Array.from({ length: count }, () => generate(node.node)).join(
+          ""
+        );
+      }
+    }
+  };
+  return () => {
+    const value = generate(root);
+    if (!matcher.test(value))
+      throw new Error(
+        `Regex generator produced a non-matching string for '${regex}'`
+      );
+    return value;
+  };
+};

--- a/src/fuzzer/analysis/RegexStringBuilder.ts
+++ b/src/fuzzer/analysis/RegexStringBuilder.ts
@@ -8,6 +8,8 @@ type RegexNode =
   | { type: "repeat"; node: RegexNode; min: number; max: number }
   | { type: "assertion"; kind: "wordBoundary" | "nonWordBoundary" };
 
+type LengthBounds = { min: number; max: number };
+
 /**
  * Builds a structural string generator for the supported regular-expression
  * subset. Unsupported constructs throw before any client input is made.
@@ -158,6 +160,49 @@ export const create = (
   const root = parseChoice();
   if (source[index] === "$") index++;
   if (index !== source.length) fail("trailing input");
+  const boundsFor = (node: RegexNode): LengthBounds => {
+    switch (node.type) {
+      case "chars":
+        return { min: 1, max: 1 };
+      case "assertion":
+        return { min: 0, max: 0 };
+      case "sequence":
+        return node.nodes.reduce(
+          (bounds, child) => {
+            const childBounds = boundsFor(child);
+            return {
+              min: bounds.min + childBounds.min,
+              max: bounds.max + childBounds.max,
+            };
+          },
+          { min: 0, max: 0 }
+        );
+      case "choice": {
+        const childBounds = node.nodes.map(boundsFor);
+        return {
+          min: Math.min(...childBounds.map((bounds) => bounds.min)),
+          max: Math.max(...childBounds.map((bounds) => bounds.max)),
+        };
+      }
+      case "repeat": {
+        const childBounds = boundsFor(node.node);
+        return {
+          min: node.min * childBounds.min,
+          max: node.max * childBounds.max,
+        };
+      }
+    }
+  };
+  const regexBounds = boundsFor(root);
+  const effectiveBounds = {
+    min: Math.max(regexBounds.min, options.strLength.min),
+    max: Math.min(regexBounds.max, options.strLength.max),
+  };
+  if (effectiveBounds.min > effectiveBounds.max) {
+    fail(
+      `length range ${options.strLength.min}-${options.strLength.max} conflicts with regex length ${regexBounds.min}-${regexBounds.max}`
+    );
+  }
   const matcher = new RegExp(source);
   const generate = (node: RegexNode): string => {
     switch (node.type) {
@@ -165,11 +210,16 @@ export const create = (
         return node.chars[Math.floor(prng() * node.chars.length)];
       case "sequence":
         return node.nodes.map(generate).join("");
-      case "choice":
+      case "choice": {
         return generate(node.nodes[Math.floor(prng() * node.nodes.length)]);
+      }
       case "assertion": return "";
       case "repeat": {
-        const count = node.min + Math.floor(prng() * (node.max - node.min + 1));
+        const range = node.max - node.min + 1;
+        // Favor shorter expansions so several unbounded repetitions can still
+        // fit within the effective string-length range.
+        const count =
+          node.min + Math.floor(prng() * prng() * range);
         return Array.from({ length: count }, () => generate(node.node)).join(
           ""
         );
@@ -177,11 +227,18 @@ export const create = (
     }
   };
   return () => {
-    const value = generate(root);
-    if (!matcher.test(value))
-      throw new Error(
-        `Regex generator produced a non-matching string for '${regex}'`
-      );
-    return value;
+    for (let attempt = 0; attempt < 100; attempt++) {
+      const value = generate(root);
+      if (
+        value.length >= effectiveBounds.min &&
+        value.length <= effectiveBounds.max &&
+        matcher.test(value)
+      ) {
+        return value;
+      }
+    }
+    throw new Error(
+      `Regex generator could not satisfy the effective length range ${effectiveBounds.min}-${effectiveBounds.max} for '${regex}'`
+    );
   };
 };

--- a/src/fuzzer/analysis/Types.ts
+++ b/src/fuzzer/analysis/Types.ts
@@ -128,6 +128,7 @@ export type ArgOptions = {
   // For type string
   strCharset: string; // string representing the characters allowed in the input
   strLength: Interval<number>; // length of characters allowed in the input
+  strRegex: string | undefined; // regular expression the input must match
 
   // For type number
   numInteger: boolean; // true if the numeric argument input is an integer
@@ -164,6 +165,7 @@ export type ArgOptionOverride = {
   dimsUnique?: boolean;
   strLength?: Interval<number>;
   strCharset?: string;
+  strRegex?: string;
   children?: ArgOptionOverrides;
   isNoInput?: boolean;
 };

--- a/src/fuzzer/analysis/python/PythonProgram.test.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.test.ts
@@ -880,6 +880,33 @@ def test_example(trigger, dep, trigger_val):
     expect(args[2].getIntervals()).toEqual([{ min: 0, max: 100 }]);
   });
 
+  it("maps Hypothesis from_regex to the string regex option", () => {
+    const fn = ProgramFactory.fromSource(
+      () => `
+PATTERN = r"[a-zA-Z_][a-zA-Z0-9_]{0,4}"
+FULLMATCH = False
+
+@given(
+    inline=st.from_regex(r"[a-z]+", fullmatch=True),
+    referenced=st.from_regex(PATTERN, alphabet="super"),
+  partial=st.from_regex(r"[0-9]+", fullmatch=FULLMATCH),
+  anchored=st.from_regex(r"\\A[a-z_]\\Z", fullmatch=True)
+)
+def test_regex(inline, referenced, partial, anchored):
+    pass
+        `,
+      "python"
+    ).functionsExported["test_regex"];
+
+    expect(fn.getArgDefs().map((arg) => arg.getOptions().strRegex)).toEqual([
+      "\\A[a-z]+\\Z",
+      "[a-zA-Z_][a-zA-Z0-9_]{0,4}",
+      "[0-9]+",
+      "\\A[a-z_]\\Z",
+    ]);
+    expect(fn.getArgDefs()[1].getOptions().strCharset).toEqual("super");
+  });
+
   it("hypothesis @given positional arguments", () => {
     const fn = ProgramFactory.fromSource(
       () => `

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -1185,6 +1185,35 @@ export class PythonProgram extends AbstractProgram {
         break;
       }
 
+      case "from_regex": {
+        const parsedRegex = parseLiteral(getKwdArg(node, "regex", 0));
+        const alphabet = parseLiteral(getKwdArg(node, "alphabet", 2));
+        const fullmatch = parseLiteral(getKwdArg(node, "fullmatch", 1));
+        if (typeof parsedRegex !== "string") {
+          console.warn(
+            `Unsupported or unrecognized 'from_regex' regex value. Is it compiled?'.`
+          );
+          return undefined;
+        }
+        let regex = parsedRegex;
+        if (fullmatch === true) {
+          if (!regex.startsWith("\\A")) regex = `\\A${regex}`;
+          if (!regex.endsWith("\\Z")) regex = `${regex}\\Z`;
+        }
+
+        thisType.type = {
+          type: ArgTag.STRING,
+          dims: 0,
+          children: [],
+          options: {
+            strRegex: regex,
+            ...(alphabet === undefined ? {} : { strCharset: String(alphabet) }),
+          },
+          resolved: true,
+        };
+        break;
+      }
+
       case "integers": {
         const minVal = parseLiteral(getKwdArg(node, "min_value", 0));
         const maxVal = parseLiteral(getKwdArg(node, "max_value", 1));

--- a/src/ui/FuzzPanelController.ts
+++ b/src/ui/FuzzPanelController.ts
@@ -3040,7 +3040,7 @@ ${inArgConsts}
           arg.getOptions().strCharset
         )}">Character set</vscode-text-field>`;
         html += " ";
-        html += /*html*/ `<vscode-text-field size="20" ${disabledFlag} id="${idBase}-strRegex" name="${idBase}-strRegex" value="${htmlEscape(
+        html += /*html*/ `<vscode-text-field size="10" ${disabledFlag} id="${idBase}-strRegex" name="${idBase}-strRegex" value="${htmlEscape(
           arg.getOptions().strRegex ?? ""
         )}">Regex</vscode-text-field>`;
         break;

--- a/src/ui/FuzzPanelController.ts
+++ b/src/ui/FuzzPanelController.ts
@@ -3039,6 +3039,10 @@ ${inArgConsts}
         html += /*html*/ `<vscode-text-field size="10" ${disabledFlag} id="${idBase}-strCharset" name="${idBase}-strCharset" value="${htmlEscape(
           arg.getOptions().strCharset
         )}">Character set</vscode-text-field>`;
+        html += " ";
+        html += /*html*/ `<vscode-text-field size="20" ${disabledFlag} id="${idBase}-strRegex" name="${idBase}-strRegex" value="${htmlEscape(
+          arg.getOptions().strRegex ?? ""
+        )}">Regex</vscode-text-field>`;
         break;
       }
 
@@ -3606,6 +3610,7 @@ function _applyArgOverrides(
               thisOverride.string.strCharset === ""
                 ? argDefaults.strCharset
                 : thisOverride.string.strCharset,
+            strRegex: thisOverride.string.strRegex,
           });
         }
         break;

--- a/src/ui/FuzzPanelView.ts
+++ b/src/ui/FuzzPanelView.ts
@@ -2294,6 +2294,7 @@ function getConfigFromUi(): FuzzPanelFuzzRunMessage {
     const minStrLen = document.getElementById(idBase + "-minStrLen");
     const maxStrLen = document.getElementById(idBase + "-maxStrLen");
     const strCharset = document.getElementById(idBase + "-strCharset");
+    const strRegex = document.getElementById(idBase + "-strRegex");
     const isNoInput = document.getElementById(idBase + "-isNoInput");
 
     // Process numeric overrides
@@ -2321,10 +2322,16 @@ function getConfigFromUi(): FuzzPanelFuzzRunMessage {
 
     // Process string overrides
     if (minStrLen && maxStrLen && strCharset) {
-      disableArr.push(minStrLen, maxStrLen);
+      disableArr.push(
+        minStrLen,
+        maxStrLen,
+        strCharset,
+        ...(strRegex ? [strRegex] : [])
+      );
       const minStrLenVal = minStrLen.getAttribute("current-value");
       const maxStrLenVal = maxStrLen.getAttribute("current-value");
       const strCharsetVal = strCharset.getAttribute("current-value");
+      const strRegexVal = strRegex?.getAttribute("current-value");
       if (
         minStrLenVal !== null &&
         maxStrLenVal !== null &&
@@ -2337,6 +2344,7 @@ function getConfigFromUi(): FuzzPanelFuzzRunMessage {
           ),
           maxStrLen: Math.max(Number(minStrLenVal), Number(maxStrLenVal), 0),
           strCharset: strCharsetVal,
+          strRegex: strRegexVal === "" ? undefined : (strRegexVal ?? undefined),
         };
       }
     } // TODO: Validation !!!


### PR DESCRIPTION
This PR creates a rudimentary regex capability for generating strings. The functionality is exposed in a new `Regex` field on string arguments. Uncompiled regex values are also ingested from Hypothexsis `from_regex` strategies.

Currently there is no real-time ui feedback about invalid regexes, the mutation strategy is simply `re-generate`, and many types of regexes are not supported. Also, we don't try to address the differences between Python and JS regexes.