### PR TITLE
feat: instrumenter feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
         "category": "NaNofuzz"
       },
       {
+        "command": "nanofuzz.ClearCompileCache",
+        "title": "Clear compile cache",
+        "category": "NaNofuzz"
+      },
+      {
         "command": "nanofuzz.telemetry.FlushLog",
         "title": "Flush Telemetry Log to storage",
         "category": "NaNofuzz"

--- a/src/fuzzer/Fuzzer.ts
+++ b/src/fuzzer/Fuzzer.ts
@@ -15,7 +15,7 @@ import {
   FuzzTestResult,
   FuzzResultCategory,
   FuzzStopReason,
-  FuzzBusyStatusMessage,
+  FuzzStatusUpdater,
   BaseMeasureConfig,
 } from "./Types";
 import { InputAndSource, FuzzOptions } from "./Types";
@@ -325,7 +325,7 @@ export class Tester {
   public async testSync(
     injectTests: FuzzPinnedTest[] = [],
     mode: FuzzMode = { gen: true },
-    updateFn?: (payload: FuzzBusyStatusMessage) => void,
+    updateFn?: FuzzStatusUpdater,
     cancelFn?: () => boolean
   ): Promise<FuzzTestResults> {
     let result: FuzzTestResults | undefined;
@@ -357,7 +357,7 @@ export class Tester {
     injectTests: FuzzPinnedTest[] = [],
     mode: FuzzMode = { gen: true },
     callbackFn: (result: FuzzTestResults | Error) => void,
-    statusFn?: (payload: FuzzBusyStatusMessage) => void,
+    statusFn?: FuzzStatusUpdater,
     cancelFn?: () => boolean
   ): Promise<void> {
     this._runBatchAsync(
@@ -416,7 +416,7 @@ export class Tester {
   protected async *_run(
     injectTests: FuzzPinnedTest[] = [],
     mode: FuzzMode = { gen: true },
-    updateFn?: (payload: FuzzBusyStatusMessage) => void,
+    updateFn?: FuzzStatusUpdater,
     cancelFn?: () => boolean
   ): AsyncGenerator<
     FuzzTestResults | undefined,
@@ -431,7 +431,7 @@ export class Tester {
     }
     this._results.stats.counters.testingRuns++;
 
-    const update = (payload: FuzzBusyStatusMessage): void => {
+    const update: FuzzStatusUpdater = (payload) => {
       if (updateFn) {
         updateFn({ ...payload });
       } else if (payload.channel !== "update") {
@@ -502,14 +502,16 @@ export class Tester {
     this._results.stats.timers.compile = performance.now() - startCompTime;
 
     // Instrument the target, if required (currently only Typescript)
-    // Note: Python is instrumented in PythonRunnerHost
+    // Note: Python is currently instrumented in PythonRunnerHost
+    // Assumes: put, transformers, & validators are in the same module
     const instrumentTime = performance.now(); // start time: instrument
     const targetMod = this._lastCompiler
       ? Instrumenter.prepareInstrumentedTree(
           mod,
           this._lastCompiler.getCompiledDependencies(),
           this._measures,
-          this._lastCompiler.options.tmpDir
+          this._lastCompiler.options.tmpDir,
+          updateFn
         )
       : mod;
     this._results.stats.timers.instrument = performance.now() - instrumentTime;

--- a/src/fuzzer/Types.ts
+++ b/src/fuzzer/Types.ts
@@ -300,6 +300,11 @@ export type FuzzBusyStatusMessage =
     };
 
 /**
+ * Fuzzer status update callback
+ */
+export type FuzzStatusUpdater = (payload: FuzzBusyStatusMessage) => void;
+
+/**
  * Exception class for TypeScript compiler errors
  */
 export type TypescriptCompilerErrorDetails = {

--- a/src/fuzzer/compilers/Instrumenter.ts
+++ b/src/fuzzer/compilers/Instrumenter.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as crypto from "node:crypto";
 import { AbstractMeasure } from "../measures/AbstractMeasure";
+import { FuzzStatusUpdater } from "../Types";
 
 /**
  * Instruments source files with a given set of measures.
@@ -41,7 +42,8 @@ export class Instrumenter {
     targetEntry: string,
     dependencyPaths: string[],
     measures: AbstractMeasure[],
-    tmpDir: string
+    tmpDir: string,
+    updateFn?: FuzzStatusUpdater
   ): string {
     const measureHash = Instrumenter.getMeasureHash(measures);
     if (measureHash === "uninstrumented" || measures.length === 0) {
@@ -65,6 +67,33 @@ export class Instrumenter {
         !fs.existsSync(instPath) || fs.statSync(instPath).mtimeMs < cleanMtime;
 
       if (isStale) {
+        // Compute clean user-facing path by stripping the temporary compilation directory prefix
+        let displayPath = path.relative(tmpDir, cleanPath);
+        displayPath = displayPath.replace(/^inst-[^/\\]+[/\\]?/, "");
+        if (process.platform === "win32") {
+          if (/^[a-zA-Z][/\\]/.test(displayPath)) {
+            displayPath =
+              displayPath.charAt(0) + ":" + displayPath.substring(1);
+          }
+        } else {
+          if (!displayPath.startsWith("/")) {
+            displayPath = "/" + displayPath;
+          }
+        }
+        displayPath = path.normalize(displayPath);
+
+        // Provide feedback that we are instrumenting
+        if (updateFn) {
+          updateFn({
+            msg: ` - Instrument: ${displayPath}`,
+            channel: "milestone",
+          });
+          updateFn({
+            msg: `Instrumenting: ${displayPath}`,
+            channel: "update",
+            pct: 0.1,
+          });
+        }
         fs.mkdirSync(path.dirname(instPath), { recursive: true });
 
         // Copy source map if present

--- a/src/fuzzer/compilers/TypescriptCompiler.ts
+++ b/src/fuzzer/compilers/TypescriptCompiler.ts
@@ -17,7 +17,7 @@ import path from "node:path";
 import os from "node:os";
 import * as JSONN from "../../Jsonn";
 import {
-  FuzzBusyStatusMessage,
+  FuzzStatusUpdater,
   TypescriptCompilerError,
   TypescriptCompilerErrorDetails,
   VmGlobals,
@@ -158,7 +158,7 @@ export class TypescriptCompiler {
   /**
    * Compile the TypeScript file
    */
-  public compileSync(updateFn: (msg: FuzzBusyStatusMessage) => void): string {
+  public compileSync(updateFn: FuzzStatusUpdater): string {
     // Determine options using the module path
     this._options = structuredClone(defaultOptions);
     this._determineOptions();
@@ -368,10 +368,7 @@ export class TypescriptCompiler {
    * @param `module` node module
    * @param `updateFn` function for client status updates
    */
-  protected _tsc(
-    module: NodeJS.Module,
-    updateFn: (msg: FuzzBusyStatusMessage) => void
-  ): void {
+  protected _tsc(module: NodeJS.Module, updateFn: FuzzStatusUpdater): void {
     let exitCode = 0;
 
     // Determine the compiled name of the module
@@ -380,7 +377,7 @@ export class TypescriptCompiler {
 
     // Provide feedback that we are compiling
     updateFn({
-      msg: `Compiling: ${module.filename}`,
+      msg: ` - Compile...: ${module.filename}`,
       channel: "milestone",
     });
     updateFn({
@@ -917,7 +914,12 @@ const defaultOptions: CompilerOptions = {
   target: "ES2022", // default to ES2022
   moduleKind: "nodenext", // cjs is required for running inside express
   emitOnError: false, // fail compilation in case of errors
-  tmpDir: path.join(fs.realpathSync(os.tmpdir()), "nanofuzz", "tsc", String(process.pid)), // path for compiled files
+  tmpDir: path.join(
+    fs.realpathSync(os.tmpdir()),
+    "nanofuzz",
+    "tsc",
+    String(process.pid)
+  ), // path for compiled files
   lib: ["DOM", "ScriptHost", "ES2020", "ES2021.String", "ES2022"], // default to ES2020
   types: [""], // do not automatically import types
   typeRoots: [], // do not automatically import types

--- a/src/ui/CommandLine.test.ts
+++ b/src/ui/CommandLine.test.ts
@@ -12,11 +12,15 @@ import { prompt } from "../fuzzer/adapters/LlmAdapter";
 
 function runCli(args: string[]): ChildProcess.SpawnSyncReturns<string> {
   const cliScript = path.resolve(__dirname, "../../build/cli/cli.cjs");
-  return ChildProcess.spawnSync(process.execPath, [cliScript, ...args], {
+  const res = ChildProcess.spawnSync(process.execPath, [cliScript, ...args], {
     encoding: "utf8",
     cwd: path.resolve(__dirname, "../.."),
     shell: process.platform === "win32",
   });
+  if (res.stdout) {
+    process.stdout.write(res.stdout);
+  }
+  return res;
 }
 
 describe("cli:", () => {
@@ -478,6 +482,44 @@ def ${targetFn}(n: int) -> int:
       }
     }
   });
+
+  /**
+   * Commented out so the cache clear does not step on other running tests
+   *
+  it("--clear-compile-cache: clears compiler cache prior to testing", () => {
+    const outputFile = path.join(tmpDir, "clear_cache_output.json5");
+    const targetFile = "src/fuzzer/test_fixtures/Fuzzer.testfixtures.ts";
+    const targetFn = "testCoverageOneFile";
+
+    // First run to populate cache
+    const res1 = runCli([
+      targetFile,
+      targetFn,
+      "--max-tests",
+      "5",
+    ]);
+    expect(res1.status).toBe(0);
+
+    // Second run with --clear-compile-cache flag
+    const res2 = runCli([
+      targetFile,
+      targetFn,
+      "--output-file",
+      outputFile,
+      "--clear-compile-cache",
+      "--max-tests",
+      "5",
+    ]);
+
+    expect(res2.status).toBe(0);
+    expect(fs.existsSync(outputFile)).toBeTrue();
+
+    const outputData = JSON5.parse<FuzzTestResults>(
+      fs.readFileSync(outputFile, "utf8")
+    );
+    expect(outputData.results.length).toBeGreaterThan(0);
+  });
+  */
 });
 
 function getFnNameAndModule(fnObj: unknown): {

--- a/src/ui/FuzzPanelController.ts
+++ b/src/ui/FuzzPanelController.ts
@@ -27,6 +27,7 @@ import { CodeCoverageMeasureStats } from "../fuzzer/measures/AbstractCoverageMea
 import * as ProgramFactory from "../fuzzer/analysis/ProgramFactory";
 import { AbstractProgram } from "../fuzzer/analysis/AbstractProgram";
 import { PythonProgram } from "../fuzzer/analysis/python/PythonProgram";
+import * as CompilerFactory from "../fuzzer/compilers/CompilerFactory";
 
 // Consts for validator result arg name generation
 const resultArgCandidateNames = ["r", "result", "_r", "_result"];
@@ -2585,7 +2586,7 @@ def ${transformerName}(${pyParams}) -> ${pyTupleType}:
               moreCalls -= pendingCalls;
               callCategories++;
               aiGeneratorText.push(
-                `${pendingCalls} ${pendingCalls === 1 ? "was" : "were"} awaiting a response when testing ended${moreCalls ? "," : "."}`
+                `${pendingCalls} ${pendingCalls === 1 ? "was" : "were"} still in-flight when testing ended, and their results will be used if you click the "continue" button${moreCalls ? "," : "."}`
               );
             }
             if (aiGenStats.gen.calls.valid) {
@@ -2633,7 +2634,7 @@ def ${transformerName}(${pyParams}) -> ${pyTupleType}:
             // Tokens and estimated costs
             if (aiGenStats.gen.tokens.sent + aiGenStats.gen.tokens.received) {
               aiGeneratorText.push(
-                `All these interactions used ${aiGenStats.gen.tokens.sent} input tokens and ${aiGenStats.gen.tokens.received} output tokens.`
+                `These non in-flight interactions used ${aiGenStats.gen.tokens.sent} input tokens and ${aiGenStats.gen.tokens.received} output tokens.`
               );
               if (
                 !(
@@ -4198,6 +4199,13 @@ export const commands = {
   fuzzWithValidator: {
     name: "nanofuzz.FuzzWithValidator",
     fn: handleFuzzWithValidatorCommand,
+  },
+  clearCompileCache: {
+    name: "nanofuzz.ClearCompileCache",
+    fn: () => {
+      CompilerFactory.clean();
+      vscode.window.showInformationMessage(`Compile cache cleared`);
+    },
   },
 };
 

--- a/test.cjs
+++ b/test.cjs
@@ -3,9 +3,11 @@ const path = require("path");
 const os = require("os");
 const { spawn } = require("child_process");
 
+const isVerbose = process.argv.includes("--verbose");
+
 // Determine test files to run
 function getTestFiles() {
-  const args = process.argv.slice(2);
+  const args = process.argv.slice(2).filter((arg) => arg !== "--verbose");
 
   // If specific files or filter keywords were passed via CLI args
   if (args.length > 0) {
@@ -153,10 +155,14 @@ async function main() {
         `${progress.padStart(7)} ${statusTag} ${res.file} (${res.durationSec}s)`
       );
 
+      if (isVerbose && res.stdout) {
+        process.stdout.write(res.stdout);
+      }
+
       // Print output inline if test failed
       if (res.code !== 0) {
         console.error(`\n--- FAILURE OUTPUT: ${res.file} ---`);
-        if (res.stdout) console.error(res.stdout);
+        if (res.stdout && !isVerbose) console.error(res.stdout);
         if (res.stderr) console.error(res.stderr);
         console.error(`--- END FAILURE OUTPUT ---\n`);
       }


### PR DESCRIPTION
Adds instrumentation feedback to the screen (both CLI and FuzzPanel). We can do this more easily now that instrumentation has been refactored out of TypescriptCompiler.

```
NaNofuzz v0.3.6
Target: testCoverageOneFile of /<path>/src/fuzzer/test_fixtures/Fuzzer.testfixtures.ts
 - Compile...: /<path>/src/fuzzer/test_fixtures/Fuzzer.testfixtures.ts
 - Compile...: /<path>/src/fuzzer/test_fixtures/Fuzzer.textfixturees2.ts
 - Compile...: /<path>/src/fuzzer/Types.ts
 - Instrument: /<path>/src/fuzzer/test_fixtures/Fuzzer.testfixtures.js
 - Instrument: /<path>/src/fuzzer/test_fixtures/Fuzzer.textfixturees2.js
 - Instrument: /<path>/src/fuzzer/Types.js
Target ready to test.
 - Executed 10 and skipped 0 tests in 6738 ms this run. Stopped for reason: maxTests.
 - Injected 0 and generated 10 inputs (0 were dupes) this run.
 - Total tests with exceptions: 0, timeouts: 0, errors: 0
 - Total tests where human validator passed: 0, failed: 0
 - Total tests where property validator passed: 10, failed: 0
 - Total tests where heuristic validator passed: 10, failed: 0
Testing finished.
```