### PR TITLE
fix: missing runner await

### DIFF
--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -524,7 +524,7 @@ export class Tester {
     const propRunners = this._validators.map((vFnRef) =>
       RunnerFactory(this.env, mod, vFnRef.name)
     );
-    propRunners.forEach(async (p) => await p.onRunStart());
+    await Promise.all(propRunners.map((p) => p.onRunStart()));
     const propertyOracle = new PropertyOracle(propRunners);
 
     // Are we currently injecting inputs?


### PR DESCRIPTION
Due to a missing property runner await in `Fuzzer`, it was possible for testing to start while a python property runner was still initializing, which could lead to unpredictable results.