### PR TITLE
fix: skipped input counters

### DIFF
--- a/src/fuzzer/Fuzzer.test.ts
+++ b/src/fuzzer/Fuzzer.test.ts
@@ -757,6 +757,7 @@ describe("fuzzer:", () => {
     expect(skips.length).toBeGreaterThan(0);
     skips.forEach((r) => {
       expect(r.skipped).toBeTrue();
+      expect(r.passedImplicit).toBe("unknown");
       expect(r.skipReason).toContain("n cannot be 5");
     });
   });

--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -934,60 +934,62 @@ export class Tester {
         }
 
         const startValTime = performance.now(); // start timer
-        // IMPLICIT ORACLE --------------------------------------------
-        if (this._options.useImplicit) {
-          result.passedImplicit = ImplicitOracle.judge(
-            result.timeout,
-            result.exception,
-            this._function.isVoid(),
-            result.output
-          );
+        if (!result.skipped) {
+          // IMPLICIT ORACLE --------------------------------------------
+          if (this._options.useImplicit) {
+            result.passedImplicit = ImplicitOracle.judge(
+              result.timeout,
+              result.exception,
+              this._function.isVoid(),
+              result.output
+            );
+          }
+
+          // EXAMPLE ORACLE ---------------------------------------------
+          // If a human annotated an expected output, then check it
+          if (this._options.useHuman && result.expectedOutput) {
+            result.passedHuman = ExampleOracle.judge(
+              result.timeout,
+              result.exception,
+              result.expectedOutput,
+              result.output
+            );
+          }
+
+          // PROPERTY ORACLE --------------------------------------------
+          // If a property validator is selected, call it to evaluate the result
+          if (this._options.useProperty) {
+            (
+              await propertyOracle.judge(
+                Object.freeze({
+                  in: result.input.map((i) => i.value), // inputs
+                  out:
+                    result.output.length === 0
+                      ? "timeout or exception"
+                      : result.output[0].value,
+                  exception: result.exception,
+                  timeout: result.timeout,
+                }),
+                Math.max(this._options.fnTimeout, 1)
+              )
+            ).forEach((j, i) => {
+              if (isError(j)) {
+                result.passedValidators.push("unknown");
+                result.validatorException = true;
+                result.validatorExceptionMessage = j.message;
+                result.validatorExceptionFunction = this._validators[i].name;
+                result.validatorExceptionStack = j.stack;
+              } else {
+                result.passedValidators.push(j);
+              }
+            });
+
+            // Summarize propert judgments.
+            result.passedValidator = PropertyOracle.summarize(
+              result.passedValidators
+            );
+          } // if validator
         }
-
-        // EXAMPLE ORACLE ---------------------------------------------
-        // If a human annotated an expected output, then check it
-        if (this._options.useHuman && result.expectedOutput) {
-          result.passedHuman = ExampleOracle.judge(
-            result.timeout,
-            result.exception,
-            result.expectedOutput,
-            result.output
-          );
-        }
-
-        // PROPERTY ORACLE --------------------------------------------
-        // If a property validator is selected, call it to evaluate the result
-        if (this._options.useProperty) {
-          (
-            await propertyOracle.judge(
-              Object.freeze({
-                in: result.input.map((i) => i.value), // inputs
-                out:
-                  result.output.length === 0
-                    ? "timeout or exception"
-                    : result.output[0].value,
-                exception: result.exception,
-                timeout: result.timeout,
-              }),
-              Math.max(this._options.fnTimeout, 1)
-            )
-          ).forEach((j, i) => {
-            if (isError(j)) {
-              result.passedValidators.push("unknown");
-              result.validatorException = true;
-              result.validatorExceptionMessage = j.message;
-              result.validatorExceptionFunction = this._validators[i].name;
-              result.validatorExceptionStack = j.stack;
-            } else {
-              result.passedValidators.push(j);
-            }
-          });
-
-          // Summarize propert judgments.
-          result.passedValidator = PropertyOracle.summarize(
-            result.passedValidators
-          );
-        } // if validator
 
         // Validator stats
         const valTime = performance.now() - startValTime; // stop timer

--- a/src/ui/CommandLine.test.ts
+++ b/src/ui/CommandLine.test.ts
@@ -372,6 +372,40 @@ describe("cli:", () => {
     expect(outputData.results.length).toBe(maxFailures);
     expect(outputData.stats.counters.failedTests).toBe(maxFailures);
   });
+
+  it("--max-failures: stop fuzzing python put after 1 failure", () => {
+    const pyFile = path.join(
+      tmpDir,
+      `pbt_test_${Math.random().toString(36).substring(2, 9)}.py`
+    );
+    const targetFn = "test_range_max_exclusive_rejects_boundary";
+    fs.writeFileSync(
+      pyFile,
+      `
+def ${targetFn}(n: int) -> int:
+    raise Exception("boundary error")
+`,
+      "utf8"
+    );
+
+    try {
+      const res = runCli([
+        pyFile,
+        targetFn,
+        "--max-runtime",
+        "300000",
+        "--max-failures",
+        "1",
+      ]);
+
+      expect(res.status).toBe(1);
+      expect(res.stdout).toContain("Stopped for reason: maxFailures.");
+    } finally {
+      if (fs.existsSync(pyFile)) {
+        fs.rmSync(pyFile, { force: true });
+      }
+    }
+  });
 });
 
 function getFnNameAndModule(fnObj: unknown): {


### PR DESCRIPTION
Fixes a problem where inputs abandoned during PUT execution (e.g., via assume) were still validated, which caused incorrect counters, particularly for the heuristic validator.