### PR TITLE
fix: stats accounting in record mode

### DIFF
--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -563,11 +563,16 @@ export class Tester {
         this._measures.forEach((e) => {
           e.onRunEnd(this._results);
         });
-        this._compositeInputGenerator.onRunEnd(this._results); // also handles shutdown for subgens
+        await this._compositeInputGenerator.onRunEnd(this._results); // also handles shutdown for subgens
 
         // Shut down runners
-        await runner.onRunEnd();
-        await propRunners.forEach(async (p) => p.onRunEnd());
+        await Promise.all(
+          [
+            runner.onRunEnd(),
+            transformRunner?.onRunEnd(),
+            ...propRunners.map((p) => p.onRunEnd()),
+          ].filter((e) => e !== undefined)
+        );
 
         update({
           msg: `Testing ${cancelFn && cancelFn() ? "paused" : "finished"}.`,

--- a/src/fuzzer/adapters/LlmAdapter.ts
+++ b/src/fuzzer/adapters/LlmAdapter.ts
@@ -88,10 +88,6 @@ export class LlmAdapter {
     return this._cacheManager.stats;
   }
 
-  public get cacheManager(): LlmCacheManager {
-    return this._cacheManager;
-  }
-
   public static async flushCache(timeoutMs = 5000): Promise<void> {
     await LlmCacheManager.flushAllActive(timeoutMs);
   }

--- a/src/fuzzer/adapters/LlmCacheManager.ts
+++ b/src/fuzzer/adapters/LlmCacheManager.ts
@@ -198,6 +198,16 @@ export class LlmCacheManager {
     this.saveCache();
   }
 
+  public static readonly inFlight = {
+    get length(): number {
+      let len = 0;
+      for (const manager of LlmCacheManager._activeManagers) {
+        len += manager._pendingQueries.size;
+      }
+      return len;
+    },
+  };
+
   public static async flushAllActive(timeoutMs = 5000): Promise<void> {
     for (const manager of LlmCacheManager._activeManagers) {
       await manager.flush(timeoutMs);

--- a/src/fuzzer/generators/AbstractInputGenerator.ts
+++ b/src/fuzzer/generators/AbstractInputGenerator.ts
@@ -1,6 +1,7 @@
 import seedrandom from "seedrandom";
 import { ArgDef } from "../analysis/ArgDef";
 import { InputAndSource } from "./../Types";
+import { FuzzTestResults } from "../Fuzzer";
 import { InputGeneratorStats } from "./Types";
 
 /**
@@ -63,7 +64,7 @@ export abstract class AbstractInputGenerator {
   /**
    * Executes any tasks when the test run ends
    */
-  public onRunEnd(): void {
+  public async onRunEnd(_results?: FuzzTestResults): Promise<void> {
     return;
   } // fn: onRunEnd
 }

--- a/src/fuzzer/generators/AiInputGenerator.ts
+++ b/src/fuzzer/generators/AiInputGenerator.ts
@@ -8,11 +8,17 @@ import {
 import * as JSONN from "../../Jsonn";
 import * as ValueMapper from "../mappers/ValueMapper";
 import { LlmAdapter } from "../adapters/LlmAdapter";
-import { ArgDef, FunctionDef, InputAndSource } from "../Fuzzer";
+import {
+  ArgDef,
+  FunctionDef,
+  FuzzTestResults,
+  InputAndSource,
+} from "../Fuzzer";
 import { ArgDefValidator } from "../analysis/ArgDefValidator";
 import * as zod from "zod";
 import { InputGeneratorStatsAi } from "./Types";
 import { isError } from "../Util";
+import * as Config from "../../Config";
 
 /**
  * Generates new inputs using a large language model
@@ -446,6 +452,23 @@ export class AiInputGenerator extends AbstractInputGenerator {
     }
     return res;
   } // getter: stats
+
+  /**
+   * Cleanup and flush in-flight LLM requests if in a recording cache mode
+   */
+  public override async onRunEnd(results?: FuzzTestResults): Promise<void> {
+    await super.onRunEnd(results);
+    const cacheMode = Config.get<string>(
+      "nanofuzz.ai.cacheMode",
+      "passthrough"
+    );
+    if (cacheMode.includes("record")) {
+      await LlmAdapter.flushCache(5000);
+    }
+    if (results) {
+      results.stats.generators.AiInputGenerator.gen = this.stats;
+    }
+  } // fn: onRunEnd
 } // class: AiInputGenerator
 
 /**

--- a/src/fuzzer/generators/CompositeInputGenerator.test.ts
+++ b/src/fuzzer/generators/CompositeInputGenerator.test.ts
@@ -6,7 +6,7 @@ import { ArgDef } from "../analysis/ArgDef";
 import { FuzzOptions, InputAndSource } from "../Types";
 
 describe("src/fuzzer/generators/CompositeInputGenerator:", () => {
-  it("builds checkpoints during _selectNextSubGen and populates them onRunEnd", () => {
+  it("builds checkpoints during _selectNextSubGen and populates them onRunEnd", async () => {
     const program = ProgramFactory.fromSource(
       () => `export function dummyFn(x: number) {}`,
       "typescript"
@@ -109,7 +109,7 @@ describe("src/fuzzer/generators/CompositeInputGenerator:", () => {
       },
     };
 
-    cig.onRunEnd(mockResults);
+    await cig.onRunEnd(mockResults);
 
     const cigStats = mockResults.stats.generators.CompositeInputGenerator;
     expect(cigStats).toBeDefined();

--- a/src/fuzzer/generators/CompositeInputGenerator.ts
+++ b/src/fuzzer/generators/CompositeInputGenerator.ts
@@ -6,7 +6,6 @@ import { ScoredInput } from "./Types";
 import { FuzzOptions, InputAndSource } from "./../Types";
 import { FunctionDef, FuzzTestResults, FuzzTestStats } from "../Fuzzer";
 import { InputGeneratorFactory } from "./InputGeneratorFactory";
-import { AiInputGenerator } from "./AiInputGenerator";
 
 /**
  * The Composite Input Generator subsumes multiple types of input generator and biases
@@ -424,17 +423,9 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
   /**
    * Cleanup all subgens and update stats when the test run ends
    */
-  public onRunEnd(results?: FuzzTestResults): void {
-    super.onRunEnd();
-    this._subgens.forEach((subgen) => {
-      subgen.onRunEnd();
-      if (
-        subgen.name === "AiInputGenerator" &&
-        subgen instanceof AiInputGenerator
-      ) {
-        this._genStats["AiInputGenerator"].gen = subgen.stats;
-      }
-    });
+  public async onRunEnd(results?: FuzzTestResults): Promise<void> {
+    await super.onRunEnd(results);
+    await Promise.all(this._subgens.map((g) => g.onRunEnd(results)));
     if (results) {
       results.stats.generators.CompositeInputGenerator = {
         config: {

--- a/src/fuzzer/generators/RandomInputGenerator.ts
+++ b/src/fuzzer/generators/RandomInputGenerator.ts
@@ -39,7 +39,7 @@ export class RandomInputGenerator extends AbstractInputGenerator {
    * Don't re-use generators across runs because the ranges may
    * have changed.
    */
-  public onRunEnd(): void {
+  public override async onRunEnd(): Promise<void> {
     this._gen = undefined;
   } // fn: onRunEnd
 } // class: RandomInputGenerator

--- a/src/ui/CommandLine.ts
+++ b/src/ui/CommandLine.ts
@@ -296,8 +296,6 @@ async function run(): Promise<void> {
       results.stats.counters.passedTests + results.stats.counters.failedTests;
     const someTestsFailed = results.stats.counters.failedTests;
 
-    await LlmAdapter.flushCache(5000);
-
     if (someTestsRan && !results.stats.counters.erroredTests) {
       if (someTestsFailed) {
         process.exit(ERROR_TEST_FAILURE); // tests ran and some failed


### PR DESCRIPTION
This PR makes the output file stats consistent when running in an ai cache recording mode via CLI.