### PR TITLE
fix: cig chunk size off-by-one

### DIFF
--- a/src/fuzzer/generators/CompositeInputGenerator.test.ts
+++ b/src/fuzzer/generators/CompositeInputGenerator.test.ts
@@ -129,4 +129,115 @@ describe("src/fuzzer/generators/CompositeInputGenerator:", () => {
       "number"
     );
   });
+
+  it("rotates subgens after chunkSize generated inputs", async () => {
+    const program = ProgramFactory.fromSource(
+      () => `export function dummyFn(x: number) {}`,
+      "typescript"
+    );
+    const fnDef = program.functionsExported["dummyFn"];
+
+    const genStats: FuzzTestStats["generators"] = {
+      RandomInputGenerator: {
+        counters: { inputsGenerated: 0, dupesGenerated: 0 },
+        timers: { run: 0, val: 0, gen: 0, measure: 0, transform: 0 },
+      },
+      MutationInputGenerator: {
+        counters: { inputsGenerated: 0, dupesGenerated: 0 },
+        timers: { run: 0, val: 0, gen: 0, measure: 0, transform: 0 },
+      },
+      AiInputGenerator: {
+        counters: { inputsGenerated: 0, dupesGenerated: 0 },
+        timers: { run: 0, val: 0, gen: 0, measure: 0, transform: 0 },
+      },
+    };
+
+    const options = {
+      RandomInputGenerator: { enabled: true },
+      MutationInputGenerator: { enabled: false },
+      AiInputGenerator: { enabled: false },
+    };
+
+    const leaderboard = new Leaderboard<InputAndSource>();
+    const allInputs = new Map<string, unknown>();
+
+    const cig = new CompositeInputGenerator(
+      options,
+      fnDef,
+      "test-seed",
+      [],
+      leaderboard,
+      genStats,
+      allInputs
+    );
+
+    cig.onRunStart(true);
+
+    const chunkSize = 20;
+    for (let i = 0; i < chunkSize * 2; i++) {
+      cig.next();
+    }
+
+    const mockFuzzOptions: FuzzOptions = {
+      argDefaults: ArgDef.getDefaultOptions(),
+      measures: {
+        FailedTestMeasure: { enabled: true, weight: 1 },
+        CoverageMeasure: { enabled: false, weight: 0 },
+      },
+      generators: options,
+      maxTests: 100,
+      fnTimeout: 1000,
+      suiteTimeout: 10000,
+      seed: "test-seed",
+      maxDupeInputs: 100,
+      maxFailures: 0,
+      useImplicit: true,
+      useHuman: false,
+      useProperty: true,
+      useTransformer: false,
+    };
+
+    const mockResults: FuzzTestResults = {
+      toolVersion: "test",
+      env: {
+        options: mockFuzzOptions,
+        function: fnDef,
+        validators: [],
+        transformers: [],
+      },
+      results: [],
+      interesting: { inputs: [] },
+      stopReason: FuzzStopReason.MAXTESTS,
+      stats: {
+        timers: {
+          total: 0,
+          compile: 0,
+          put: 0,
+          val: 0,
+          gen: 0,
+          transform: 0,
+          measure: 0,
+        },
+        counters: {
+          testingRuns: 1,
+          inputsGenerated: chunkSize * 2,
+          dupesGenerated: 0,
+          inputsInjected: 0,
+          erroredTests: 0,
+          passedTests: chunkSize * 2,
+          inputsSkipped: 0,
+          failedTests: 0,
+        },
+        generators: genStats,
+        measures: {},
+      },
+    };
+
+    await cig.onRunEnd(mockResults);
+
+    const cigStats = mockResults.stats.generators.CompositeInputGenerator;
+    expect(cigStats?.checkpoints.length).toBe(2);
+    expect(cigStats?.checkpoints[0].tick).toBe(1);
+    expect(cigStats?.checkpoints[1].tick).toBe(chunkSize + 1);
+  });
 });

--- a/src/fuzzer/generators/CompositeInputGenerator.ts
+++ b/src/fuzzer/generators/CompositeInputGenerator.ts
@@ -27,27 +27,27 @@ import { InputGeneratorFactory } from "./InputGeneratorFactory";
  * false when the injected inputs are exhausted.
  */
 export class CompositeInputGenerator extends AbstractInputGenerator {
-  private _subgens; // Subordinate input generators
-  private _activeSubgens: boolean[] = []; // boolean array of whether subgen is active
-  private _tick = 0; // Number of inputs generated
-  private _ticksLeftInChunk = 0; // Number of input generations remaining in this chunk
-  private _measures: AbstractMeasure[]; // Measures that provide feedback
-  private _history: {
+  protected _subgens; // Subordinate input generators
+  protected _activeSubgens: boolean[] = []; // boolean array of whether subgen is active
+  protected _tick = 0; // Number of inputs generated
+  protected _ticksLeftInChunk = 0; // Number of input generations remaining in this chunk
+  protected _measures: AbstractMeasure[]; // Measures that provide feedback
+  protected _history: {
     progress: (number | undefined)[][]; // progress by measure and input tick (of L)
     cost: (number | undefined)[]; // cost by input tick (of L)
     currentIndex: number; // current index (of L) into last dimension of progress and cost
   }[] = []; // history for each input generator
-  private _scoredInputs: ScoredInput[] = []; // List of scored inputs
-  private _injectedInputs: Omit<InputAndSource, "tick">[] = []; // Inputs to force generate first
-  private _selectedSubgenIndex = -1; // Selected subordinate input generator (e.g., by efficiency)
-  private _leaderboard; // Interesting inputs
-  private _lastInput?: InputAndSource; // Last input generated
-  private _L = 500; // Lookback window size for history
-  private _chunkSize = 20; // Re-evaluate subgen after _chunkSize inputs generated
-  private _P = 0.1; // Additional chance of subgen exploration
-  private _permitSubgens = true; // Allow generators to produce inputs
-  private _genStats: FuzzTestStats["generators"]; // Generator statistics
-  private _checkpoints: NonNullable<
+  protected _scoredInputs: ScoredInput[] = []; // List of scored inputs
+  protected _injectedInputs: Omit<InputAndSource, "tick">[] = []; // Inputs to force generate first
+  protected _selectedSubgenIndex = -1; // Selected subordinate input generator (e.g., by efficiency)
+  protected _leaderboard; // Interesting inputs
+  protected _lastInput?: InputAndSource; // Last input generated
+  protected _L = 500; // Lookback window size for history
+  protected _chunkSize = 20; // Re-evaluate subgen after _chunkSize inputs generated
+  protected _P = 0.1; // Additional chance of subgen exploration
+  protected _permitSubgens = true; // Allow generators to produce inputs
+  protected _genStats: FuzzTestStats["generators"]; // Generator statistics
+  protected _checkpoints: NonNullable<
     FuzzTestStats["generators"]["CompositeInputGenerator"]
   >["checkpoints"] = []; // status of subgens at selection
   public static readonly INJECTED = "injected";
@@ -96,7 +96,7 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
    * If the lookback window size changes, the measure history is reset with
    * the new window size.
    */
-  private _loadConfig(): void {
+  protected _loadConfig(): void {
     const L = Config.get<number>(
       "nanofuzz.generators.compositeLookbackWindow",
       500
@@ -201,7 +201,7 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
     // subgen is no longer available, start a new chunk and choose
     // the subgen for that chunk
     if (
-      this._ticksLeftInChunk-- < 1 ||
+      this._ticksLeftInChunk-- <= 1 ||
       !this._subgens[this._selectedSubgenIndex].nextable() ||
       !this._activeSubgens[this._selectedSubgenIndex]
     ) {
@@ -312,7 +312,7 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
    *
    * @returns the index of the selected subgen
    */
-  private _selectNextSubGen(): number {
+  protected _selectNextSubGen(): number {
     // At least one subgen needs to be available
     if (!this._subgens.some((g) => g.nextable())) {
       throw new Error(


### PR DESCRIPTION
The chunk size calculation was generating chunks that were actually chunk size +1. This PR corrects that issue so that chunks are actually chunk-sized.