### PR TITLE
fix: test worker count

### DIFF
--- a/test.cjs
+++ b/test.cjs
@@ -113,16 +113,20 @@ async function main() {
   }
 
   const testFiles = sortTestFiles(rawFiles);
+  const totalFiles = testFiles.length;
 
   // Use OS available parallelism (number of CPU cores) or JOBS env var
-  const maxConcurrency = process.env.JOBS
-    ? parseInt(process.env.JOBS, 10)
-    : Math.max(
-        1,
-        os.availableParallelism ? os.availableParallelism() : os.cpus().length
-      );
+  // Do not exceed the number of test files to avoid idle workers
+  const maxConcurrency = Math.min(
+    process.env.JOBS
+      ? parseInt(process.env.JOBS, 10)
+      : Math.max(
+          1,
+          os.availableParallelism ? os.availableParallelism() : os.cpus().length
+        ),
+    totalFiles
+  );
 
-  const totalFiles = testFiles.length;
   console.log(
     `Running ${totalFiles} test file(s) in parallel using ${maxConcurrency} worker(s)...\n`
   );


### PR DESCRIPTION
Correct test worker count in the testing script. Previously the number of workers could exceed the number of test files:

```
$ node test.cjs src/fuzzer/FuzzerCoverageMultiFile.test.ts
Running 1 test file(s) in parallel using 8 worker(s)...
```

Now it will not exceed the number of test files:

```
$ node test.cjs src/fuzzer/FuzzerCoverageMultiFile.test.ts
Running 1 test file(s) in parallel using 1 worker(s)...
```