### PR TITLE
fix: `@given` ingestion

### DIFF
--- a/src/fuzzer/analysis/python/PythonProgram.test.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.test.ts
@@ -1278,6 +1278,39 @@ def test_lru_eviction_order_after_reads(capacity: int, ops1: list, ops2: list, n
     expect(numPosArg?.getIntervals()).toEqual([{ min: 0, max: 10 }]);
   });
 
+  it("handles strategies like st.tuples inside st.sampled_from", () => {
+    const fn = ProgramFactory.fromSource(
+      () => `
+@given(
+    capacity=st.integers(min_value=2, max_value=4),
+    ops=st.lists(
+        st.sampled_from([
+            st.tuples(
+                st.just('read'),
+                st.integers(min_value=0, max_value=10)
+            ),
+            st.tuples(
+                st.just('write'),
+                st.integers(min_value=0, max_value=10),
+                st.just(999)
+            )
+        ]),
+        min_size=5,
+        max_size=7,
+    )
+)
+def test_lru_eviction_order_after_reads(capacity: int, ops: list):
+    pass
+`,
+      "python"
+    ).functionsExported["test_lru_eviction_order_after_reads"];
+
+    const opsArg = fn.getArgDefs().find((a) => a.getName() === "ops");
+    expect(opsArg?.getType()).toBe(ArgTag.UNION);
+    expect(opsArg?.getDim()).toBe(1);
+    expect(opsArg?.getChildren().length).toBe(2);
+  });
+
   it("isVoid===true for functions lacking return statements", () => {
     const fns = ProgramFactory.fromSource(
       () => `

--- a/src/fuzzer/analysis/python/PythonProgram.test.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.test.ts
@@ -1209,6 +1209,36 @@ def test_add_overwrites_boundary_expired_item(key, old_value, new_value):
     expect(newChildren[1].getOptions().strLength).toEqual({ min: 1, max: 10 });
   });
 
+  it("@given dimsUnique for st.lists(..., unique=True) and st.sets(...)", () => {
+    const fn = ProgramFactory.fromSource(
+      () => `
+@given(
+    initial=st.lists(st.integers(min_value=0, max_value=20), min_size=3, max_size=12, unique=True),
+    ops=st.lists(
+        st.tuples(
+            st.sampled_from(['add', 'discard']),
+            st.integers()
+        ), 
+        min_size=1, max_size=8
+    ),
+    unique_set=st.sets(st.integers(min_value=1, max_value=5))
+)
+def test_indexedset_index_invariant_after_discard(initial: list[int], ops: List[Tuple[Literal["add","discard"], int]], unique_set: set[int]):
+    pass
+`,
+      "python"
+    ).functionsExported["test_indexedset_index_invariant_after_discard"];
+
+    const argDefs = fn.getArgDefs();
+    const initialArg = argDefs.find((a) => a.getName() === "initial");
+    const opsArg = argDefs.find((a) => a.getName() === "ops");
+    const setArg = argDefs.find((a) => a.getName() === "unique_set");
+
+    expect(initialArg?.getOptions().dimsUnique).toBeTrue();
+    expect(opsArg?.getOptions().dimsUnique).toBeFalse();
+    expect(setArg?.getOptions().dimsUnique).toBeTrue();
+  });
+
   it("isVoid===true for functions lacking return statements", () => {
     const fns = ProgramFactory.fromSource(
       () => `
@@ -1301,13 +1331,17 @@ def transformer_empty(*args: tuple[()]):
     ).functionsExported;
 
     const lowerArgs = fns["transformer_lowercase"].getArgDefs();
-    expect(lowerArgs.map((a) => [a.getName(), PythonProgram.getTypeAnnotation(a)])).toEqual([
+    expect(
+      lowerArgs.map((a) => [a.getName(), PythonProgram.getTypeAnnotation(a)])
+    ).toEqual([
       ["args_0", "str"],
       ["args_1", "int"],
     ]);
 
     const capArgs = fns["transformer_capitalized"].getArgDefs();
-    expect(capArgs.map((a) => [a.getName(), PythonProgram.getTypeAnnotation(a)])).toEqual([
+    expect(
+      capArgs.map((a) => [a.getName(), PythonProgram.getTypeAnnotation(a)])
+    ).toEqual([
       ["args_0", "str"],
       ["args_1", "float"],
     ]);
@@ -1326,7 +1360,9 @@ def greeting_transformer(*args: MyTuple):
     ).functionsExported;
 
     const args = fns["greeting_transformer"].getArgDefs();
-    expect(args.map((a) => [a.getName(), PythonProgram.getTypeAnnotation(a)])).toEqual([
+    expect(
+      args.map((a) => [a.getName(), PythonProgram.getTypeAnnotation(a)])
+    ).toEqual([
       ["args_0", "str"],
       ["args_1", "int"],
     ]);

--- a/src/fuzzer/analysis/python/PythonProgram.test.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.test.ts
@@ -1239,6 +1239,45 @@ def test_indexedset_index_invariant_after_discard(initial: list[int], ops: List[
     expect(setArg?.getOptions().dimsUnique).toBeTrue();
   });
 
+  it("handles min_size after max_size in st.lists regardless of order or inline comments", () => {
+    const fn = ProgramFactory.fromSource(
+      () => `
+@given(
+    capacity=st.integers(min_value=2, max_value=4),
+    ops1=st.lists(
+        st.tuples(
+            st.sampled_from(['read','write']),
+            st.integers(min_value=0, max_value=10),
+            st.just(999)
+        ),
+        max_size=7, # len(ops) >= capacity
+        min_size=5,
+    ),
+    ops2=st.lists(
+        st.tuples(
+            st.sampled_from(['read','write']),
+            st.integers(min_value=0, max_value=10),
+            st.just(999)
+        ),
+        max_size=7,
+        min_size=5,
+    ),
+    num_pos=st.integers(0, 10)
+)
+def test_lru_eviction_order_after_reads(capacity: int, ops1: list, ops2: list, num_pos: int):
+    pass
+`,
+      "python"
+    ).functionsExported["test_lru_eviction_order_after_reads"];
+
+    const ops1Arg = fn.getArgDefs().find((a) => a.getName() === "ops1");
+    const ops2Arg = fn.getArgDefs().find((a) => a.getName() === "ops2");
+    const numPosArg = fn.getArgDefs().find((a) => a.getName() === "num_pos");
+    expect(ops1Arg?.getOptions().dimLength).toEqual([{ min: 5, max: 7 }]);
+    expect(ops2Arg?.getOptions().dimLength).toEqual([{ min: 5, max: 7 }]);
+    expect(numPosArg?.getIntervals()).toEqual([{ min: 0, max: 10 }]);
+  });
+
   it("isVoid===true for functions lacking return statements", () => {
     const fns = ProgramFactory.fromSource(
       () => `

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -1623,6 +1623,13 @@ export class PythonProgram extends AbstractProgram {
         const getSampledType = (
           valueNode: Parser.Node
         ): TypeRef | undefined => {
+          if (valueNode.type === "call" || valueNode.type === "identifier") {
+            const strategyTypeRef = this._getTypeRefFromStrategy(valueNode);
+            if (strategyTypeRef) {
+              return strategyTypeRef;
+            }
+          }
+
           const literalValue = parseLiteral(valueNode);
           if (isArgType(literalValue)) {
             return {

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -1030,8 +1030,25 @@ export class PythonProgram extends AbstractProgram {
       let typeRef = paramName
         ? (hypothesisArgMap[paramName] ?? hypothesisPositionalArgs[paramIndex])
         : hypothesisPositionalArgs[paramIndex];
+
       if (typeRef !== undefined) {
         typeRef.name = paramName;
+        // Merge underlying type info from AST if hypothesis strategy left type UNRESOLVED
+        if (!typeRef.type || typeRef.type.type === ArgTag.UNRESOLVED) {
+          try {
+            const astTypeRef = this._getTypeRefFromAstNode(paramNode);
+            if (astTypeRef?.type) {
+              if (!typeRef.type) {
+                typeRef.type = structuredClone(astTypeRef.type);
+              } else {
+                typeRef.type.type = astTypeRef.type.type;
+                typeRef.type.children = structuredClone(astTypeRef.type.children);
+              }
+            }
+          } catch {
+            // Ignore if parameter lacks native type annotation
+          }
+        }
       } else {
         typeRef = this._getTypeRefFromAstNode(paramNode);
       }
@@ -1521,8 +1538,10 @@ export class PythonProgram extends AbstractProgram {
           innerResolvedType.options.dimLength = [];
         }
         const dimsUnique = parseLiteral(getKwdArg(node, "unique", -1));
-        if (funcName === "lists" && typeof dimsUnique === "boolean") {
+        if (typeof dimsUnique === "boolean") {
           innerResolvedType.options.dimsUnique = dimsUnique;
+        } else if (funcName === "sets") {
+          innerResolvedType.options.dimsUnique = true;
         }
         innerResolvedType.options.dimLength.push({
           min: Number(minSize ?? dftInterval.min),

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -1042,7 +1042,9 @@ export class PythonProgram extends AbstractProgram {
                 typeRef.type = structuredClone(astTypeRef.type);
               } else {
                 typeRef.type.type = astTypeRef.type.type;
-                typeRef.type.children = structuredClone(astTypeRef.type.children);
+                typeRef.type.children = structuredClone(
+                  astTypeRef.type.children
+                );
               }
             }
           } catch {
@@ -1090,9 +1092,7 @@ export class PythonProgram extends AbstractProgram {
               const armsWithPos = tupleArms.filter(
                 (t) => t.type!.children!.length > k
               );
-              const posChildren = armsWithPos.map(
-                (t) => t.type!.children![k]
-              );
+              const posChildren = armsWithPos.map((t) => t.type!.children![k]);
               const isOptional = armsWithPos.length < totalArms;
               const firstName = posChildren.find((c) => c.name)?.name;
               const posName = firstName ?? `${paramName ?? "args"}_${k}`;
@@ -1274,24 +1274,53 @@ export class PythonProgram extends AbstractProgram {
     ): Parser.Node | undefined => {
       const argsNode = callNode.childForFieldName("arguments");
       if (!argsNode) return undefined;
-      let currentPos = 0;
-      for (const child of argsNode.namedChildren) {
-        if (child.type === "keyword_argument") {
-          // Find by name
-          const kwdName = child.childForFieldName("name")?.text;
-          if (kwdName === name) {
-            return resolveReference(
-              child.childForFieldName("value") ?? undefined
-            );
-          }
-        } else {
-          // Find by position
-          if (currentPos === pos) {
-            return resolveReference(child);
-          }
-          currentPos++;
+
+      // 1. Look for a named keyword argument (e.g., min_size=5)
+      const kwdNode = argsNode.namedChildren.find(
+        (child) =>
+          child.type === "keyword_argument" &&
+          child.childForFieldName("name")?.text === name
+      );
+      if (kwdNode) {
+        return resolveReference(
+          kwdNode.childForFieldName("value") ?? undefined
+        );
+      }
+
+      // 2. Fallback: look for a positional argument at index `pos`
+      if (pos >= 0) {
+        const isPositionalArg = (node: Parser.Node): boolean =>
+          [
+            "identifier",
+            "integer",
+            "float",
+            "string",
+            "true",
+            "false",
+            "none",
+            "call",
+            "attribute",
+            "subscript",
+            "list",
+            "tuple",
+            "dictionary",
+            "set",
+            "binary_operator",
+            "unary_operator",
+            "boolean_operator",
+            "comparison_operator",
+            "parenthesized_expression",
+            "lambda",
+            "list_splat",
+            "dictionary_splat",
+          ].includes(node.type);
+
+        const positionalArgs = argsNode.namedChildren.filter(isPositionalArg);
+        if (pos < positionalArgs.length) {
+          return resolveReference(positionalArgs[pos]);
         }
       }
+
       return undefined;
     };
 

--- a/src/ui/FuzzPanelController.ts
+++ b/src/ui/FuzzPanelController.ts
@@ -3397,7 +3397,11 @@ def ${transformerName}(${pyParams}) -> ${pyTupleType}:
             dim === 0
               ? /*html*/ `
                 <span class="tooltipped tooltipped-n" aria-label="Fill array with unique values?">
-                  <vscode-checkbox ${disabledFlag} id="${arrayBase}-unique" ${argOptions.dimsUnique === true ? "checked" : ""}>
+                  <vscode-checkbox ${disabledFlag} id="${arrayBase}-unique" ${
+                  argOptions.dimsUnique === true ? "checked" : ""
+                } current-checked="${
+                  argOptions.dimsUnique === true ? "true" : "false"
+                }">
                     Unique?
                   </vscode-checkbox>
                 </span>`

--- a/src/ui/FuzzPanelView.ts
+++ b/src/ui/FuzzPanelView.ts
@@ -2412,9 +2412,8 @@ function getConfigFromUi(): FuzzPanelFuzzRunMessage {
       }
       if (dim === 0 && unique !== null) {
         dimsUnique =
-          "checked" in unique && typeof unique.checked === "boolean"
-            ? unique.checked
-            : false;
+          unique.getAttribute("current-checked") === "true" ||
+          ("checked" in unique && unique.checked === true);
       }
       arrayBase = `${idBase}-array-${++dim}`;
     }


### PR DESCRIPTION
This PR fixes a bug where merging @given and native types could cause dropping of `dimsUnique`. Also fixes:
- a bug where sets were not getting `dimsUnique` by default
- problems with strategy parameter extraction (e.g., `st.tuples` in `st.sampled_from`)