### PR TITLE
feat: cig checkpoint stats option

### DIFF
--- a/src/fuzzer/generators/CompositeInputGenerator.test.ts
+++ b/src/fuzzer/generators/CompositeInputGenerator.test.ts
@@ -4,9 +4,10 @@ import { FuzzStopReason, FuzzTestResults, FuzzTestStats } from "../Fuzzer";
 import * as ProgramFactory from "../analysis/ProgramFactory";
 import { ArgDef } from "../analysis/ArgDef";
 import { FuzzOptions, InputAndSource } from "../Types";
+import * as Config from "../../Config";
 
 describe("src/fuzzer/generators/CompositeInputGenerator:", () => {
-  it("builds checkpoints during _selectNextSubGen and populates them onRunEnd", async () => {
+  it("checkpoint stats not tracked by default", async () => {
     const program = ProgramFactory.fromSource(
       () => `export function dummyFn(x: number) {}`,
       "typescript"
@@ -48,11 +49,7 @@ describe("src/fuzzer/generators/CompositeInputGenerator:", () => {
     );
 
     cig.onRunStart(true);
-
-    // Generating inputs triggers _selectNextSubGen
-    expect(cig.nextable()).toBeTrue();
-    const input1 = cig.next();
-    expect(input1).toBeDefined();
+    cig.next();
 
     const mockFuzzOptions: FuzzOptions = {
       argDefaults: ArgDef.getDefaultOptions(),
@@ -113,131 +110,251 @@ describe("src/fuzzer/generators/CompositeInputGenerator:", () => {
 
     const cigStats = mockResults.stats.generators.CompositeInputGenerator;
     expect(cigStats).toBeDefined();
-    expect(cigStats?.checkpoints).toBeDefined();
-    expect(cigStats?.checkpoints.length).toBeGreaterThan(0);
+    expect(cigStats?.checkpoints).toEqual([]);
+  });
 
-    const firstCheckpoint = cigStats?.checkpoints[0];
-    expect(firstCheckpoint?.tick).toBeDefined();
-    expect(firstCheckpoint?.gens.RandomInputGenerator).toBeDefined();
-    expect(typeof firstCheckpoint?.gens.RandomInputGenerator.nextable).toBe(
-      "boolean"
-    );
-    expect(typeof firstCheckpoint?.gens.RandomInputGenerator.productivity).toBe(
-      "number"
-    );
-    expect(typeof firstCheckpoint?.gens.RandomInputGenerator.cost).toBe(
-      "number"
-    );
+  it("checkpoint stats tracked if enabled", async () => {
+    Config.override("nanofuzz.generators.compositeTrackCheckpoints", true);
+    try {
+      const program = ProgramFactory.fromSource(
+        () => `export function dummyFn(x: number) {}`,
+        "typescript"
+      );
+      const fnDef = program.functionsExported["dummyFn"];
+
+      const genStats: FuzzTestStats["generators"] = {
+        RandomInputGenerator: {
+          counters: { inputsGenerated: 0, dupesGenerated: 0 },
+          timers: { run: 0, val: 0, gen: 0, measure: 0, transform: 0 },
+        },
+        MutationInputGenerator: {
+          counters: { inputsGenerated: 0, dupesGenerated: 0 },
+          timers: { run: 0, val: 0, gen: 0, measure: 0, transform: 0 },
+        },
+        AiInputGenerator: {
+          counters: { inputsGenerated: 0, dupesGenerated: 0 },
+          timers: { run: 0, val: 0, gen: 0, measure: 0, transform: 0 },
+        },
+      };
+
+      const options = {
+        RandomInputGenerator: { enabled: true },
+        MutationInputGenerator: { enabled: false },
+        AiInputGenerator: { enabled: false },
+      };
+
+      const leaderboard = new Leaderboard<InputAndSource>();
+      const allInputs = new Map<string, unknown>();
+
+      const cig = new CompositeInputGenerator(
+        options,
+        fnDef,
+        "test-seed",
+        [],
+        leaderboard,
+        genStats,
+        allInputs
+      );
+
+      cig.onRunStart(true);
+
+      // Generating inputs triggers _selectNextSubGen
+      expect(cig.nextable()).toBeTrue();
+      const input1 = cig.next();
+      expect(input1).toBeDefined();
+
+      const mockFuzzOptions: FuzzOptions = {
+        argDefaults: ArgDef.getDefaultOptions(),
+        measures: {
+          FailedTestMeasure: { enabled: true, weight: 1 },
+          CoverageMeasure: { enabled: false, weight: 0 },
+        },
+        generators: options,
+        maxTests: 100,
+        fnTimeout: 1000,
+        suiteTimeout: 10000,
+        seed: "test-seed",
+        maxDupeInputs: 100,
+        maxFailures: 0,
+        useImplicit: true,
+        useHuman: false,
+        useProperty: true,
+        useTransformer: false,
+      };
+
+      const mockResults: FuzzTestResults = {
+        toolVersion: "test",
+        env: {
+          options: mockFuzzOptions,
+          function: fnDef,
+          validators: [],
+          transformers: [],
+        },
+        results: [],
+        interesting: { inputs: [] },
+        stopReason: FuzzStopReason.MAXTESTS,
+        stats: {
+          timers: {
+            total: 0,
+            compile: 0,
+            put: 0,
+            val: 0,
+            gen: 0,
+            transform: 0,
+            measure: 0,
+          },
+          counters: {
+            testingRuns: 1,
+            inputsGenerated: 1,
+            dupesGenerated: 0,
+            inputsInjected: 0,
+            erroredTests: 0,
+            passedTests: 1,
+            inputsSkipped: 0,
+            failedTests: 0,
+          },
+          generators: genStats,
+          measures: {},
+        },
+      };
+
+      await cig.onRunEnd(mockResults);
+
+      const cigStats = mockResults.stats.generators.CompositeInputGenerator;
+      expect(cigStats).toBeDefined();
+      expect(cigStats?.checkpoints).toBeDefined();
+      expect(cigStats?.checkpoints.length).toBeGreaterThan(0);
+
+      const firstCheckpoint = cigStats?.checkpoints[0];
+      expect(firstCheckpoint?.tick).toBeDefined();
+      expect(firstCheckpoint?.gens.RandomInputGenerator).toBeDefined();
+      expect(typeof firstCheckpoint?.gens.RandomInputGenerator.nextable).toBe(
+        "boolean"
+      );
+      expect(
+        typeof firstCheckpoint?.gens.RandomInputGenerator.productivity
+      ).toBe("number");
+      expect(typeof firstCheckpoint?.gens.RandomInputGenerator.cost).toBe(
+        "number"
+      );
+    } finally {
+      Config.override("nanofuzz.generators.compositeTrackCheckpoints", false);
+    }
   });
 
   it("rotates subgens after chunkSize generated inputs", async () => {
-    const program = ProgramFactory.fromSource(
-      () => `export function dummyFn(x: number) {}`,
-      "typescript"
-    );
-    const fnDef = program.functionsExported["dummyFn"];
+    Config.override("nanofuzz.generators.compositeTrackCheckpoints", true);
+    try {
+      const program = ProgramFactory.fromSource(
+        () => `export function dummyFn(x: number) {}`,
+        "typescript"
+      );
+      const fnDef = program.functionsExported["dummyFn"];
 
-    const genStats: FuzzTestStats["generators"] = {
-      RandomInputGenerator: {
-        counters: { inputsGenerated: 0, dupesGenerated: 0 },
-        timers: { run: 0, val: 0, gen: 0, measure: 0, transform: 0 },
-      },
-      MutationInputGenerator: {
-        counters: { inputsGenerated: 0, dupesGenerated: 0 },
-        timers: { run: 0, val: 0, gen: 0, measure: 0, transform: 0 },
-      },
-      AiInputGenerator: {
-        counters: { inputsGenerated: 0, dupesGenerated: 0 },
-        timers: { run: 0, val: 0, gen: 0, measure: 0, transform: 0 },
-      },
-    };
+      const genStats: FuzzTestStats["generators"] = {
+        RandomInputGenerator: {
+          counters: { inputsGenerated: 0, dupesGenerated: 0 },
+          timers: { run: 0, val: 0, gen: 0, measure: 0, transform: 0 },
+        },
+        MutationInputGenerator: {
+          counters: { inputsGenerated: 0, dupesGenerated: 0 },
+          timers: { run: 0, val: 0, gen: 0, measure: 0, transform: 0 },
+        },
+        AiInputGenerator: {
+          counters: { inputsGenerated: 0, dupesGenerated: 0 },
+          timers: { run: 0, val: 0, gen: 0, measure: 0, transform: 0 },
+        },
+      };
 
-    const options = {
-      RandomInputGenerator: { enabled: true },
-      MutationInputGenerator: { enabled: false },
-      AiInputGenerator: { enabled: false },
-    };
+      const options = {
+        RandomInputGenerator: { enabled: true },
+        MutationInputGenerator: { enabled: false },
+        AiInputGenerator: { enabled: false },
+      };
 
-    const leaderboard = new Leaderboard<InputAndSource>();
-    const allInputs = new Map<string, unknown>();
+      const leaderboard = new Leaderboard<InputAndSource>();
+      const allInputs = new Map<string, unknown>();
 
-    const cig = new CompositeInputGenerator(
-      options,
-      fnDef,
-      "test-seed",
-      [],
-      leaderboard,
-      genStats,
-      allInputs
-    );
+      const cig = new CompositeInputGenerator(
+        options,
+        fnDef,
+        "test-seed",
+        [],
+        leaderboard,
+        genStats,
+        allInputs
+      );
 
-    cig.onRunStart(true);
+      cig.onRunStart(true);
 
-    const chunkSize = 20;
-    for (let i = 0; i < chunkSize * 2; i++) {
-      cig.next();
+      const chunkSize = 20;
+      for (let i = 0; i < chunkSize * 2; i++) {
+        cig.next();
+      }
+
+      const mockFuzzOptions: FuzzOptions = {
+        argDefaults: ArgDef.getDefaultOptions(),
+        measures: {
+          FailedTestMeasure: { enabled: true, weight: 1 },
+          CoverageMeasure: { enabled: false, weight: 0 },
+        },
+        generators: options,
+        maxTests: 100,
+        fnTimeout: 1000,
+        suiteTimeout: 10000,
+        seed: "test-seed",
+        maxDupeInputs: 100,
+        maxFailures: 0,
+        useImplicit: true,
+        useHuman: false,
+        useProperty: true,
+        useTransformer: false,
+      };
+
+      const mockResults: FuzzTestResults = {
+        toolVersion: "test",
+        env: {
+          options: mockFuzzOptions,
+          function: fnDef,
+          validators: [],
+          transformers: [],
+        },
+        results: [],
+        interesting: { inputs: [] },
+        stopReason: FuzzStopReason.MAXTESTS,
+        stats: {
+          timers: {
+            total: 0,
+            compile: 0,
+            put: 0,
+            val: 0,
+            gen: 0,
+            transform: 0,
+            measure: 0,
+          },
+          counters: {
+            testingRuns: 1,
+            inputsGenerated: chunkSize * 2,
+            dupesGenerated: 0,
+            inputsInjected: 0,
+            erroredTests: 0,
+            passedTests: chunkSize * 2,
+            inputsSkipped: 0,
+            failedTests: 0,
+          },
+          generators: genStats,
+          measures: {},
+        },
+      };
+
+      await cig.onRunEnd(mockResults);
+
+      const cigStats = mockResults.stats.generators.CompositeInputGenerator;
+      expect(cigStats?.checkpoints.length).toBe(2);
+      expect(cigStats?.checkpoints[0].tick).toBe(1);
+      expect(cigStats?.checkpoints[1].tick).toBe(chunkSize + 1);
+    } finally {
+      Config.override("nanofuzz.generators.compositeTrackCheckpoints", false);
     }
-
-    const mockFuzzOptions: FuzzOptions = {
-      argDefaults: ArgDef.getDefaultOptions(),
-      measures: {
-        FailedTestMeasure: { enabled: true, weight: 1 },
-        CoverageMeasure: { enabled: false, weight: 0 },
-      },
-      generators: options,
-      maxTests: 100,
-      fnTimeout: 1000,
-      suiteTimeout: 10000,
-      seed: "test-seed",
-      maxDupeInputs: 100,
-      maxFailures: 0,
-      useImplicit: true,
-      useHuman: false,
-      useProperty: true,
-      useTransformer: false,
-    };
-
-    const mockResults: FuzzTestResults = {
-      toolVersion: "test",
-      env: {
-        options: mockFuzzOptions,
-        function: fnDef,
-        validators: [],
-        transformers: [],
-      },
-      results: [],
-      interesting: { inputs: [] },
-      stopReason: FuzzStopReason.MAXTESTS,
-      stats: {
-        timers: {
-          total: 0,
-          compile: 0,
-          put: 0,
-          val: 0,
-          gen: 0,
-          transform: 0,
-          measure: 0,
-        },
-        counters: {
-          testingRuns: 1,
-          inputsGenerated: chunkSize * 2,
-          dupesGenerated: 0,
-          inputsInjected: 0,
-          erroredTests: 0,
-          passedTests: chunkSize * 2,
-          inputsSkipped: 0,
-          failedTests: 0,
-        },
-        generators: genStats,
-        measures: {},
-      },
-    };
-
-    await cig.onRunEnd(mockResults);
-
-    const cigStats = mockResults.stats.generators.CompositeInputGenerator;
-    expect(cigStats?.checkpoints.length).toBe(2);
-    expect(cigStats?.checkpoints[0].tick).toBe(1);
-    expect(cigStats?.checkpoints[1].tick).toBe(chunkSize + 1);
   });
 });

--- a/src/fuzzer/generators/CompositeInputGenerator.ts
+++ b/src/fuzzer/generators/CompositeInputGenerator.ts
@@ -47,6 +47,7 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
   protected _P = 0.1; // Additional chance of subgen exploration
   protected _permitSubgens = true; // Allow generators to produce inputs
   protected _genStats: FuzzTestStats["generators"]; // Generator statistics
+  protected _trackCheckpoints = false; // Track checkpoints for statistics
   protected _checkpoints: NonNullable<
     FuzzTestStats["generators"]["CompositeInputGenerator"]
   >["checkpoints"] = []; // status of subgens at selection
@@ -108,6 +109,10 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
     this._P = Config.get<number>(
       "nanofuzz.generators.compositeExplorationChance",
       0.1
+    );
+    this._trackCheckpoints = Config.get<boolean>(
+      "nanofuzz.generators.compositeTrackCheckpoints",
+      false
     );
 
     if (L !== this._L || !this._history.length) {
@@ -346,18 +351,22 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
         totalProductivity += productivity[g];
       }
 
-      checkpointGens[e.name] = {
-        active: !!this._activeSubgens[g],
-        nextable: !!(this._activeSubgens[g] && e.nextable()),
-        productivity: productivity[g],
-        cost: cost[g],
-      };
+      if (this._trackCheckpoints) {
+        checkpointGens[e.name] = {
+          active: !!this._activeSubgens[g],
+          nextable: !!(this._activeSubgens[g] && e.nextable()),
+          productivity: productivity[g],
+          cost: cost[g],
+        };
+      }
     }); // foreach: subgen
 
-    this._checkpoints.push({
-      tick: this._tick,
-      gens: checkpointGens,
-    });
+    if (this._trackCheckpoints) {
+      this._checkpoints.push({
+        tick: this._tick,
+        gens: checkpointGens,
+      });
+    }
 
     // All active subgens have a minimum chance of being selected,
     // which is determined by _P

--- a/src/ui/CommandLine.test.ts
+++ b/src/ui/CommandLine.test.ts
@@ -202,14 +202,41 @@ describe("cli:", () => {
     expect(outputData.results.length).toBeGreaterThan(0);
 
     // Verify composite generator config recorded in output stats
-    const cigConfig =
-      outputData.stats.generators.CompositeInputGenerator?.config;
-    expect(cigConfig).toBeDefined();
-    expect(cigConfig?.lookbackWindow).toBe(300);
-    expect(cigConfig?.chunkSize).toBe(10);
-    expect(cigConfig?.explorationChance).toBe(0.2);
-    expect(cigConfig?.initialFocus).toBe(150);
-    expect(cigConfig?.focusDecay).toBe(2);
+    const cigStats = outputData.stats.generators.CompositeInputGenerator;
+    expect(cigStats?.config).toBeDefined();
+    expect(cigStats?.config?.lookbackWindow).toBe(300);
+    expect(cigStats?.config?.chunkSize).toBe(10);
+    expect(cigStats?.config?.explorationChance).toBe(0.2);
+    expect(cigStats?.config?.initialFocus).toBe(150);
+    expect(cigStats?.config?.focusDecay).toBe(2);
+    expect(cigStats?.checkpoints).toEqual([]);
+  });
+
+  it("--cig-stats-checkpoints flag enables checkpoints tracking in output stats", () => {
+    const outputFile = path.join(tmpDir, "cig_checkpoints_output.json5");
+    const targetFile = "src/fuzzer/test_fixtures/Fuzzer.testfixtures.ts";
+    const targetFn = "testCoverageOneFile";
+
+    const res = runCli([
+      targetFile,
+      targetFn,
+      "--output-file",
+      outputFile,
+      "--cig-stats-checkpoints",
+      "--max-tests",
+      "10",
+    ]);
+
+    expect(res.status).toBe(0);
+    expect(fs.existsSync(outputFile)).toBeTrue();
+
+    const outputData = JSON5.parse<FuzzTestResults>(
+      fs.readFileSync(outputFile, "utf8")
+    );
+
+    const cigStats = outputData.stats.generators.CompositeInputGenerator;
+    expect(cigStats?.checkpoints).toBeDefined();
+    expect(cigStats?.checkpoints?.length).toBeGreaterThan(0);
   });
 
   it("--ai-cache-*: cache miss in replay-error mode", () => {

--- a/src/ui/CommandLine.ts
+++ b/src/ui/CommandLine.ts
@@ -138,6 +138,10 @@ Commander.program
     parseIntArgGeZero,
     1
   )
+  .option(
+    `--cig-stats-checkpoints`,
+    `Track composite generator subgen selection statistics`
+  )
 
   // ------------------------------ System Cleanup ----------------------------- //
 
@@ -263,6 +267,9 @@ for (const key in options) {
       break;
     case "cigInputFocusDecay":
       Config.override("nanofuzz.generators.leaderboardFocusDecay", value);
+      break;
+    case "cigStatsCheckpoints":
+      Config.override("nanofuzz.generators.compositeTrackCheckpoints", value);
       break;
   }
 }


### PR DESCRIPTION
This PR adds a point of control so that composite input generator checkpoint stats may be turned on using the `--cig-stats-checkpoints` cli option, or via the VSCode extension settings. By default checkpoints are not tracked.