### PR TITLE
feat: llm cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,6 +155,27 @@
             "type": "boolean",
             "default": false,
             "description": "Write AI debug information to the console"
+          },
+          "nanofuzz.ai.cacheMode": {
+            "title": "LLM response cache mode",
+            "order": 70,
+            "type": "string",
+            "enum": [
+              "passthrough",
+              "record",
+              "replay-record",
+              "replay-error",
+              "replay-passthrough"
+            ],
+            "default": "passthrough",
+            "description": "Mode for caching and replaying LLM query responses"
+          },
+          "nanofuzz.ai.cacheFile": {
+            "title": "LLM response cache file path",
+            "order": 80,
+            "type": "string",
+            "default": ".nanofuzz-llm-cache.json",
+            "description": "File path where recorded LLM query responses and latencies are saved"
           }
         }
       },

--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -1334,6 +1334,18 @@ export type FuzzTestStats = {
         initialFocus: number;
         focusDecay: number;
       };
+      checkpoints: {
+        tick: number; // tick of the checkpoint
+        gens: Record<
+          string,
+          {
+            active: boolean; // subgen is active
+            nextable: boolean; // subgen is active and nextable
+            productivity: number; // current productivity[g] for this input generator
+            cost: number; // current cost[g] for this input generator
+          }
+        >;
+      }[];
     };
   };
   measures: {

--- a/src/fuzzer/adapters/LlmAdapter.ts
+++ b/src/fuzzer/adapters/LlmAdapter.ts
@@ -8,6 +8,12 @@ import { isError } from "../Util";
 import * as telemetry from "../../telemetry/Telemetry";
 import * as zod from "zod";
 import { zodOutputFormat } from "./AnthropicUtils";
+import { LlmCacheManager } from "./LlmCacheManager";
+import {
+  LlmCacheMode,
+  LlmCacheStats,
+  LlmQueryResult,
+} from "../generators/Types";
 
 /**
  * An adapter for chatting with an LLM about the program under test
@@ -15,6 +21,7 @@ import { zodOutputFormat } from "./AnthropicUtils";
 export class LlmAdapter {
   protected _modelConfig: Parameters<typeof nodellm.createLLM>[0] = {}; // LLM configuration
   protected _backend: nodellm.NodeLLMCore; // LLM instance
+  protected _cacheManager: LlmCacheManager; // Cache manager
   protected _cfgString: string; // LLM config; for detecting config changes
 
   public constructor() {
@@ -44,6 +51,7 @@ export class LlmAdapter {
 
     // Create the model backend
     this._backend = nodellm.createLLM(this._modelConfig);
+    this._cacheManager = new LlmCacheManager(cfg.cacheMode, cfg.cacheFile);
   } // constructor
 
   /**
@@ -76,6 +84,18 @@ export class LlmAdapter {
     return `v=${this._backend.provider?.id},n=${LlmAdapter._getConfig().modelName}`;
   } // getter: id
 
+  public get cacheStats(): LlmCacheStats {
+    return this._cacheManager.stats;
+  }
+
+  public get cacheManager(): LlmCacheManager {
+    return this._cacheManager;
+  }
+
+  public static async flushCache(timeoutMs = 5000): Promise<void> {
+    await LlmCacheManager.flushAllActive(timeoutMs);
+  }
+
   /**
    * Prompt an LLM to generate inputs for a function
    *
@@ -100,7 +120,7 @@ export class LlmAdapter {
         schema
       );
       const inputs: { programInputs: { [k: string]: ArgValueType }[] } =
-        JSONN.parse(response.response);
+        JSONN.parse(response.text);
 
       // Sanity check llm output
       if (
@@ -143,78 +163,79 @@ export class LlmAdapter {
   private async _query(
     prompt: string[],
     schema?: zod.ZodObject
-  ): Promise<{
-    response: string;
-    stats: {
-      tokensSent: number;
-      tokensSentCost: { amt: number; unit: string };
-      tokensReceived: number;
-      tokensReceivedCost: { amt: number; unit: string };
-    };
-  }> {
+  ): Promise<LlmQueryResult> {
     LlmAdapter._handleDebug();
 
-    const promptParts: nodellm.ContentPart[] = [];
-    prompt.forEach((e) => {
-      promptParts.push({
-        type: "text",
-        text: e,
-      });
-    });
-
     const provider = LlmAdapter._getConfig().provider;
-    vscode.commands.executeCommand(
-      telemetry.commands.logTelemetry.name,
-      new telemetry.LoggerEntry(
-        "LlmAdapter.query.send",
-        "Sending query to LLM (v=%s;m=%s). Query: %s.",
-        [provider, LlmAdapter._getConfig().modelName, prompt.join("\n")]
-      )
-    );
+    const modelName = LlmAdapter._getConfig().modelName;
+    const schemaJson = schema
+      ? JSON.stringify(schema.toJSONSchema())
+      : undefined;
 
-    const baseChat = this._createChat();
-    let chat = (
-      schema ? baseChat.withSchema(schema.toJSONSchema()) : baseChat
-    ).withRequestOptions({
-      responseFormat: { type: "json_object" },
-    });
-
-    // Provider specific settings
-    if (provider === "anthropic") {
-      if (schema) {
-        // Anthropic doesn't always respect responseFormat
-        chat = chat.withParams({
-          output_config: {
-            format: zodOutputFormat(schema),
-          },
+    return await this._cacheManager.query(
+      provider,
+      modelName,
+      prompt,
+      schemaJson,
+      async () => {
+        const promptParts: nodellm.ContentPart[] = [];
+        prompt.forEach((e) => {
+          promptParts.push({
+            type: "text",
+            text: e,
+          });
         });
+
+        vscode.commands.executeCommand(
+          telemetry.commands.logTelemetry.name,
+          new telemetry.LoggerEntry(
+            "LlmAdapter.query.send",
+            "Sending query to LLM (v=%s;m=%s). Query: %s.",
+            [provider, modelName, prompt.join("\n")]
+          )
+        );
+
+        const baseChat = this._createChat();
+        let chat = (
+          schema ? baseChat.withSchema(schema.toJSONSchema()) : baseChat
+        ).withRequestOptions({
+          responseFormat: { type: "json_object" },
+        });
+
+        // Provider specific settings
+        if (provider === "anthropic") {
+          if (schema) {
+            // Anthropic doesn't always respect responseFormat
+            chat = chat.withParams({
+              output_config: {
+                format: zodOutputFormat(schema),
+              },
+            });
+          }
+        }
+
+        const response = await chat.ask(promptParts);
+
+        vscode.commands.executeCommand(
+          telemetry.commands.logTelemetry.name,
+          new telemetry.LoggerEntry(
+            "LlmAdapter.query.response",
+            "Received response from LLM (v=%s;m=%s). Response: %s.",
+            [provider, modelName, response.toString()]
+          )
+        );
+
+        return {
+          text: response.toString(),
+          stats: {
+            tokensSent: response.inputTokens,
+            tokensSentCost: { amt: response.input_cost ?? 0, unit: "USD" }, // USD per docs
+            tokensReceived: response.outputTokens,
+            tokensReceivedCost: { amt: response.output_cost ?? 0, unit: "USD" }, // USD per docs
+          },
+        };
       }
-    }
-
-    const response = await chat.ask(promptParts);
-
-    vscode.commands.executeCommand(
-      telemetry.commands.logTelemetry.name,
-      new telemetry.LoggerEntry(
-        "LlmAdapter.query.response",
-        "Received response from LLM (v=%s;m=%s). Response: %s.",
-        [
-          LlmAdapter._getConfig().provider,
-          LlmAdapter._getConfig().modelName,
-          response.toString(),
-        ]
-      )
     );
-
-    return {
-      response: response.toString(),
-      stats: {
-        tokensSent: response.inputTokens,
-        tokensSentCost: { amt: response.input_cost ?? 0, unit: "USD" }, // USD per docs
-        tokensReceived: response.outputTokens,
-        tokensReceivedCost: { amt: response.output_cost ?? 0, unit: "USD" }, // USD per docs
-      },
-    };
   } // fn: _query
 
   /**
@@ -236,11 +257,21 @@ export class LlmAdapter {
     provider: string;
     modelName: string;
     apiKey: string;
+    cacheMode: LlmCacheMode;
+    cacheFile: string;
   } {
     return {
       provider: LlmAdapter._getConfigValue("provider", "disabled"),
       modelName: LlmAdapter._getConfigValue("model", ""),
       apiKey: LlmAdapter._getConfigValue("apiKey", ""),
+      cacheMode: LlmAdapter._getConfigValue<LlmCacheMode>(
+        "cacheMode",
+        "passthrough"
+      ),
+      cacheFile: LlmAdapter._getConfigValue<string>(
+        "cacheFile",
+        ".nanofuzz-llm-cache.json"
+      ),
     };
   } // fn: _getConfig
 
@@ -275,7 +306,7 @@ export class LlmAdapter {
 /**
  * Parameterized prompts for the LLM
  */
-const prompt = {
+export const prompt = {
   system: (): string => {
     return `You are an experienced software engineer who writes efficient tests that thoroughly evaluate the correctness of programs. You are aware of the important differences between a programming language's various equality operators.`;
   },

--- a/src/fuzzer/adapters/LlmCacheManager.test.ts
+++ b/src/fuzzer/adapters/LlmCacheManager.test.ts
@@ -1,0 +1,348 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { LlmCacheManager, createCacheKey } from "./LlmCacheManager";
+import { LlmCacheEntry } from "../generators/Types";
+import * as JSONN from "../../Jsonn";
+
+describe("src/fuzzer/adapters/LlmCacheManager:", () => {
+  let tmpDir: string;
+  let cacheFile: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nanofuzz-cache-test-"));
+    cacheFile = path.join(tmpDir, "llm-cache.json");
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(tmpDir)) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("passthrough mode: passes queries through unrecorded", async () => {
+    const manager = new LlmCacheManager("passthrough", cacheFile);
+    let liveCalls = 0;
+
+    const queryFn = async () => {
+      liveCalls++;
+      return {
+        text: "hello",
+        stats: {
+          tokensSent: 10,
+          tokensSentCost: { amt: 0, unit: "USD" },
+          tokensReceived: 5,
+          tokensReceivedCost: { amt: 0, unit: "USD" },
+        },
+      };
+    };
+
+    const res = await manager.query(
+      "provider1",
+      "model1",
+      ["prompt1"],
+      undefined,
+      queryFn
+    );
+    expect(res.text).toBe("hello");
+    expect(liveCalls).toBe(1);
+    expect(fs.existsSync(cacheFile)).toBeFalse();
+
+    const stats = manager.stats;
+    expect(stats.calls).toBe(1);
+    expect(stats.passedThroughUnrecorded).toBe(1);
+    expect(stats.hits).toBe(0);
+    expect(stats.misses).toBe(0);
+    expect(stats.live.calls).toBe(1);
+    expect(stats.live.tokensSent).toBe(10);
+    expect(stats.live.tokensReceived).toBe(5);
+    expect(stats.replayed.calls).toBe(0);
+  });
+
+  it("record mode: records live queries and response delays", async () => {
+    const manager = new LlmCacheManager("record", cacheFile);
+    let liveCalls = 0;
+
+    const queryFn = async () => {
+      liveCalls++;
+      await new Promise((r) => setTimeout(r, 20));
+      return {
+        text: "recorded-answer",
+        stats: {
+          tokensSent: 10,
+          tokensSentCost: { amt: 0, unit: "USD" },
+          tokensReceived: 5,
+          tokensReceivedCost: { amt: 0, unit: "USD" },
+        },
+      };
+    };
+
+    const res = await manager.query(
+      "provider1",
+      "model1",
+      ["prompt1"],
+      '{"type":"object"}',
+      queryFn
+    );
+    expect(res.text).toBe("recorded-answer");
+    expect(liveCalls).toBe(1);
+    expect(fs.existsSync(cacheFile)).toBeTrue();
+
+    const stats = manager.stats;
+    expect(stats.calls).toBe(1);
+    expect(stats.recorded).toBe(1);
+    expect(stats.misses).toBe(1);
+    expect(stats.live.calls).toBe(1);
+    expect(stats.live.tokensSent).toBe(10);
+    expect(stats.live.tokensReceived).toBe(5);
+
+    // Verify cache file contents
+    const content = JSONN.parse<LlmCacheEntry[]>(
+      fs.readFileSync(cacheFile, "utf-8")
+    );
+    expect(content.length).toBe(1);
+    expect(content[0].response.text).toBe("recorded-answer");
+    expect(content[0].delayMs).toBeGreaterThanOrEqual(15);
+  });
+
+  it("replay-record mode: serves hits from cache with delay and records misses", async () => {
+    // 1. Seed cache file
+    const key = createCacheKey("provider1", "model1", ["prompt1"], undefined);
+    const seededData = [
+      {
+        key,
+        request: {
+          provider: "provider1",
+          modelName: "model1",
+          prompt: ["prompt1"],
+        },
+        response: {
+          text: "cached-answer",
+          stats: {
+            tokensSent: 5,
+            tokensSentCost: { amt: 0, unit: "USD" },
+            tokensReceived: 5,
+            tokensReceivedCost: { amt: 0, unit: "USD" },
+          },
+        },
+        delayMs: 30,
+        recordedAt: new Date().toISOString(),
+      },
+    ];
+    fs.writeFileSync(cacheFile, JSON.stringify(seededData), "utf-8");
+
+    const manager = new LlmCacheManager("replay-record", cacheFile);
+    let liveCalls = 0;
+
+    // Test CACHE HIT
+    const startHit = performance.now();
+    const hitRes = await manager.query(
+      "provider1",
+      "model1",
+      ["prompt1"],
+      undefined,
+      async () => {
+        liveCalls++;
+        return {
+          text: "live-answer",
+          stats: {
+            tokensSent: 10,
+            tokensSentCost: { amt: 0, unit: "USD" },
+            tokensReceived: 5,
+            tokensReceivedCost: { amt: 0, unit: "USD" },
+          },
+        };
+      }
+    );
+    const hitElapsed = performance.now() - startHit;
+
+    expect(hitRes.text).toBe("cached-answer");
+    expect(liveCalls).toBe(0);
+    expect(hitElapsed).toBeGreaterThanOrEqual(20);
+
+    // Test CACHE MISS
+    const missRes = await manager.query(
+      "provider1",
+      "model1",
+      ["prompt2-miss"],
+      undefined,
+      async () => {
+        liveCalls++;
+        return {
+          text: "new-recorded-answer",
+          stats: {
+            tokensSent: 10,
+            tokensSentCost: { amt: 0, unit: "USD" },
+            tokensReceived: 5,
+            tokensReceivedCost: { amt: 0, unit: "USD" },
+          },
+        };
+      }
+    );
+
+    expect(missRes.text).toBe("new-recorded-answer");
+    expect(liveCalls).toBe(1);
+
+    const stats = manager.stats;
+    expect(stats.calls).toBe(2);
+    expect(stats.hits).toBe(1);
+    expect(stats.misses).toBe(1);
+    expect(stats.recorded).toBe(1);
+    expect(stats.replayed.calls).toBe(1);
+    expect(stats.replayed.tokensSent).toBe(5);
+    expect(stats.replayed.tokensReceived).toBe(5);
+    expect(stats.live.calls).toBe(1);
+    expect(stats.live.tokensSent).toBe(10);
+    expect(stats.live.tokensReceived).toBe(5);
+
+    // Check that cache file now contains 2 entries
+    const updatedContent = JSONN.parse<LlmCacheEntry[]>(
+      fs.readFileSync(cacheFile, "utf-8")
+    );
+    expect(updatedContent.length).toBe(2);
+  });
+
+  it("replay-error mode: serves hits and throws on misses without calling live function", async () => {
+    // Seed cache file
+    const key = createCacheKey("p", "m", ["p1"], undefined);
+    const seededData = [
+      {
+        key,
+        request: { provider: "p", modelName: "m", prompt: ["p1"] },
+        response: {
+          text: "cached-p1",
+          stats: {
+            tokensSent: 1,
+            tokensSentCost: { amt: 0, unit: "USD" },
+            tokensReceived: 1,
+            tokensReceivedCost: { amt: 0, unit: "USD" },
+          },
+        },
+        delayMs: 5,
+        recordedAt: new Date().toISOString(),
+      },
+    ];
+    fs.writeFileSync(cacheFile, JSON.stringify(seededData), "utf-8");
+
+    const manager = new LlmCacheManager("replay-error", cacheFile);
+    let liveCalls = 0;
+
+    const dummyStats = {
+      tokensSent: 0,
+      tokensSentCost: { amt: 0, unit: "USD" },
+      tokensReceived: 0,
+      tokensReceivedCost: { amt: 0, unit: "USD" },
+    };
+
+    // Cache hit
+    const res = await manager.query("p", "m", ["p1"], undefined, async () => {
+      liveCalls++;
+      return { text: "live", stats: dummyStats };
+    });
+    expect(res.text).toBe("cached-p1");
+    expect(liveCalls).toBe(0);
+
+    // Cache miss -> throws error
+    await expectAsync(
+      manager.query("p", "m", ["unrecorded-prompt"], undefined, async () => {
+        liveCalls++;
+        return { text: "live", stats: dummyStats };
+      })
+    ).toBeRejectedWithError(/Cache miss in 'replay-error' mode/);
+
+    expect(liveCalls).toBe(0);
+
+    const stats = manager.stats;
+    expect(stats.calls).toBe(2);
+    expect(stats.hits).toBe(1);
+    expect(stats.misses).toBe(1);
+    expect(stats.failures).toBe(1);
+  });
+
+  it("replay-passthrough mode: serves hits and passes misses live without recording", async () => {
+    // Seed cache file
+    const key = createCacheKey("p", "m", ["p1"], undefined);
+    const seededData = [
+      {
+        key,
+        request: { provider: "p", modelName: "m", prompt: ["p1"] },
+        response: {
+          text: "cached-p1",
+          stats: {
+            tokensSent: 1,
+            tokensSentCost: { amt: 0, unit: "USD" },
+            tokensReceived: 1,
+            tokensReceivedCost: { amt: 0, unit: "USD" },
+          },
+        },
+        delayMs: 5,
+        recordedAt: new Date().toISOString(),
+      },
+    ];
+    fs.writeFileSync(cacheFile, JSON.stringify(seededData), "utf-8");
+
+    const manager = new LlmCacheManager("replay-passthrough", cacheFile);
+    let liveCalls = 0;
+
+    const dummyStats = {
+      tokensSent: 0,
+      tokensSentCost: { amt: 0, unit: "USD" },
+      tokensReceived: 0,
+      tokensReceivedCost: { amt: 0, unit: "USD" },
+    };
+
+    // Cache hit
+    const hitRes = await manager.query(
+      "p",
+      "m",
+      ["p1"],
+      undefined,
+      async () => {
+        liveCalls++;
+        return { text: "live", stats: dummyStats };
+      }
+    );
+    expect(hitRes.text).toBe("cached-p1");
+    expect(liveCalls).toBe(0);
+
+    // Cache miss -> live call executed, but NOT saved to cache file
+    const missRes = await manager.query(
+      "p",
+      "m",
+      ["unrecorded-prompt"],
+      undefined,
+      async () => {
+        liveCalls++;
+        return {
+          text: "live-unrecorded",
+          stats: {
+            tokensSent: 2,
+            tokensSentCost: { amt: 0, unit: "USD" },
+            tokensReceived: 2,
+            tokensReceivedCost: { amt: 0, unit: "USD" },
+          },
+        };
+      }
+    );
+
+    expect(missRes.text).toBe("live-unrecorded");
+    expect(liveCalls).toBe(1);
+
+    const stats = manager.stats;
+    expect(stats.calls).toBe(2);
+    expect(stats.hits).toBe(1);
+    expect(stats.misses).toBe(1);
+    expect(stats.passedThroughUnrecorded).toBe(1);
+    expect(stats.recorded).toBe(0);
+    expect(stats.replayed.calls).toBe(1);
+    expect(stats.replayed.tokensSent).toBe(1);
+    expect(stats.live.calls).toBe(1);
+    expect(stats.live.tokensSent).toBe(2);
+
+    // Cache file length should still be 1
+    const content = JSONN.parse<LlmCacheEntry[]>(
+      fs.readFileSync(cacheFile, "utf-8")
+    );
+    expect(content.length).toBe(1);
+  });
+});

--- a/src/fuzzer/adapters/LlmCacheManager.ts
+++ b/src/fuzzer/adapters/LlmCacheManager.ts
@@ -1,0 +1,224 @@
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import * as JSONN from "../../Jsonn";
+import {
+  LlmCacheEntry,
+  LlmCacheMode,
+  LlmCacheStats,
+  LlmQueryResult,
+} from "../generators/Types";
+
+export class LlmCacheManager {
+  protected static _activeManagers = new Set<LlmCacheManager>();
+
+  protected _mode: LlmCacheMode;
+  protected _filePath?: string;
+  protected _cache: Map<string, LlmCacheEntry> = new Map();
+  protected _stats: LlmCacheStats;
+  protected _pendingQueries: Set<Promise<unknown>> = new Set();
+
+  constructor(mode: LlmCacheMode = "passthrough", filePath?: string) {
+    this._mode = mode;
+    this._filePath = filePath ? path.resolve(filePath) : undefined;
+    this._stats = {
+      mode,
+      calls: 0,
+      hits: 0,
+      misses: 0,
+      recorded: 0,
+      passedThroughUnrecorded: 0,
+      failures: 0,
+      live: {
+        calls: 0,
+        tokensSent: 0,
+        tokensReceived: 0,
+        costUsd: 0,
+      },
+      replayed: {
+        calls: 0,
+        tokensSent: 0,
+        tokensReceived: 0,
+        costUsd: 0,
+      },
+    };
+    this._loadCache();
+    LlmCacheManager._activeManagers.add(this);
+  }
+
+  protected _loadCache(): void {
+    if (this._mode === "passthrough" || !this._filePath) return;
+    if (fs.existsSync(this._filePath)) {
+      try {
+        const raw = fs.readFileSync(this._filePath, "utf-8");
+        const entries: LlmCacheEntry[] = JSONN.parse(raw);
+        entries.forEach((e) => this._cache.set(e.key, e));
+      } catch (err) {
+        console.warn(
+          `[LlmCacheManager] Failed to load cache from ${this._filePath}:`,
+          err
+        );
+      }
+    }
+  }
+
+  public saveCache(): void {
+    if (!this._filePath || this._mode === "passthrough") return;
+    try {
+      const dir = path.dirname(this._filePath);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      const data = Array.from(this._cache.values());
+      fs.writeFileSync(this._filePath, JSONN.stringify(data, null, 2), "utf-8");
+    } catch (err) {
+      console.error(
+        `[LlmCacheManager] Failed to write cache to ${this._filePath}:`,
+        err
+      );
+    }
+  }
+
+  public async query(
+    provider: string,
+    modelName: string,
+    prompt: string[],
+    schemaJson: string | undefined,
+    liveQueryFn: () => Promise<LlmQueryResult>
+  ): Promise<LlmQueryResult> {
+    const queryPromise = this._executeQuery(
+      provider,
+      modelName,
+      prompt,
+      schemaJson,
+      liveQueryFn
+    );
+    this._pendingQueries.add(queryPromise);
+    try {
+      return await queryPromise;
+    } finally {
+      this._pendingQueries.delete(queryPromise);
+    }
+  }
+
+  protected async _executeQuery(
+    provider: string,
+    modelName: string,
+    prompt: string[],
+    schemaJson: string | undefined,
+    liveQueryFn: () => Promise<LlmQueryResult>
+  ): Promise<LlmQueryResult> {
+    this._stats.calls++;
+
+    // Passthrough
+    if (this._mode === "passthrough") {
+      this._stats.passedThroughUnrecorded++;
+      const liveResult = await liveQueryFn();
+      this._recordLiveStats(liveResult);
+      return liveResult;
+    }
+
+    const key = createCacheKey(provider, modelName, prompt, schemaJson);
+    const cachedEntry = this._cache.get(key);
+
+    // Cache hit
+    if (cachedEntry) {
+      this._stats.hits++;
+      const sentCost = cachedEntry.response.stats?.tokensSentCost?.amt ?? 0;
+      const receivedCost =
+        cachedEntry.response.stats?.tokensReceivedCost?.amt ?? 0;
+      this._stats.replayed.calls++;
+      this._stats.replayed.tokensSent +=
+        cachedEntry.response.stats?.tokensSent ?? 0;
+      this._stats.replayed.tokensReceived +=
+        cachedEntry.response.stats?.tokensReceived ?? 0;
+      this._stats.replayed.costUsd += sentCost + receivedCost;
+
+      if (cachedEntry.delayMs > 0) {
+        await new Promise((r) => setTimeout(r, cachedEntry.delayMs));
+      }
+      return {
+        text: cachedEntry.response.text,
+        stats: cachedEntry.response.stats,
+      };
+    }
+
+    // Cache miss
+    this._stats.misses++;
+
+    if (this._mode === "replay-error") {
+      this._stats.failures++;
+      throw new Error(
+        `LLM Cache miss in 'replay-error' mode for query key: ${key}`
+      );
+    }
+
+    if (this._mode === "replay-passthrough") {
+      this._stats.passedThroughUnrecorded++;
+      const liveResult = await liveQueryFn();
+      this._recordLiveStats(liveResult);
+      return liveResult;
+    }
+
+    // Mode is "record" or "replay-record"
+    const start = performance.now();
+    const liveResult = await liveQueryFn();
+    const delayMs = Math.round(performance.now() - start);
+
+    this._recordLiveStats(liveResult);
+    this._stats.recorded++;
+    this._cache.set(key, {
+      key,
+      request: { provider, modelName, prompt, schemaJson },
+      response: { text: liveResult.text, stats: liveResult.stats },
+      delayMs,
+      recordedAt: new Date().toISOString(),
+    });
+    this.saveCache();
+
+    return liveResult;
+  }
+
+  private _recordLiveStats(liveResult: LlmQueryResult): void {
+    const sentCost = liveResult.stats?.tokensSentCost?.amt ?? 0;
+    const receivedCost = liveResult.stats?.tokensReceivedCost?.amt ?? 0;
+    this._stats.live.calls++;
+    this._stats.live.tokensSent += liveResult.stats?.tokensSent ?? 0;
+    this._stats.live.tokensReceived += liveResult.stats?.tokensReceived ?? 0;
+    this._stats.live.costUsd += sentCost + receivedCost;
+  }
+
+  public async flush(timeoutMs = 5000): Promise<void> {
+    this.saveCache();
+    if (this._pendingQueries.size === 0) return;
+
+    const timeoutPromise = new Promise((r) => setTimeout(r, timeoutMs));
+    await Promise.race([
+      Promise.all(Array.from(this._pendingQueries)),
+      timeoutPromise,
+    ]);
+    this.saveCache();
+  }
+
+  public static async flushAllActive(timeoutMs = 5000): Promise<void> {
+    for (const manager of LlmCacheManager._activeManagers) {
+      await manager.flush(timeoutMs);
+    }
+  }
+
+  public get stats(): LlmCacheStats {
+    return { ...this._stats };
+  }
+
+  public get mode(): LlmCacheMode {
+    return this._mode;
+  }
+}
+
+export function createCacheKey(
+  provider: string,
+  modelName: string,
+  prompt: string[],
+  schemaJson?: string
+): string {
+  const payload = JSON.stringify({ provider, modelName, prompt, schemaJson });
+  return crypto.createHash("sha256").update(payload).digest("hex");
+}

--- a/src/fuzzer/generators/AiInputGenerator.ts
+++ b/src/fuzzer/generators/AiInputGenerator.ts
@@ -440,7 +440,11 @@ export class AiInputGenerator extends AbstractInputGenerator {
    * Return stats about the AI input generation process
    */
   public get stats(): InputGeneratorStatsAi {
-    return JSON.parse(JSON.stringify(this._stats));
+    const res: InputGeneratorStatsAi = JSON.parse(JSON.stringify(this._stats));
+    if (this._llm) {
+      res.cache = this._llm.cacheStats;
+    }
+    return res;
   } // getter: stats
 } // class: AiInputGenerator
 

--- a/src/fuzzer/generators/CompositeInputGenerator.test.ts
+++ b/src/fuzzer/generators/CompositeInputGenerator.test.ts
@@ -1,0 +1,132 @@
+import { CompositeInputGenerator } from "./CompositeInputGenerator";
+import { Leaderboard } from "./Leaderboard";
+import { FuzzStopReason, FuzzTestResults, FuzzTestStats } from "../Fuzzer";
+import * as ProgramFactory from "../analysis/ProgramFactory";
+import { ArgDef } from "../analysis/ArgDef";
+import { FuzzOptions, InputAndSource } from "../Types";
+
+describe("src/fuzzer/generators/CompositeInputGenerator:", () => {
+  it("builds checkpoints during _selectNextSubGen and populates them onRunEnd", () => {
+    const program = ProgramFactory.fromSource(
+      () => `export function dummyFn(x: number) {}`,
+      "typescript"
+    );
+    const fnDef = program.functionsExported["dummyFn"];
+
+    const genStats: FuzzTestStats["generators"] = {
+      RandomInputGenerator: {
+        counters: { inputsGenerated: 0, dupesGenerated: 0 },
+        timers: { run: 0, val: 0, gen: 0, measure: 0, transform: 0 },
+      },
+      MutationInputGenerator: {
+        counters: { inputsGenerated: 0, dupesGenerated: 0 },
+        timers: { run: 0, val: 0, gen: 0, measure: 0, transform: 0 },
+      },
+      AiInputGenerator: {
+        counters: { inputsGenerated: 0, dupesGenerated: 0 },
+        timers: { run: 0, val: 0, gen: 0, measure: 0, transform: 0 },
+      },
+    };
+
+    const options = {
+      RandomInputGenerator: { enabled: true },
+      MutationInputGenerator: { enabled: false },
+      AiInputGenerator: { enabled: false },
+    };
+
+    const leaderboard = new Leaderboard<InputAndSource>();
+    const allInputs = new Map<string, unknown>();
+
+    const cig = new CompositeInputGenerator(
+      options,
+      fnDef,
+      "test-seed",
+      [],
+      leaderboard,
+      genStats,
+      allInputs
+    );
+
+    cig.onRunStart(true);
+
+    // Generating inputs triggers _selectNextSubGen
+    expect(cig.nextable()).toBeTrue();
+    const input1 = cig.next();
+    expect(input1).toBeDefined();
+
+    const mockFuzzOptions: FuzzOptions = {
+      argDefaults: ArgDef.getDefaultOptions(),
+      measures: {
+        FailedTestMeasure: { enabled: true, weight: 1 },
+        CoverageMeasure: { enabled: false, weight: 0 },
+      },
+      generators: options,
+      maxTests: 100,
+      fnTimeout: 1000,
+      suiteTimeout: 10000,
+      seed: "test-seed",
+      maxDupeInputs: 100,
+      maxFailures: 0,
+      useImplicit: true,
+      useHuman: false,
+      useProperty: true,
+      useTransformer: false,
+    };
+
+    const mockResults: FuzzTestResults = {
+      toolVersion: "test",
+      env: {
+        options: mockFuzzOptions,
+        function: fnDef,
+        validators: [],
+        transformers: [],
+      },
+      results: [],
+      interesting: { inputs: [] },
+      stopReason: FuzzStopReason.MAXTESTS,
+      stats: {
+        timers: {
+          total: 0,
+          compile: 0,
+          put: 0,
+          val: 0,
+          gen: 0,
+          transform: 0,
+          measure: 0,
+        },
+        counters: {
+          testingRuns: 1,
+          inputsGenerated: 1,
+          dupesGenerated: 0,
+          inputsInjected: 0,
+          erroredTests: 0,
+          passedTests: 1,
+          inputsSkipped: 0,
+          failedTests: 0,
+        },
+        generators: genStats,
+        measures: {},
+      },
+    };
+
+    cig.onRunEnd(mockResults);
+
+    const cigStats = mockResults.stats.generators.CompositeInputGenerator;
+    expect(cigStats).toBeDefined();
+    expect(cigStats?.checkpoints).toBeDefined();
+    expect(cigStats?.checkpoints.length).toBeGreaterThan(0);
+
+    const firstCheckpoint = cigStats?.checkpoints[0];
+    expect(firstCheckpoint?.tick).toBeDefined();
+    expect(firstCheckpoint?.gens.RandomInputGenerator).toBeDefined();
+    expect(typeof firstCheckpoint?.gens.RandomInputGenerator.nextable).toBe(
+      "boolean"
+    );
+    expect(typeof firstCheckpoint?.gens.RandomInputGenerator.productivity).toBe(
+      "number"
+    );
+    expect(typeof firstCheckpoint?.gens.RandomInputGenerator.cost).toBe(
+      "number"
+    );
+  });
+});

--- a/src/fuzzer/generators/CompositeInputGenerator.ts
+++ b/src/fuzzer/generators/CompositeInputGenerator.ts
@@ -48,6 +48,9 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
   private _P = 0.1; // Additional chance of subgen exploration
   private _permitSubgens = true; // Allow generators to produce inputs
   private _genStats: FuzzTestStats["generators"]; // Generator statistics
+  private _checkpoints: NonNullable<
+    FuzzTestStats["generators"]["CompositeInputGenerator"]
+  >["checkpoints"] = []; // status of subgens at selection
   public static readonly INJECTED = "injected";
 
   /**
@@ -323,6 +326,11 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
     const progress: number[] = []; // progress of subgen for L generations
     const productivity: number[] = []; // productivity = progress / cost
     let totalProductivity = 0; // total productivity of active subgens
+    const checkpointGens: Record<
+      string,
+      { active: boolean; nextable: boolean; productivity: number; cost: number }
+    > = {};
+
     this._subgens.forEach((e, g) => {
       cost[g] = 0;
       this._history[g].cost.forEach((e) => {
@@ -338,7 +346,19 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
       if (e.nextable()) {
         totalProductivity += productivity[g];
       }
+
+      checkpointGens[e.name] = {
+        active: !!this._activeSubgens[g],
+        nextable: !!(this._activeSubgens[g] && e.nextable()),
+        productivity: productivity[g],
+        cost: cost[g],
+      };
     }); // foreach: subgen
+
+    this._checkpoints.push({
+      tick: this._tick,
+      gens: checkpointGens,
+    });
 
     // All active subgens have a minimum chance of being selected,
     // which is determined by _P
@@ -424,6 +444,7 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
           initialFocus: this._leaderboard.initialFocus,
           focusDecay: this._leaderboard.focusDecay,
         },
+        checkpoints: this._checkpoints,
       };
     }
   } // fn: onRunEnd

--- a/src/fuzzer/generators/Types.ts
+++ b/src/fuzzer/generators/Types.ts
@@ -2,6 +2,70 @@ import { BaseMeasurement } from "../measures/AbstractMeasure";
 import { InputAndSource } from "../Types";
 
 /**
+ * LLM Cache Modes
+ */
+export type LlmCacheMode =
+  | "passthrough"
+  | "record"
+  | "replay-record"
+  | "replay-error"
+  | "replay-passthrough";
+
+/**
+ * LLM Cache Entry
+ */
+export type LlmCacheEntry = {
+  key: string;
+  request: {
+    provider: string;
+    modelName: string;
+    prompt: string[];
+    schemaJson?: string;
+  };
+  response: LlmQueryResult;
+  delayMs: number;
+  recordedAt: string;
+};
+
+/**
+ * LLM Cache Statistics
+ */
+export type LlmCacheStats = {
+  mode: LlmCacheMode;
+  calls: number;
+  hits: number;
+  misses: number;
+  recorded: number;
+  passedThroughUnrecorded: number;
+  failures: number;
+  live: {
+    calls: number;
+    tokensSent: number;
+    tokensReceived: number;
+    costUsd: number;
+  };
+  replayed: {
+    calls: number;
+    tokensSent: number;
+    tokensReceived: number;
+    costUsd: number;
+  };
+};
+
+/**
+ * LLM Query Result
+ */
+export type LlmQueryResult = {
+  text: string;
+  stats: {
+    tokensSent: number;
+    tokensSentCost: { amt: number; unit: string };
+    tokensReceived: number;
+    tokensReceivedCost: { amt: number; unit: string };
+  };
+};
+
+/**
  * A scored input with its measurements
  */
 export type ScoredInput = {
@@ -40,6 +104,7 @@ export interface InputGeneratorStatsAi extends InputGeneratorStats {
     sentCost?: { amt: number; unit: string };
     receivedCost?: { amt: number; unit: string };
   };
+  cache?: LlmCacheStats;
 }
 
 /**

--- a/src/ui/CommandLine.test.ts
+++ b/src/ui/CommandLine.test.ts
@@ -4,6 +4,10 @@ import * as path from "node:path";
 import * as os from "node:os";
 import JSON5 from "json5";
 import { FuzzTestResults } from "../fuzzer/Fuzzer";
+import * as ProgramFactory from "../fuzzer/analysis/ProgramFactory";
+import { AiInputGenerator } from "../fuzzer/generators/AiInputGenerator";
+import { createCacheKey } from "../fuzzer/adapters/LlmCacheManager";
+import { prompt } from "../fuzzer/adapters/LlmAdapter";
 
 function runCli(args: string[]): ChildProcess.SpawnSyncReturns<string> {
   const cliScript = path.resolve(__dirname, "../../build/cli/cli.cjs");
@@ -206,6 +210,137 @@ describe("cli:", () => {
     expect(cigConfig?.explorationChance).toBe(0.2);
     expect(cigConfig?.initialFocus).toBe(150);
     expect(cigConfig?.focusDecay).toBe(2);
+  });
+
+  it("--ai-cache-*: cache miss in replay-error mode", () => {
+    const outputFile = path.join(tmpDir, "ai_cache_miss_output.json5");
+    const cacheFile = path.join(tmpDir, "cli_llm_cache_miss.json");
+    const targetFile = path.resolve(
+      "src/fuzzer/test_fixtures/Fuzzer.testfixtures.ts"
+    );
+    const targetFn = "testCoverageOneFile";
+
+    const res = runCli([
+      targetFile,
+      targetFn,
+      "--output-file",
+      outputFile,
+      "--model-provider",
+      "gemini",
+      "--model-name",
+      "gemini-flash",
+      "--model-key",
+      "test-key",
+      "--ai-cache-mode",
+      "replay-error",
+      "--ai-cache-file",
+      cacheFile,
+      "--max-tests",
+      "5",
+    ]);
+
+    if (res.status !== 0) {
+      console.error("CLI STDOUT:", res.stdout);
+      console.error("CLI STDERR:", res.stderr);
+    }
+
+    expect(res.status).toBe(0);
+    expect(fs.existsSync(outputFile)).toBeTrue();
+
+    const outputData = JSON5.parse<FuzzTestResults>(
+      fs.readFileSync(outputFile, "utf8")
+    );
+
+    const aiGenStats = outputData.stats.generators.AiInputGenerator?.gen;
+    expect(aiGenStats).toBeDefined();
+    expect(aiGenStats?.cache?.mode).toBe("replay-error");
+    expect(aiGenStats?.cache?.calls).toBeGreaterThanOrEqual(1);
+    expect(aiGenStats?.cache?.misses).toBeGreaterThanOrEqual(1);
+    expect(aiGenStats?.cache?.failures).toBeGreaterThanOrEqual(1);
+    expect(aiGenStats?.calls.failed).toBeGreaterThanOrEqual(1);
+  });
+
+  it("--ai-cache-*: cache hit in replay-error mode", () => {
+    const outputFile = path.join(tmpDir, "ai_cache_hit_output.json5");
+    const cacheFile = path.join(tmpDir, "cli_llm_cache_hit.json");
+    const targetFile = path.resolve(
+      "src/fuzzer/test_fixtures/Fuzzer.testfixtures.ts"
+    );
+    const targetFn = "testCoverageOneFile";
+    const provider = "gemini";
+    const modelName = "gemini-flash";
+
+    // Pre-seed cache entry for testCoverageOneFile
+    const program = ProgramFactory.fromFile(targetFile);
+    const fn = program.functionsExported[targetFn];
+    const aiGen = new AiInputGenerator(fn, "seed", new Map());
+    const [schema, directives] = aiGen["_getInputsSchema"](fn.getLang());
+    const promptText = prompt.genInputs(fn, directives, new Map());
+    const schemaJson = JSON.stringify(schema.toJSONSchema());
+    const key = createCacheKey(provider, modelName, [promptText], schemaJson);
+
+    const seededEntry = {
+      key,
+      request: { provider, modelName, prompt: [promptText], schemaJson },
+      response: {
+        text: JSON.stringify({ programInputs: [{ s: "replay-cached-input" }] }),
+        stats: {
+          tokensSent: 100,
+          tokensSentCost: { amt: 0.001, unit: "USD" },
+          tokensReceived: 50,
+          tokensReceivedCost: { amt: 0.001, unit: "USD" },
+        },
+      },
+      delayMs: 10,
+      recordedAt: new Date().toISOString(),
+    };
+
+    fs.mkdirSync(path.dirname(cacheFile), { recursive: true });
+    fs.writeFileSync(
+      cacheFile,
+      JSON5.stringify([seededEntry], null, 2),
+      "utf8"
+    );
+
+    const res = runCli([
+      targetFile,
+      targetFn,
+      "--output-file",
+      outputFile,
+      "--model-provider",
+      provider,
+      "--model-name",
+      modelName,
+      "--model-key",
+      "test-key",
+      "--ai-cache-mode",
+      "replay-error",
+      "--ai-cache-file",
+      cacheFile,
+      "--max-tests",
+      "5",
+    ]);
+
+    if (res.status !== 0) {
+      console.error("CLI STDOUT:", res.stdout);
+      console.error("CLI STDERR:", res.stderr);
+    }
+
+    expect(res.status).toBe(0);
+    expect(fs.existsSync(outputFile)).toBeTrue();
+
+    const outputData = JSON5.parse<FuzzTestResults>(
+      fs.readFileSync(outputFile, "utf8")
+    );
+
+    const aiGenStats = outputData.stats.generators.AiInputGenerator?.gen;
+
+    expect(aiGenStats).toBeDefined();
+    expect(aiGenStats?.cache?.mode).toBe("replay-error");
+    expect(aiGenStats?.cache?.calls).toBe(1);
+    expect(aiGenStats?.cache?.hits).toBe(1);
+    expect(aiGenStats?.cache?.misses).toBe(0);
+    expect(aiGenStats?.calls.sent).toBe(1);
   });
 });
 

--- a/src/ui/CommandLine.ts
+++ b/src/ui/CommandLine.ts
@@ -7,6 +7,7 @@ import { ArgDef, FuzzBusyStatusMessage, Tester } from "../fuzzer/Fuzzer";
 import * as CompilerFactory from "../fuzzer/compilers/CompilerFactory";
 import path from "node:path";
 import { isError } from "../fuzzer/Util";
+import { LlmAdapter } from "../fuzzer/adapters/LlmAdapter";
 
 /**
  * Command line interface for NaNofuzz.
@@ -95,6 +96,12 @@ Commander.program
   .option(`--model-provider <string>`, `AI model provider`)
   .option(`--model-name <string>`, `AI model name`)
   .option(`--model-key <string>`, `AI model API key`)
+  .option(
+    `--ai-cache-mode <mode>`,
+    `LLM cache mode (passthrough, record, replay-record, replay-error, replay-passthrough)`,
+    parseAiCacheMode
+  )
+  .option(`--ai-cache-file <path>`, `Path to LLM cache file`)
 
   // ------------------------ Composite Input Generator ------------------------ //
 
@@ -213,6 +220,12 @@ for (const key in options) {
     case "modelKey":
       Config.override("nanofuzz.ai.apiKey", value);
       break;
+    case "aiCacheMode":
+      Config.override("nanofuzz.ai.cacheMode", value);
+      break;
+    case "aiCacheFile":
+      Config.override("nanofuzz.ai.cacheFile", value);
+      break;
 
     // composite input generator config options
     case "cigInputLookback":
@@ -283,6 +296,8 @@ async function run(): Promise<void> {
       results.stats.counters.passedTests + results.stats.counters.failedTests;
     const someTestsFailed = results.stats.counters.failedTests;
 
+    await LlmAdapter.flushCache(5000);
+
     if (someTestsRan && !results.stats.counters.erroredTests) {
       if (someTestsFailed) {
         process.exit(ERROR_TEST_FAILURE); // tests ran and some failed
@@ -293,6 +308,7 @@ async function run(): Promise<void> {
       process.exit(ERROR_INTERNAL); // internal error
     }
   } catch (e: unknown) {
+    await LlmAdapter.flushCache(5000);
     if (isError(e)) {
       if (e.stack) {
         console.error(e.stack);
@@ -318,6 +334,22 @@ function parseFloatArgGeZero(value: string, _previous: number): number {
   }
   return parsedValue;
 } // fn: parseFloatArgGeZero
+
+function parseAiCacheMode(value: string, _previous: string): string {
+  const allowed = [
+    "passthrough",
+    "record",
+    "replay-record",
+    "replay-error",
+    "replay-passthrough",
+  ];
+  if (!allowed.includes(value)) {
+    throw new Commander.InvalidArgumentError(
+      `Invalid ai cache mode '${value}'. Allowed: ${allowed.join(", ")}`
+    );
+  }
+  return value;
+} // fn: parseAiCacheMode
 
 function parseFloatArgZeroToOne(value: string, _previous: number): number {
   const parsedValue = parseFloatArgGeZero(value, _previous);


### PR DESCRIPTION
This PR adds the ability to record LLM sessions and replay them later in, e.g., tests.

This functionality is exposed via CLI:
```
  --ai-cache-mode <mode>             LLM cache mode (passthrough, record, replay-record,
                                     replay-error, replay-passthrough)
  --ai-cache-file <path>             Path to LLM cache file
```

Use the `record` mode to record LLM query/responses to the `--ai-cache-file` file. Use the `replay-passthrough` mode to replay previously-seen queries from the file and pass new ones onto the LLM. Use the `replay-record` mode to do the same, except also record the query/responses passed through to the LLM.

Statistics on cache hits and misses, as well as actual tokens used are captured in NaNofuzz' output file.