### PR TITLE
doc: rmv `choco` ref from `contributing.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,14 +30,6 @@ Be sure you have these tools installed:
 
 If you're using [Nix][], all dependencies other than Git will be automatically provided by the `flake.nix` file in this repo once you've cloned it.
 
-If you're using Windows, install the VC++ bits needed to build `tree-sitter`.
-More details may be found [here](https://github.com/nodejs/node-gyp#on-windows).
-You can use Cocolatey for this:
-
-```cmd
-choco install python visualstudio2022-workload-vctools -y
-```
-
 ### Developing in Windows WSL
 
 Here are some WSL-specific guides:

--- a/src/fuzzer/generators/CompositeInputGenerator.ts
+++ b/src/fuzzer/generators/CompositeInputGenerator.ts
@@ -37,7 +37,7 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
     cost: (number | undefined)[]; // cost by input tick (of L)
     currentIndex: number; // current index (of L) into last dimension of progress and cost
   }[] = []; // history for each input generator
-  protected _scoredInputs: ScoredInput[] = []; // List of scored inputs
+  protected interestingInputs: ScoredInput[] = []; // List of interesting inputs
   protected _injectedInputs: Omit<InputAndSource, "tick">[] = []; // Inputs to force generate first
   protected _selectedSubgenIndex = -1; // Selected subordinate input generator (e.g., by efficiency)
   protected _leaderboard; // Interesting inputs
@@ -288,7 +288,7 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
 
     // Update history of composite input generator if the input was interesting
     if (interestingReasons.length > 0) {
-      this._scoredInputs.push({
+      this.interestingInputs.push({
         input: this._lastInput,
         tick: this._tick,
         score: weightedProgress,
@@ -375,7 +375,8 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
     const activeSubgens = this._subgens.filter(
       (e, i) => this._activeSubgens[i] && e.nextable()
     );
-    const addlChanceSpace = totalProductivity > 0 ? totalProductivity * this._P : 1;
+    const addlChanceSpace =
+      totalProductivity > 0 ? totalProductivity * this._P : 1;
     const addlChance = addlChanceSpace / activeSubgens.length;
 
     // Randomly select an active subgen with a bias toward subgens
@@ -413,7 +414,7 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
    * @returns interesting inputs
    */
   public getInterestingInputs(): ScoredInput[] {
-    return this._scoredInputs.map((i) => {
+    return this.interestingInputs.map((i) => {
       return { ...i };
     });
   } // fn: getInterestingInputs

--- a/src/fuzzer/generators/CompositeInputGenerator.ts
+++ b/src/fuzzer/generators/CompositeInputGenerator.ts
@@ -286,15 +286,17 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
       h.currentIndex = (h.currentIndex + 1) % this._L;
     }
 
-    // Update history of composite input generator
-    this._scoredInputs[this._tick] = {
-      input: this._lastInput,
-      tick: this._tick,
-      score: weightedProgress,
-      cost,
-      measurements,
-      interestingReasons,
-    };
+    // Update history of composite input generator if the input was interesting
+    if (interestingReasons.length > 0) {
+      this._scoredInputs.push({
+        input: this._lastInput,
+        tick: this._tick,
+        score: weightedProgress,
+        cost,
+        measurements,
+        interestingReasons,
+      });
+    }
 
     // Update leaderboard & last measured input if we have measures
     // (e.g., the input was not a dupe and was actually executed)
@@ -411,11 +413,9 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
    * @returns interesting inputs
    */
   public getInterestingInputs(): ScoredInput[] {
-    return this._scoredInputs
-      .filter((i) => i.interestingReasons.length)
-      .map((i) => {
-        return { ...i };
-      });
+    return this._scoredInputs.map((i) => {
+      return { ...i };
+    });
   } // fn: getInterestingInputs
 
   /**

--- a/src/ui/FuzzPanelController.ts
+++ b/src/ui/FuzzPanelController.ts
@@ -2912,7 +2912,9 @@ def ${transformerName}(${pyParams}) -> ${pyTupleType}:
             html += /*html*/ `
                   <div class="fuzzGridPanel${showThisGrid ? `` : ` hidden`}" id="view-${e.id}">
                     <div class="fuzzPanelDescription">${
-                      e.id === "runInfo" ? e.description : htmlEscape(e.description)
+                      e.id === "runInfo"
+                        ? e.description
+                        : htmlEscape(e.description)
                     }</div>`;
             if (e.hasGrid) {
               html += /*html*/ `

--- a/src/ui/FuzzPanelController.ts
+++ b/src/ui/FuzzPanelController.ts
@@ -2911,7 +2911,9 @@ def ${transformerName}(${pyParams}) -> ${pyTupleType}:
 
             html += /*html*/ `
                   <div class="fuzzGridPanel${showThisGrid ? `` : ` hidden`}" id="view-${e.id}">
-                    <div class="fuzzPanelDescription">${htmlEscape(e.description)}</div>`;
+                    <div class="fuzzPanelDescription">${
+                      e.id === "runInfo" ? e.description : htmlEscape(e.description)
+                    }</div>`;
             if (e.hasGrid) {
               html += /*html*/ `
                     <div id="fuzzResultsGrid-${e.id}">


### PR DESCRIPTION
Remove windows choco reference from the contributing guide because it is no longer required given that we switched from the native version of tree-sitter to the wasm version.