### PR TITLE
feat: ingest uuids strategy

### DIFF
--- a/src/fuzzer/analysis/python/PythonProgram.test.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.test.ts
@@ -907,6 +907,57 @@ def test_regex(inline, referenced, partial, anchored):
     expect(fn.getArgDefs()[1].getOptions().strCharset).toEqual("super");
   });
 
+  it("maps Hypothesisuuids strategy to string regex and length options", () => {
+    const fn = ProgramFactory.fromSource(
+      () => `
+@given(
+    id1=st.uuids(),
+    id2=st.uuids(version=4),
+    id3=st.uuids(allow_nil=True),
+    id4=st.uuids(version=5, allow_nil=True)
+)
+def test_uuid(id1, id2, id3, id4):
+    pass
+      `,
+      "python"
+    ).functionsExported["test_uuid"];
+
+    const args = fn.getArgDefs();
+    expect(args.length).toEqual(4);
+
+    expect(args[0].getName()).toEqual("id1");
+    expect(args[0].getType()).toEqual(ArgTag.STRING);
+    expect(args[0].getOptions().strLength).toEqual({ min: 36, max: 36 });
+    expect(args[0].getOptions().strCharset).toEqual("0123456789abcdefABCDEF-");
+    expect(args[0].getOptions().strRegex).toEqual(
+      "\\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\\Z"
+    );
+
+    expect(args[1].getName()).toEqual("id2");
+    expect(args[1].getType()).toEqual(ArgTag.STRING);
+    expect(args[1].getOptions().strLength).toEqual({ min: 36, max: 36 });
+    expect(args[1].getOptions().strCharset).toEqual("0123456789abcdefABCDEF-");
+    expect(args[1].getOptions().strRegex).toEqual(
+      "\\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\\Z"
+    );
+
+    expect(args[2].getName()).toEqual("id3");
+    expect(args[2].getType()).toEqual(ArgTag.STRING);
+    expect(args[2].getOptions().strLength).toEqual({ min: 36, max: 36 });
+    expect(args[2].getOptions().strCharset).toEqual("0123456789abcdefABCDEF-");
+    expect(args[2].getOptions().strRegex).toEqual(
+      "\\A(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)\\Z"
+    );
+
+    expect(args[3].getName()).toEqual("id4");
+    expect(args[3].getType()).toEqual(ArgTag.STRING);
+    expect(args[3].getOptions().strLength).toEqual({ min: 36, max: 36 });
+    expect(args[3].getOptions().strCharset).toEqual("0123456789abcdefABCDEF-");
+    expect(args[3].getOptions().strRegex).toEqual(
+      "\\A(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-5[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)\\Z"
+    );
+  });
+
   it("hypothesis @given positional arguments", () => {
     const fn = ProgramFactory.fromSource(
       () => `

--- a/src/fuzzer/analysis/python/PythonProgram.test.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.test.ts
@@ -899,7 +899,7 @@ def test_example(trigger, dep, trigger_val):
     expect(args[2].getIntervals()).toEqual([{ min: 0, max: 100 }]);
   });
 
-  it("hypothesis @settings max_examples option", () => {
+  it("hypothesis @settings `max_examples`", () => {
     const program = ProgramFactory.fromSource(
       () => `
 MAX_EX = 250
@@ -931,7 +931,7 @@ def test_without_settings(x):
     expect(fn3.getRef().fuzzOptions).toBeUndefined();
   });
 
-  it("maps Hypothesis from_regex to the string regex option", () => {
+  it("hypothesis @given `from_regex` strategy", () => {
     const fn = ProgramFactory.fromSource(
       () => `
 PATTERN = r"[a-zA-Z_][a-zA-Z0-9_]{0,4}"
@@ -958,7 +958,7 @@ def test_regex(inline, referenced, partial, anchored):
     expect(fn.getArgDefs()[1].getOptions().strCharset).toEqual("super");
   });
 
-  it("maps Hypothesisuuids strategy to string regex and length options", () => {
+  it("hypothesis @given `uuids` strategy", () => {
     const fn = ProgramFactory.fromSource(
       () => `
 @given(
@@ -1045,7 +1045,7 @@ def test_bounds(integer, decimal):
     expect(args[1].getIntervals()).toEqual([{ min: -1.5, max: 2.5 }]);
   });
 
-  it("hypothesis @given nested lists and fixed_dictionaries", () => {
+  it("hypothesis @given `lists` nested and fixed_dictionaries", () => {
     const fn = ProgramFactory.fromSource(
       () => `
 @given(
@@ -1082,7 +1082,7 @@ def test_nested(complex_data):
     expect(tagsField?.getDim()).toEqual(1); // st.lists(st.text()) nested inside dict
   });
 
-  it("maps Hypothesis list uniqueness to ArgDef option", () => {
+  it("hypothesis @given `lists` uniqueness", () => {
     const fn = ProgramFactory.fromSource(
       () => `
 USE_UNIQUE_VALUES = True
@@ -1107,7 +1107,7 @@ def test_lists(unique_values, duplicate_values, unconstrained_values, referenced
     ]);
   });
 
-  it("hypothesis @given sampled_from", () => {
+  it("hypothesis @given `sampled_from`", () => {
     const fn = ProgramFactory.fromSource(
       () => `
 @given(
@@ -1131,7 +1131,7 @@ def test_sampled(status):
     ).toBeTrue();
   });
 
-  it("hypothesis @given sampled_from module-level constants", () => {
+  it("hypothesis @given `sampled_from` module-level constants", () => {
     const fn = ProgramFactory.fromSource(
       () => `
 _KEYWORDS = ["if", "else", "while", "return", "def", "class"]
@@ -1156,7 +1156,7 @@ def test_terminal_priority_keyword_wins(kw):
     ]);
   });
 
-  it("hypothesis @given sampled_from tuples", () => {
+  it("hypothesis @given `sampled_from` tuples", () => {
     const fn = ProgramFactory.fromSource(
       () => `
 @given(st.sampled_from([("input", "disabled")]))
@@ -1174,7 +1174,7 @@ def test_sampled_tuple(elem_attr):
     ]);
   });
 
-  it("hypothesis @given sampled_from dictionaries", () => {
+  it("hypothesis @given `sampled_from` dictionaries", () => {
     const fn = ProgramFactory.fromSource(
       () => `
 @given(st.sampled_from([{"mode": "disabled", "retry": 0}]))
@@ -1196,7 +1196,7 @@ def test_sampled_dictionary(config):
     ]);
   });
 
-  it("hypothesis @given permutations", () => {
+  it("hypothesis @given `permutations`", () => {
     const fn = ProgramFactory.fromSource(
       () => `
 @given(
@@ -1220,7 +1220,7 @@ def test_perm(items):
     ]);
   });
 
-  it("hypothesis @given permutations range and constant reference", () => {
+  it("hypothesis @given `permutations` range and constant reference", () => {
     const fn = ProgramFactory.fromSource(
       () => `
 RANGE_CONST = range(1, 5)
@@ -1251,7 +1251,7 @@ def test_perm_range(nums, ref_nums):
     ]);
   });
 
-  it("hypothesis @given permutations range(2001) generates 2001 unique elements performantly", () => {
+  it("hypothesis @given `permutations` range(2001) generates 2001 unique elements performantly", () => {
     const fn = ProgramFactory.fromSource(
       () => `
 @given(
@@ -1276,7 +1276,7 @@ def test_perm_large(nums):
     }
   });
 
-  it("hypothesis @given fixed_dictionaries with optional keys", () => {
+  it("hypothesis @given `fixed_dictionaries` optional keys", () => {
     const fn = ProgramFactory.fromSource(
       () => `
 @given(
@@ -1374,7 +1374,7 @@ def test_add_overwrites_boundary_expired_item(key, old_value, new_value):
     expect(newChildren[1].getOptions().strLength).toEqual({ min: 1, max: 10 });
   });
 
-  it("@given dimsUnique for st.lists(..., unique=True) and st.sets(...)", () => {
+  it("hypothesis @given `lists` and `sets` uniqueness", () => {
     const fn = ProgramFactory.fromSource(
       () => `
 @given(
@@ -1404,7 +1404,7 @@ def test_indexedset_index_invariant_after_discard(initial: list[int], ops: List[
     expect(setArg?.getOptions().dimsUnique).toBeTrue();
   });
 
-  it("handles min_size after max_size in st.lists regardless of order or inline comments", () => {
+  it("hypothesis @given `lists` handles min_size after max_size regardless of order or inline comments", () => {
     const fn = ProgramFactory.fromSource(
       () => `
 @given(
@@ -1443,7 +1443,7 @@ def test_lru_eviction_order_after_reads(capacity: int, ops1: list, ops2: list, n
     expect(numPosArg?.getIntervals()).toEqual([{ min: 0, max: 10 }]);
   });
 
-  it("handles strategies like st.tuples inside st.sampled_from", () => {
+  it("hypothesis @given `tuples` inside `sampled_from", () => {
     const fn = ProgramFactory.fromSource(
       () => `
 @given(

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -1240,6 +1240,37 @@ export class PythonProgram extends AbstractProgram {
         break;
       }
 
+      case "uuids": {
+        const version = parseLiteral(getKwdArg(node, "version", -1));
+        const allowNil = parseLiteral(getKwdArg(node, "allow_nil", -1)) === true;
+
+        // Base pattern depending on version
+        let uuidPattern: string;
+        if (typeof version === "number" && version >= 1 && version <= 5) {
+          uuidPattern = `[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-${version}[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}`;
+        } else {
+          uuidPattern = `[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}`;
+        }
+
+        // Incorporate the Nil UUID if allow_nil=True
+        const finalRegex = allowNil
+          ? `\\A(?:${uuidPattern}|00000000-0000-0000-0000-000000000000)\\Z`
+          : `\\A${uuidPattern}\\Z`;
+
+        thisType.type = {
+          type: ArgTag.STRING,
+          dims: 0,
+          children: [],
+          options: {
+            strLength: { min: 36, max: 36 },
+            strCharset: "0123456789abcdefABCDEF-",
+            strRegex: finalRegex,
+          },
+          resolved: true,
+        };
+        break;
+      }
+
       case "integers": {
         const minVal = parseLiteral(getKwdArg(node, "min_value", 0));
         const maxVal = parseLiteral(getKwdArg(node, "max_value", 1));

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -583,6 +583,19 @@ export class PythonProgram extends AbstractProgram {
             return [ArgTag.STRING, 0];
           case "bool":
             return [ArgTag.BOOLEAN, 0];
+          case "UUID":
+            return [
+              ArgTag.STRING,
+              0,
+              "UUID",
+              undefined,
+              {
+                strLength: { min: 36, max: 36 },
+                strCharset: "0123456789abcdefABCDEF-",
+                strRegex:
+                  "\\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\\Z",
+              },
+            ];
           default:
             return [ArgTag.UNRESOLVED, 0, node.text];
         }
@@ -644,7 +657,18 @@ export class PythonProgram extends AbstractProgram {
       case "member_type":
       case "attribute":
         if (node.text === "uuid.UUID") {
-          return [ArgTag.UNRESOLVED, 0, "UUID"];
+          return [
+            ArgTag.STRING,
+            0,
+            "UUID",
+            undefined,
+            {
+              strLength: { min: 36, max: 36 },
+              strCharset: "0123456789abcdefABCDEF-",
+              strRegex:
+                "\\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\\Z",
+            },
+          ];
         }
         return [ArgTag.UNRESOLVED, 0, node.text];
       default:
@@ -836,6 +860,10 @@ export class PythonProgram extends AbstractProgram {
     // Get the node's type and dimensions
     const [type, dims, typeRefNode, literalValue, typeOptions] =
       this._getTypeFromAstNode(typeNode, this._options);
+
+    if (typeRefNode) {
+      thisType.typeRefName = typeRefNode;
+    }
 
     // Create the TypeRef data structure
     switch (type) {
@@ -1464,10 +1492,7 @@ export class PythonProgram extends AbstractProgram {
             const parsedArgs = posArgs
               .map((c) => parseLiteral(resolveReference(c)))
               .filter((v): v is number => typeof v === "number");
-            if (
-              parsedArgs.length > 0 &&
-              parsedArgs.length === posArgs.length
-            ) {
+            if (parsedArgs.length > 0 && parsedArgs.length === posArgs.length) {
               let start = 0;
               let stop: number;
               let step = 1;
@@ -1622,7 +1647,8 @@ export class PythonProgram extends AbstractProgram {
 
       case "uuids": {
         const version = parseLiteral(getKwdArg(node, "version", -1));
-        const allowNil = parseLiteral(getKwdArg(node, "allow_nil", -1)) === true;
+        const allowNil =
+          parseLiteral(getKwdArg(node, "allow_nil", -1)) === true;
 
         // Base pattern depending on version
         let uuidPattern: string;
@@ -2243,6 +2269,24 @@ export class PythonProgram extends AbstractProgram {
         type: this.options.anyType,
         dims: this.options.anyDims,
         children: [],
+        resolved: true,
+      };
+      return typeRef;
+    } else if (
+      typeRef.typeRefName === "UUID" ||
+      typeRef.typeRefName === "uuid.UUID"
+    ) {
+      typeRef.typeRefName = "UUID";
+      typeRef.type = {
+        type: ArgTag.STRING,
+        dims: 0,
+        children: [],
+        options: {
+          strLength: { min: 36, max: 36 },
+          strCharset: "0123456789abcdefABCDEF-",
+          strRegex:
+            "\\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\\Z",
+        },
         resolved: true,
       };
       return typeRef;

--- a/src/fuzzer/analysis/python/PythonProgram.ts
+++ b/src/fuzzer/analysis/python/PythonProgram.ts
@@ -643,6 +643,9 @@ export class PythonProgram extends AbstractProgram {
       }
       case "member_type":
       case "attribute":
+        if (node.text === "uuid.UUID") {
+          return [ArgTag.UNRESOLVED, 0, "UUID"];
+        }
         return [ArgTag.UNRESOLVED, 0, node.text];
       default:
         throw new Error(
@@ -1634,6 +1637,7 @@ export class PythonProgram extends AbstractProgram {
           ? `\\A(?:${uuidPattern}|00000000-0000-0000-0000-000000000000)\\Z`
           : `\\A${uuidPattern}\\Z`;
 
+        thisType.typeRefName = "UUID";
         thisType.type = {
           type: ArgTag.STRING,
           dims: 0,
@@ -1815,6 +1819,10 @@ export class PythonProgram extends AbstractProgram {
           min: Number(minSize ?? dftInterval.min),
           max: Number(maxSize ?? dftInterval.max),
         });
+
+        if (innerTypeRef.typeRefName) {
+          thisType.typeRefName = innerTypeRef.typeRefName;
+        }
 
         thisType.type = {
           type: innerResolvedType.type,

--- a/src/fuzzer/runners/AbstractRunner.ts
+++ b/src/fuzzer/runners/AbstractRunner.ts
@@ -77,10 +77,18 @@ export type RunnerResult = {
   env: VmGlobals;
 };
 
+export type TypeHint =
+  | "uuid"
+  | "default"
+  | { kind: "array"; element: TypeHint }
+  | { kind: "tuple"; elements: TypeHint[] }
+  | { kind: "object"; fields: Record<string, TypeHint> }
+  | { kind: "union"; arms: TypeHint[] };
+
 export type RunnerInput = {
   args: unknown[];
   seq: number;
-  typeHints?: string[];
+  typeHints?: TypeHint[];
 };
 
 /**

--- a/src/fuzzer/runners/AbstractRunner.ts
+++ b/src/fuzzer/runners/AbstractRunner.ts
@@ -80,6 +80,7 @@ export type RunnerResult = {
 export type RunnerInput = {
   args: unknown[];
   seq: number;
+  typeHints?: string[];
 };
 
 /**

--- a/src/fuzzer/runners/PythonRunner.test.ts
+++ b/src/fuzzer/runners/PythonRunner.test.ts
@@ -104,12 +104,15 @@ def process_nested(uuids_list: list[uuid.UUID], obj_data: UserObj, tuple_data: t
       const uuidStr2 = "87654321-4321-3214-3218-cba987654321";
       const hexNotUuid = "12345678123441238123123456789abc";
 
-      const res = await runner.run([
-        [uuidStr1, uuidStr2],
-        { id: uuidStr1 },
-        [uuidStr2, 42],
-        hexNotUuid,
-      ]);
+      const res = await runner.run(
+        [
+          [uuidStr1, uuidStr2],
+          { id: uuidStr1 },
+          [uuidStr2, 42],
+          hexNotUuid,
+        ],
+        2000
+      );
 
       await runner.onRunEnd();
 

--- a/src/fuzzer/runners/PythonRunner.test.ts
+++ b/src/fuzzer/runners/PythonRunner.test.ts
@@ -1,6 +1,17 @@
 import { PythonRunner } from "./PythonRunner";
+import { FuzzEnv } from "../Fuzzer";
+import { ArgDef } from "../analysis/ArgDef";
+import * as ProgramFactory from "../analysis/ProgramFactory";
+import * as Parser from "../adapters/ParserAdapter";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
 
 describe("fuzzer/runners/PythonRunner", () => {
+  beforeAll(async () => {
+    await Parser.init();
+  });
+
   it("resolves python interpreter trying python3 first and python as fallback", () => {
     const spy = spyOn(PythonRunner, "canExecute");
 
@@ -23,5 +34,95 @@ describe("fuzzer/runners/PythonRunner", () => {
     // Case 4: neither works, returns candidate
     spy.and.callFake(() => false);
     expect(PythonRunner.resolveInterpreter("python3")).toBe("python3");
+  });
+
+  it("nested UUID inputs and outputs", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nanofuzz-runner-"));
+    const pyPath = path.join(tmpDir, "uuid_test.py");
+    const pyCode = `import uuid
+
+def process_nested(uuids_list, obj_data, tuple_data, plain_str):
+    assert all(isinstance(u, uuid.UUID) for u in uuids_list), "uuids_list elements must be uuid.UUID"
+    assert isinstance(obj_data['id'], uuid.UUID), "obj_data['id'] must be uuid.UUID"
+    assert isinstance(tuple_data[0], uuid.UUID), "tuple_data[0] must be uuid.UUID"
+    assert isinstance(plain_str, str), "plain_str must remain str"
+    return {
+        "status": "ok",
+        "returned_uuid": uuid.UUID("12345678-1234-4123-8123-123456789abc"),
+        "returned_list": [uuid.UUID("87654321-4321-3214-3218-cba987654321")]
+    }
+`;
+    fs.writeFileSync(pyPath, pyCode);
+
+    try {
+      const srcCode = `import uuid
+from typing import TypedDict, List, Tuple
+
+class UserObj(TypedDict):
+    id: uuid.UUID
+
+def process_nested(uuids_list: list[uuid.UUID], obj_data: UserObj, tuple_data: tuple[uuid.UUID, int], plain_str: str):
+    pass
+`;
+      const program = ProgramFactory.fromSource(
+        () => srcCode,
+        "python",
+        pyPath
+      );
+      const fnDef = program.functionsExported["process_nested"];
+      const env: FuzzEnv = {
+        function: fnDef,
+        options: {
+          argDefaults: ArgDef.getDefaultOptions(),
+          maxTests: 1000,
+          maxDupeInputs: 1000,
+          maxFailures: 0,
+          fnTimeout: 100,
+          suiteTimeout: 0,
+          useImplicit: true,
+          useHuman: false,
+          useProperty: false,
+          useTransformer: false,
+          measures: {
+            CoverageMeasure: { enabled: true, weight: 1 },
+            FailedTestMeasure: { enabled: true, weight: 1 },
+          },
+          generators: {
+            RandomInputGenerator: { enabled: true },
+            MutationInputGenerator: { enabled: true },
+            AiInputGenerator: { enabled: false },
+          },
+        },
+        validators: [],
+        transformers: [],
+      };
+
+      const runner = new PythonRunner(pyPath, "process_nested", env, 2000);
+      await runner.onRunStart();
+
+      const uuidStr1 = "12345678-1234-4123-8123-123456789abc";
+      const uuidStr2 = "87654321-4321-3214-3218-cba987654321";
+      const hexNotUuid = "12345678123441238123123456789abc";
+
+      const res = await runner.run([
+        [uuidStr1, uuidStr2],
+        { id: uuidStr1 },
+        [uuidStr2, 42],
+        hexNotUuid,
+      ]);
+
+      await runner.onRunEnd();
+
+      expect(res.result.tag).toBe("value");
+      if (res.result.tag === "value") {
+        expect(res.result.value).toEqual({
+          status: "ok",
+          returned_uuid: "12345678-1234-4123-8123-123456789abc",
+          returned_list: ["87654321-4321-3214-3218-cba987654321"],
+        });
+      }
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/fuzzer/runners/PythonRunner.ts
+++ b/src/fuzzer/runners/PythonRunner.ts
@@ -3,7 +3,10 @@ import {
   Arc,
   RunnerInput,
   RunnerResult,
+  TypeHint,
 } from "./AbstractRunner";
+import { ArgDef } from "../analysis/ArgDef";
+import { ArgTag } from "../analysis/Types";
 import { FuzzEnv } from "../Fuzzer";
 import JSON5 from "json5";
 import DotEnv from "dotenv";
@@ -13,6 +16,52 @@ import * as ChildProcess from "node:child_process";
 import * as path from "node:path";
 import * as fs from "node:fs";
 import { findInAncestor, isError } from "../Util";
+
+function isUuidArg(arg: ArgDef): boolean {
+  return arg.getTypeRef() === "UUID";
+}
+
+function getBaseTypeHint(arg: ArgDef): TypeHint {
+  if (isUuidArg(arg)) {
+    return "uuid";
+  }
+
+  switch (arg.getType()) {
+    case ArgTag.TUPLE:
+      return {
+        kind: "tuple",
+        elements: arg.getChildren().map(getTypeHint),
+      };
+    case ArgTag.OBJECT: {
+      const fields: Record<string, TypeHint> = {};
+      for (const child of arg.getChildren()) {
+        fields[child.getName()] = getTypeHint(child);
+      }
+      return { kind: "object", fields };
+    }
+    case ArgTag.UNION:
+      return {
+        kind: "union",
+        arms: arg.getChildren().map(getTypeHint),
+      };
+    case ArgTag.NUMBER:
+    case ArgTag.STRING:
+    case ArgTag.BOOLEAN:
+    case ArgTag.LITERAL:
+    case ArgTag.UNRESOLVED:
+    default:
+      return "default";
+  }
+}
+
+function getTypeHint(arg: ArgDef): TypeHint {
+  const dims = arg.getDim();
+  let hint: TypeHint = getBaseTypeHint(arg);
+  for (let i = 0; i < dims; i++) {
+    hint = { kind: "array", element: hint };
+  }
+  return hint;
+}
 
 /**
  * Python runner
@@ -90,12 +139,7 @@ export class PythonRunner extends AbstractRunner {
     try {
       const host = await this._getHost();
       const typeHints =
-        this._env?.function.getArgDefs().map((arg) => {
-          if (arg.getTypeRef() === "UUID") {
-            return "uuid";
-          }
-          return "default";
-        }) ?? [];
+        this._env?.function.getArgDefs().map(getTypeHint) ?? [];
 
       const input: RunnerInput = {
         args: inputs,

--- a/src/fuzzer/runners/PythonRunner.ts
+++ b/src/fuzzer/runners/PythonRunner.ts
@@ -4,6 +4,7 @@ import {
   RunnerInput,
   RunnerResult,
 } from "./AbstractRunner";
+import { FuzzEnv } from "../Fuzzer";
 import JSON5 from "json5";
 import DotEnv from "dotenv";
 import vscode from "vscode";
@@ -21,6 +22,7 @@ export class PythonRunner extends AbstractRunner {
   protected _timeout: number;
   protected _runDepth = 0;
   protected _fn: string;
+  protected _env: FuzzEnv | undefined;
   protected _host: PythonHost | undefined = undefined;
   protected _seq = 0;
   protected _coverageInfo?: CoverageInfo = undefined;
@@ -37,12 +39,19 @@ export class PythonRunner extends AbstractRunner {
    *
    * @param `filename` path and filename of Python program module
    * @param `fn` exported Python function within `module` to call
+   * @param `env` optional fuzzer environment
    */
-  constructor(filename: string, fn: string, timeout: number = 0) {
+  constructor(
+    filename: string,
+    fn: string,
+    env?: FuzzEnv,
+    timeout: number = 0
+  ) {
     super(fn);
     this._filename = filename;
     this._timeout = timeout;
     this._fn = fn;
+    this._env = env;
   } // fn: constructor
 
   /**
@@ -80,9 +89,18 @@ export class PythonRunner extends AbstractRunner {
 
     try {
       const host = await this._getHost();
+      const typeHints =
+        this._env?.function.getArgDefs().map((arg) => {
+          if (arg.getTypeRef() === "UUID") {
+            return "uuid";
+          }
+          return "default";
+        }) ?? [];
+
       const input: RunnerInput = {
         args: inputs,
         seq: thisSeq,
+        typeHints,
       };
 
       const payload = JSON5.stringify(input);

--- a/src/fuzzer/runners/PythonRunner.ts
+++ b/src/fuzzer/runners/PythonRunner.ts
@@ -556,7 +556,7 @@ class PythonHost {
   protected _onClose = (): void => {
     this._errors.push(
       new Error(
-        `PythonHost exited unexpectedly (exit code: ${this._proc.exitCode}, stderr: ${this._proc.stderr.read()}, stdout: ${this._proc.stdout.read()}, cli: ${this._cli}, cwd: ${this._cwd})`
+        `PythonHost exited unexpectedly (exit code: ${this._proc.exitCode}, stderr: ${this._stderr.toString("utf8")}, stdout: ${this._stdout.toString("utf8")}, cli: ${this._cli}, cwd: ${this._cwd})`
       )
     );
     this.kill();

--- a/src/fuzzer/runners/PythonRunnerHost.py
+++ b/src/fuzzer/runners/PythonRunnerHost.py
@@ -289,27 +289,66 @@ def static_coverage(cov: coverage.Coverage, filename: str) -> dict:
     }
 
 
-def transform_uuid_arg(val: Any) -> Any:
-    if isinstance(val, str):
-        try:
-            return uuid.UUID(val)
-        except ValueError:
-            return val
-    if isinstance(val, list):
-        return [transform_uuid_arg(item) for item in val]
-    if isinstance(val, dict):
-        return {k: transform_uuid_arg(v) for k, v in val.items()}
+def transform_uuid_arg(val: Any, hint: Any) -> Any:
+    if val is None:
+        return None
+
+    if hint == "uuid":
+        if isinstance(val, str):
+            if len(val) in (32, 36):
+                try:
+                    return uuid.UUID(val)
+                except ValueError:
+                    return val
+        return val
+
+    if hint == "default" or not isinstance(hint, dict):
+        return val
+
+    kind = hint.get("kind")
+
+    if kind == "array" and isinstance(val, list):
+        elem_hint = hint.get("element", "default")
+        return [transform_uuid_arg(item, elem_hint) for item in val]
+
+    if kind == "tuple" and (isinstance(val, tuple) or isinstance(val, list)):
+        elem_hints = hint.get("elements", [])
+        transformed = [
+            transform_uuid_arg(item, elem_hints[i]) if i < len(elem_hints) else item
+            for i, item in enumerate(val)
+        ]
+        return tuple(transformed) if isinstance(val, tuple) else transformed
+
+    if kind == "object" and isinstance(val, dict):
+        field_hints = hint.get("fields", {})
+        return {
+            k: transform_uuid_arg(v, field_hints[k]) if k in field_hints else v
+            for k, v in val.items()
+        }
+
+    if kind == "union":
+        arms = hint.get("arms", [])
+        if isinstance(val, str) and any(
+            arm == "uuid" or (isinstance(arm, dict) and arm.get("kind") == "uuid")
+            for arm in arms
+        ):
+            try:
+                return uuid.UUID(val)
+            except ValueError:
+                pass
+        for arm in arms:
+            transformed = transform_uuid_arg(val, arm)
+            if isinstance(transformed, uuid.UUID) or transformed != val:
+                return transformed
+        return val
+
     return val
 
 
-def serialize_uuids(val: Any) -> Any:
-    if isinstance(val, uuid.UUID):
-        return str(val)
-    if isinstance(val, list):
-        return [serialize_uuids(item) for item in val]
-    if isinstance(val, dict):
-        return {k: serialize_uuids(v) for k, v in val.items()}
-    return val
+def json5_default(obj: Any) -> Any:
+    if isinstance(obj, uuid.UUID):
+        return str(obj)
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON5 serializable")
 
 
 def run_put(input: RunnerInput, filename: str, cov: coverage.Coverage) -> RunnerResult:
@@ -325,8 +364,7 @@ def run_put(input: RunnerInput, filename: str, cov: coverage.Coverage) -> Runner
     args = list(input["args"])
     type_hints = input.get("typeHints", [])
     for i in range(min(len(args), len(type_hints))):
-        if type_hints[i] == "uuid":
-            args[i] = transform_uuid_arg(args[i])
+        args[i] = transform_uuid_arg(args[i], type_hints[i])
 
     try:
         with redirect_stdout(io.StringIO()) as f:
@@ -374,7 +412,7 @@ def run_put(input: RunnerInput, filename: str, cov: coverage.Coverage) -> Runner
 
     return RunnerValueResult(
         tag="value",
-        value=serialize_uuids(value),
+        value=value,
         seq=input["seq"],
         coverageData=coverageData,
         coverageArcs=coverageArcs
@@ -388,7 +426,7 @@ def put_result(result: RunnerResult) -> None:
 
 
 def send_msg(data: RunnerResult):
-    msg = json5.dumps(data).encode('utf-8')
+    msg = json5.dumps(data, default=json5_default).encode('utf-8')
     logging.debug(f"[{pid}]  - Writing {len(msg)} bytes: {msg}")
     sys.stdout.buffer.write(struct.pack(
         '>I', len(msg)))  # payload size
@@ -456,7 +494,7 @@ if __name__ == "__main__":
     logging.debug(f"[{pid}] Sent READY message (length {len(msg)})")
 
     # Send the static coverage info once
-    msg = json5.dumps(coverageInfo).encode('utf-8')
+    msg = json5.dumps(coverageInfo, default=json5_default).encode('utf-8')
     sys.stdout.buffer.write(struct.pack('>I', len(msg)))  # payload size
     sys.stdout.buffer.write(msg)  # payload
     sys.stdout.buffer.flush()

--- a/src/fuzzer/runners/PythonRunnerHost.py
+++ b/src/fuzzer/runners/PythonRunnerHost.py
@@ -7,6 +7,8 @@ import struct
 import logging
 import tempfile
 import traceback
+import re
+import uuid
 from contextlib import redirect_stdout
 from typing import Any, Literal, List, Tuple, Union, TypedDict, NotRequired
 
@@ -287,6 +289,29 @@ def static_coverage(cov: coverage.Coverage, filename: str) -> dict:
     }
 
 
+def transform_uuid_arg(val: Any) -> Any:
+    if isinstance(val, str):
+        try:
+            return uuid.UUID(val)
+        except ValueError:
+            return val
+    if isinstance(val, list):
+        return [transform_uuid_arg(item) for item in val]
+    if isinstance(val, dict):
+        return {k: transform_uuid_arg(v) for k, v in val.items()}
+    return val
+
+
+def serialize_uuids(val: Any) -> Any:
+    if isinstance(val, uuid.UUID):
+        return str(val)
+    if isinstance(val, list):
+        return [serialize_uuids(item) for item in val]
+    if isinstance(val, dict):
+        return {k: serialize_uuids(v) for k, v in val.items()}
+    return val
+
+
 def run_put(input: RunnerInput, filename: str, cov: coverage.Coverage) -> RunnerResult:
     logging.debug(f"[{pid}] Running function '{fnname}' for {input}")
 
@@ -296,16 +321,23 @@ def run_put(input: RunnerInput, filename: str, cov: coverage.Coverage) -> Runner
     error = None
     skip = None
     value = None
+
+    args = list(input["args"])
+    type_hints = input.get("typeHints", [])
+    for i in range(min(len(args), len(type_hints))):
+        if type_hints[i] == "uuid":
+            args[i] = transform_uuid_arg(args[i])
+
     try:
         with redirect_stdout(io.StringIO()) as f:
             # If fn is a Hypothesis-wrapped test, bypass Hypothesis
             # and call the original underlying function
             if hasattr(fn, 'hypothesis') and hasattr(fn.hypothesis, 'inner_test'):
                 # Unwrap Hypothesis test function
-                value = fn.hypothesis.inner_test(*input["args"])
+                value = fn.hypothesis.inner_test(*args)
             else:
                 # Not Hypothesis; call directly
-                value = fn(*input["args"])
+                value = fn(*args)
     except Exception as e:
         if e.__class__.__name__ == "UnsatisfiedAssumption":
             skip = e
@@ -342,7 +374,7 @@ def run_put(input: RunnerInput, filename: str, cov: coverage.Coverage) -> Runner
 
     return RunnerValueResult(
         tag="value",
-        value=value,
+        value=serialize_uuids(value),
         seq=input["seq"],
         coverageData=coverageData,
         coverageArcs=coverageArcs

--- a/src/fuzzer/runners/RunnerFactory.ts
+++ b/src/fuzzer/runners/RunnerFactory.ts
@@ -14,13 +14,13 @@ import { PythonRunner } from "./PythonRunner";
  * @returns an appropriate AbstractRunner instance
  */
 export function RunnerFactory(
-  _env: FuzzEnv,
+  env: FuzzEnv,
   module: NodeJS.Module | string,
   fn: string
 ): AbstractRunner {
   if (typeof module === "string") {
     if (PythonProgram.understands({ filename: module })) {
-      return new PythonRunner(module, fn);
+      return new PythonRunner(module, fn, env);
     } else {
       throw new Error("Not yet implemented");
     }


### PR DESCRIPTION
This PR allows NaNofuzz to ingest Hypothesis `uuids` strategies, represents them as regex strings, and converts them back into uuids inside the PythonRunnerHost.