### PR TITLE
fix: python code coverage for validators, transformers

### DIFF
--- a/src/fuzzer/FuzzerPython.test.ts
+++ b/src/fuzzer/FuzzerPython.test.ts
@@ -39,6 +39,22 @@ describe("fuzzer: python targets", () => {
       expect(r.validatorException).toBeFalse();
       expect(r.passedValidator).toBe("pass");
     });
+
+    // Check code coverage includes both PUT and validator functions
+    const covStats = await fuzzResult.stats.measures.CodeCoverageMeasure?.();
+    expect(covStats).toBeDefined();
+    if (covStats && covStats.files.length) {
+      const fileStats = covStats.files[0];
+      const coveredFnNames = Object.keys(fileStats.fileMap.f).map(
+        (idx) => fileStats.fileMap.fnMap[idx]?.name
+      );
+      expect(coveredFnNames).toContain("greeting");
+      expect(
+        coveredFnNames.some(
+          (name) => name && name.includes("greetingValidator")
+        )
+      ).toBeTrue();
+    }
   });
 
   it("Python timeouts", async () => {
@@ -169,6 +185,18 @@ describe("fuzzer: python targets", () => {
         }
       }
     });
+
+    // Check code coverage includes both PUT and transformer functions
+    const covStats = await fuzzResult.stats.measures.CodeCoverageMeasure?.();
+    expect(covStats).toBeDefined();
+    if (covStats && covStats.files.length) {
+      const fileStats = covStats.files[0];
+      const coveredFnNames = Object.keys(fileStats.fileMap.f).map(
+        (idx) => fileStats.fileMap.fnMap[idx]?.name
+      );
+      expect(coveredFnNames).toContain("py_transformed");
+      expect(coveredFnNames).toContain("py_transformedTransformer");
+    }
   });
 
   it("Python transformer exception", async () => {

--- a/src/fuzzer/measures/PythonCoverageMeasure.test.ts
+++ b/src/fuzzer/measures/PythonCoverageMeasure.test.ts
@@ -86,8 +86,10 @@ class TestPythonCoverageMeasure extends PythonCoverageMeasure {
   }
 
   public record(run: PythonRun): void {
+    this.onBeforeNextTestExecution();
     this._info.lines = run.lines;
     this._info.arcs = run.arcs;
+    this.recordHits(this._coverage);
   }
 
   /**
@@ -888,6 +890,7 @@ describe("fuzzer/analysis/measures/PythonCoverageMeasure:", () => {
        * @param `runs` what the call executed, by file
        */
       public record(runs: Record<string, PythonRun>): void {
+        this.onBeforeNextTestExecution();
         for (const [file, info] of Object.entries(this._coverage) as [
           string,
           CoverageInfo,
@@ -895,6 +898,7 @@ describe("fuzzer/analysis/measures/PythonCoverageMeasure:", () => {
           info.lines = runs[file]?.lines;
           info.arcs = runs[file]?.arcs;
         }
+        this.recordHits(this._coverage);
       }
     } // class: MultiFileMeasure
 

--- a/src/fuzzer/measures/PythonCoverageMeasure.test.ts
+++ b/src/fuzzer/measures/PythonCoverageMeasure.test.ts
@@ -82,7 +82,7 @@ class TestPythonCoverageMeasure extends PythonCoverageMeasure {
     super();
     this._info = { ...staticInfo };
     this._coverage = { [file]: this._info };
-    this._runner = new StubPythonRunner(this._coverage);
+    this._runners = [new StubPythonRunner(this._coverage)];
   }
 
   public record(run: PythonRun): void {
@@ -877,7 +877,7 @@ describe("fuzzer/analysis/measures/PythonCoverageMeasure:", () => {
         for (const [file, info] of Object.entries(statics)) {
           this._coverage[file] = { ...info };
         }
-        this._runner = new StubPythonRunner(this._coverage);
+        this._runners = [new StubPythonRunner(this._coverage)];
       }
 
       /**

--- a/src/fuzzer/measures/PythonCoverageMeasure.ts
+++ b/src/fuzzer/measures/PythonCoverageMeasure.ts
@@ -24,51 +24,41 @@ import {
 } from "./AbstractCoverageMeasure";
 
 /**
- * End column for a synthesized statement location. coverage.py reports
- * coverage by line, not by column, so each executable line is treated as a
- * statement spanning the entire line. Consumers (e.g., the coverage heatmap)
- * clamp this to the line's actual end; a zero-width span would render nothing.
+ * A coverage measure implementation that collects and
+ * processes coverage.py code coverage for Python
+ * and translates it into istanbul format for NaNofuzz.
  */
-const END_OF_LINE_COLUMN = Number.MAX_SAFE_INTEGER;
-
-/**
- * Returns the range covering all of `line`. coverage.py reports coverage by
- * line, so every synthesized location spans a whole line.
- */
-function wholeLine(line: number): Range {
-  return {
-    start: { line, column: 0 },
-    end: { line, column: END_OF_LINE_COLUMN },
-  };
-} // fn: wholeLine
-
-/**
- * Returns a lookup key for `arc`, so that arcs can be compared by value.
- */
-function arcKey(arc: Arc): string {
-  return `${arc[0]},${arc[1]}`;
-} // fn: arcKey
-
 export class PythonCoverageMeasure extends AbstractCoverageMeasure {
-  protected _runner?: PythonRunner;
+  protected _runners: PythonRunner[] = [];
+  protected _coverageData: CoverageMapData = {};
   protected _globalCoverageMap = createCoverageMap({});
   protected _history = new Map<number, CoverageMeasurementNode>(); // measurement history
   protected _lastNode: CoverageMeasurementNode | undefined = undefined;
 
   /**
-   * Connects this measure to the run's Python runner, which is the source of
-   * the coverage data reported by the host process.
+   * Connects this measure to the run's Python runners, which are the source of
+   * the coverage data reported by the host processes.
    *
-   * @param `runner` the test runner for this run
+   * @param `runners` test runners for this run
    */
-  public onRunStart(runners: AbstractRunner[] | AbstractRunner): void {
-    const runner = Array.isArray(runners) ? runners[0] : runners;
-    if (!(runner instanceof PythonRunner)) {
-      throw new Error(
-        `${this.name} requires a PythonRunner, but received a ${runner?.constructor.name}`
-      );
-    }
-    this._runner = runner;
+  public override onRunStart(runners: AbstractRunner[] | AbstractRunner): void {
+    const runnerList = Array.isArray(runners) ? runners : [runners];
+    this._runners = [];
+    this._coverageData = {};
+
+    runnerList.forEach((r) => {
+      if (r instanceof PythonRunner) {
+        this._runners.push(r);
+        if (r.coverageInfo) {
+          this.recordHits(r.coverageInfo);
+        }
+        r.onCoverage((covInfo) => {
+          if (isFullCoverage(covInfo)) {
+            this.recordHits(covInfo);
+          }
+        });
+      }
+    });
 
     // Reset per-run state so a re-run does not accumulate coverage from the
     // previous run.
@@ -76,6 +66,54 @@ export class PythonCoverageMeasure extends AbstractCoverageMeasure {
     this._history.clear();
     this._lastNode = undefined;
   } // fn: onRunStart
+
+  /**
+   * Records code coverage hits for the given Python coverage information.
+   *
+   * @param covinfo Python coverage info
+   */
+  public recordHits(covinfo: FullCoverage): void {
+    const mapData = this._toCoverageMapData(covinfo);
+    const map = createCoverageMap(this._coverageData);
+    AbstractCoverageMeasure.better_merge(map, mapData);
+    const plainData: CoverageMapData = {};
+    for (const f of map.files()) {
+      plainData[f] = AbstractCoverageMeasure.file_snapshot(
+        map.fileCoverageFor(f)
+      );
+    }
+    this._coverageData = plainData;
+  } // fn: recordHits
+
+  /**
+   * Zeroes out the code coverage data prior to each test execution so that
+   * we record incremental code coverage for each test execution.
+   */
+  public override onBeforeNextTestExecution(): void {
+    if (this._coverageData) {
+      for (const fileKey of Object.keys(this._coverageData)) {
+        this._coverageData[fileKey] = { ...this._coverageData[fileKey] };
+        const fileCoverage = this._coverageData[fileKey];
+        if (fileCoverage.b) {
+          Object.keys(fileCoverage.b).forEach((bKey) => {
+            fileCoverage.b[bKey] = Array<number>(
+              fileCoverage.b[bKey].length
+            ).fill(0);
+          });
+        }
+        if (fileCoverage.s) {
+          Object.keys(fileCoverage.s).forEach((sKey) => {
+            fileCoverage.s[sKey] = 0;
+          });
+        }
+        if (fileCoverage.f) {
+          Object.keys(fileCoverage.f).forEach((fKey) => {
+            fileCoverage.f[fKey] = 0;
+          });
+        }
+      }
+    }
+  } // fn: onBeforeNextTestExecution
 
   /**
    * Measure the code coverage of the most recent test execution.
@@ -91,16 +129,30 @@ export class PythonCoverageMeasure extends AbstractCoverageMeasure {
     const measure = super.measure(input, result);
 
     // Sanity check that we have the runner and its coverage info
-    if (this._runner === undefined) {
+    if (this._runners.length === 0) {
       throw new Error("Coverage measure not connected to runner");
     }
 
     // Translate the runner's line/arc coverage into an istanbul
     // CoverageMapData so we can reuse istanbul's merge and summary machinery
     // and stay compatible with the CoverageMeasurement shape.
-    const currentCoverageData = this._runner.coverageInfo
-      ? this._toCoverageMapData(this._runner.coverageInfo)
-      : {};
+    let currentCoverageData: CoverageMapData = {};
+    if (Object.keys(this._coverageData).length > 0) {
+      currentCoverageData = this._snapshot();
+    } else {
+      const map = createCoverageMap({});
+      for (const r of this._runners) {
+        if (r.coverageInfo) {
+          const mapData = this._toCoverageMapData(r.coverageInfo);
+          AbstractCoverageMeasure.better_merge(map, mapData);
+        }
+      }
+      for (const f of map.files()) {
+        currentCoverageData[f] = AbstractCoverageMeasure.file_snapshot(
+          map.fileCoverageFor(f)
+        );
+      }
+    }
 
     // Total coverage in a map, summing statements, branches, and functions --
     // matching CoverageMeasure, so that newly-covered branches and functions
@@ -268,6 +320,11 @@ export class PythonCoverageMeasure extends AbstractCoverageMeasure {
     return ret;
   } // fn: _toCoverageMapData
 
+  /**
+   * Called when the test run ends.
+   *
+   * @param results The results of the test run.
+   */
   public onRunEnd(results: FuzzTestResults): void {
     results.stats.measures.CodeCoverageMeasure =
       async (): Promise<CodeCoverageMeasureStats> => {
@@ -324,7 +381,7 @@ export class PythonCoverageMeasure extends AbstractCoverageMeasure {
           files,
         };
       };
-  }
+  } // fn: onRunEnd
 
   /**
    * Calculates a numeric value representing the test execution's progress
@@ -339,14 +396,84 @@ export class PythonCoverageMeasure extends AbstractCoverageMeasure {
     );
   } // fn: delta
 
+  /**
+   * Checks if coverage data exists for the given tick.
+   *
+   * @param tick The tick to check for coverage data.
+   * @returns True if coverage data exists for the specified tick, false otherwise.
+   */
   public hasCoverage(tick: number): boolean {
     return this._history.has(tick);
-  }
+  } // fn: hasCoverage
+
+  /**
+   * Retrieves the coverage measurement for the given tick.
+   *
+   * @param tick The tick for which to retrieve coverage data.
+   * @returns The coverage measurement for the specified tick.
+   */
   public getCoverage(tick: number): CoverageMeasurement {
     const node = this._history.get(tick);
     if (node) {
       return node.meas; // rep leak !!!!!!!
     }
     throw new Error(`No coverahe data for "${tick}"`);
-  }
-}
+  } // fn: getCoverage
+
+  /**
+   * Returns a private copy of the current coverage data.
+   */
+  protected _snapshot(): CoverageMapData {
+    const snapshot: CoverageMapData = {};
+    for (const fileKey of Object.keys(this._coverageData)) {
+      const fileCoverage = this._coverageData[fileKey];
+      const b: FileCoverage["b"] = {};
+      for (const bKey of Object.keys(fileCoverage.b)) {
+        b[bKey] = [...fileCoverage.b[bKey]];
+      }
+      snapshot[fileKey] = {
+        ...fileCoverage,
+        s: { ...fileCoverage.s },
+        f: { ...fileCoverage.f },
+        b,
+      };
+    }
+    return snapshot;
+  } // fn: _snapshot
+} // class: PythonCoverageMeasure
+
+/**
+ * Checks if the given value is a FullCoverage object.
+ *
+ * @param val The value to check.
+ * @returns True if the value is a FullCoverage object, false otherwise.
+ */
+function isFullCoverage(val: unknown): val is FullCoverage {
+  return typeof val === "object" && val !== null;
+} // fn: isFullCoverage
+
+/**
+ * End column for a synthesized statement location. coverage.py reports
+ * coverage by line, not by column, so each executable line is treated as a
+ * statement spanning the entire line. Consumers (e.g., the coverage heatmap)
+ * clamp this to the line's actual end; a zero-width span would render nothing.
+ */
+const END_OF_LINE_COLUMN = Number.MAX_SAFE_INTEGER;
+
+/**
+ * Returns the range covering all of `line`. coverage.py reports coverage by
+ * line, so every synthesized location spans a whole line.
+ */
+function wholeLine(line: number): Range {
+  return {
+    start: { line, column: 0 },
+    end: { line, column: END_OF_LINE_COLUMN },
+  };
+} // fn: wholeLine
+
+/**
+ * Returns a lookup key for `arc`, so that arcs can be compared by value.
+ */
+function arcKey(arc: Arc): string {
+  return `${arc[0]},${arc[1]}`;
+} // fn: arcKey

--- a/src/fuzzer/measures/PythonCoverageMeasure.ts
+++ b/src/fuzzer/measures/PythonCoverageMeasure.ts
@@ -30,7 +30,7 @@ import {
  */
 export class PythonCoverageMeasure extends AbstractCoverageMeasure {
   protected _runners: PythonRunner[] = [];
-  protected _coverageData: CoverageMapData = {};
+  protected _coverageData: CoverageMap = createCoverageMap({});
   protected _globalCoverageMap = createCoverageMap({});
   protected _history = new Map<number, CoverageMeasurementNode>(); // measurement history
   protected _lastNode: CoverageMeasurementNode | undefined = undefined;
@@ -44,7 +44,7 @@ export class PythonCoverageMeasure extends AbstractCoverageMeasure {
   public override onRunStart(runners: AbstractRunner[] | AbstractRunner): void {
     const runnerList = Array.isArray(runners) ? runners : [runners];
     this._runners = [];
-    this._coverageData = {};
+    this._coverageData = createCoverageMap({});
 
     runnerList.forEach((r) => {
       if (r instanceof PythonRunner) {
@@ -74,15 +74,7 @@ export class PythonCoverageMeasure extends AbstractCoverageMeasure {
    */
   public recordHits(covinfo: FullCoverage): void {
     const mapData = this._toCoverageMapData(covinfo);
-    const map = createCoverageMap(this._coverageData);
-    AbstractCoverageMeasure.better_merge(map, mapData);
-    const plainData: CoverageMapData = {};
-    for (const f of map.files()) {
-      plainData[f] = AbstractCoverageMeasure.file_snapshot(
-        map.fileCoverageFor(f)
-      );
-    }
-    this._coverageData = plainData;
+    AbstractCoverageMeasure.better_merge(this._coverageData, mapData);
   } // fn: recordHits
 
   /**
@@ -91,9 +83,8 @@ export class PythonCoverageMeasure extends AbstractCoverageMeasure {
    */
   public override onBeforeNextTestExecution(): void {
     if (this._coverageData) {
-      for (const fileKey of Object.keys(this._coverageData)) {
-        this._coverageData[fileKey] = { ...this._coverageData[fileKey] };
-        const fileCoverage = this._coverageData[fileKey];
+      for (const fileKey of this._coverageData.files()) {
+        const fileCoverage = this._coverageData.fileCoverageFor(fileKey);
         if (fileCoverage.b) {
           Object.keys(fileCoverage.b).forEach((bKey) => {
             fileCoverage.b[bKey] = Array<number>(
@@ -136,23 +127,15 @@ export class PythonCoverageMeasure extends AbstractCoverageMeasure {
     // Translate the runner's line/arc coverage into an istanbul
     // CoverageMapData so we can reuse istanbul's merge and summary machinery
     // and stay compatible with the CoverageMeasurement shape.
-    let currentCoverageData: CoverageMapData = {};
-    if (Object.keys(this._coverageData).length > 0) {
-      currentCoverageData = this._snapshot();
-    } else {
-      const map = createCoverageMap({});
+    if (this._coverageData.files().length === 0) {
       for (const r of this._runners) {
         if (r.coverageInfo) {
           const mapData = this._toCoverageMapData(r.coverageInfo);
-          AbstractCoverageMeasure.better_merge(map, mapData);
+          AbstractCoverageMeasure.better_merge(this._coverageData, mapData);
         }
       }
-      for (const f of map.files()) {
-        currentCoverageData[f] = AbstractCoverageMeasure.file_snapshot(
-          map.fileCoverageFor(f)
-        );
-      }
     }
+    const currentCoverageData = this._snapshot();
 
     // Total coverage in a map, summing statements, branches, and functions --
     // matching CoverageMeasure, so that newly-covered branches and functions
@@ -425,18 +408,10 @@ export class PythonCoverageMeasure extends AbstractCoverageMeasure {
    */
   protected _snapshot(): CoverageMapData {
     const snapshot: CoverageMapData = {};
-    for (const fileKey of Object.keys(this._coverageData)) {
-      const fileCoverage = this._coverageData[fileKey];
-      const b: FileCoverage["b"] = {};
-      for (const bKey of Object.keys(fileCoverage.b)) {
-        b[bKey] = [...fileCoverage.b[bKey]];
-      }
-      snapshot[fileKey] = {
-        ...fileCoverage,
-        s: { ...fileCoverage.s },
-        f: { ...fileCoverage.f },
-        b,
-      };
+    for (const fileKey of this._coverageData.files()) {
+      snapshot[fileKey] = AbstractCoverageMeasure.file_snapshot(
+        this._coverageData.fileCoverageFor(fileKey)
+      );
     }
     return snapshot;
   } // fn: _snapshot

--- a/src/fuzzer/runners/AbstractRunner.ts
+++ b/src/fuzzer/runners/AbstractRunner.ts
@@ -158,6 +158,9 @@ export type RunnerInput = {
   timeout?: number;
   fnName?: string;
   filename?: string;
+  collect?: {
+    coverageData?: true;
+  };
 };
 
 /**

--- a/src/fuzzer/runners/PythonRunner.test.ts
+++ b/src/fuzzer/runners/PythonRunner.test.ts
@@ -472,4 +472,65 @@ def process_floats(nan_val: float, inf_val: float):
       }
     }
   });
+
+  it("skips coverage collection when coverage is disabled", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nanofuzz-runner-"));
+    const pyPath = path.join(tmpDir, "nocov_test.py");
+    const pyCode = `
+def add_one(x: int) -> int:
+    return x + 1
+`;
+    fs.writeFileSync(pyPath, pyCode);
+
+    try {
+      const program = ProgramFactory.fromSource(() => pyCode, "python", pyPath);
+      const fnDef = program.functionsExported["add_one"];
+      const env: FuzzEnv = {
+        function: fnDef,
+        options: {
+          argDefaults: ArgDef.getDefaultOptions(),
+          maxTests: 1000,
+          maxDupeInputs: 1000,
+          maxFailures: 0,
+          fnTimeout: 100,
+          suiteTimeout: 0,
+          useImplicit: true,
+          useHuman: false,
+          useProperty: false,
+          useTransformer: false,
+          measures: {
+            CoverageMeasure: { enabled: false, weight: 1 },
+            FailedTestMeasure: { enabled: true, weight: 1 },
+          },
+          generators: {
+            RandomInputGenerator: { enabled: true },
+            MutationInputGenerator: { enabled: true },
+            AiInputGenerator: { enabled: false },
+          },
+        },
+        validators: [],
+        transformers: [],
+      };
+
+      const runner = new PythonRunner(pyPath, "add_one", env, 2000);
+      await runner.onRunStart();
+
+      const res = await runner.run([5], 2000);
+      await runner.onRunEnd();
+
+      expect(res.result.tag).toBe("value");
+      expect(runner.coverageInfo).toBeUndefined();
+    } finally {
+      try {
+        fs.rmSync(tmpDir, {
+          recursive: true,
+          force: true,
+          maxRetries: 10,
+          retryDelay: 100,
+        });
+      } catch {
+        // Ignore
+      }
+    }
+  });
 });

--- a/src/fuzzer/runners/python/PythonRunner.ts
+++ b/src/fuzzer/runners/python/PythonRunner.ts
@@ -31,6 +31,8 @@ export class PythonRunner extends AbstractRunner {
   protected _host: PythonHost | undefined = undefined;
   protected _seq = 0;
   protected _coverageInfo?: FullCoverage = undefined;
+  protected _coverageEnabled = true;
+  protected _coverageCallback?: (covData: unknown) => void;
   protected _pythonEnv: PythonEnv | undefined;
   protected static _envs: {
     [file: string]: PythonEnv;
@@ -67,6 +69,10 @@ export class PythonRunner extends AbstractRunner {
   public async onRunStart(): Promise<void> {
     await super.onRunStart();
     this._killHost();
+    if (this._env?.options?.measures?.CoverageMeasure?.enabled !== undefined) {
+      this._coverageEnabled =
+        this._env.options.measures.CoverageMeasure.enabled;
+    }
     this._pythonEnv = PythonRunner.envFor(this._filename);
     await this._getHost();
   } // fn: onRunStart
@@ -100,6 +106,9 @@ export class PythonRunner extends AbstractRunner {
         args: inputs,
         seq: thisSeq,
         typeHints,
+        collect: {
+          coverageData: this._coverageEnabled ? true : undefined,
+        },
       };
 
       const payload = JSON5.stringify(input, (_key, val) => {
@@ -126,7 +135,12 @@ export class PythonRunner extends AbstractRunner {
 
       // Refresh the dynamic coverage with what this call executed. A timeout
       // is killed mid-run, so the host never reports coverage for it.
-      if (result.result.tag === "timeout") {
+      if (
+        result.result.tag === "timeout" ||
+        !this._coverageEnabled ||
+        !result.result.coverageData ||
+        Object.keys(result.result.coverageData).length === 0
+      ) {
         this._coverageInfo = undefined;
       } else {
         this._coverageInfo = result.result.staticCoverage;
@@ -143,6 +157,7 @@ export class PythonRunner extends AbstractRunner {
                 ? coverageArcs[filename]
                 : undefined;
           }
+          this._coverageCallback?.(this._coverageInfo);
         }
       }
 
@@ -172,7 +187,7 @@ export class PythonRunner extends AbstractRunner {
     } finally {
       this._runDepth--;
     }
-  }
+  } // fn: run
 
   /**
    * Tears down the runner host at the end of the test run
@@ -183,7 +198,24 @@ export class PythonRunner extends AbstractRunner {
     await super.onRunEnd();
     this._killHost();
     this._pythonEnv = undefined;
-  }
+  } // fn: onRunEnd
+
+  /**
+   * Returns the current coverage information, if any
+   */
+  public override get coverageInfo(): FullCoverage | undefined {
+    return this._coverageInfo;
+  } // fn: coverageInfo
+
+  /**
+   * Registers a callback to be invoked with coverage data
+   *
+   * @param callback the callback to register
+   */
+  public override onCoverage(callback: (covData: unknown) => void): void {
+    this._coverageCallback = callback;
+    this._coverageEnabled = true;
+  } // fn: onCoverage
 
   /**
    * Returns the python environment for a file
@@ -279,7 +311,7 @@ export class PythonRunner extends AbstractRunner {
     }, 10000);
 
     return pythonEnv;
-  }
+  } // fn: envFor
 
   /**
    * Returns the syspaths used by the interpreter
@@ -352,7 +384,7 @@ export class PythonRunner extends AbstractRunner {
     }
 
     return candidate || "python3";
-  }
+  } // fn: resolveInterpreter
 
   /**
    * Probes whether a python executable candidate can be spawned successfully.
@@ -370,7 +402,7 @@ export class PythonRunner extends AbstractRunner {
     } catch {
       return false;
     }
-  }
+  } // fn: canExecute
 
   /**
    * Get the current Python host process (creates a new one if needed)
@@ -449,13 +481,16 @@ export class PythonRunner extends AbstractRunner {
       this._host.kill();
       this._host = undefined;
     }
-  }
-
-  public get coverageInfo(): FullCoverage | undefined {
-    return this._coverageInfo;
-  }
+  } // fn: _killHost
 } // class: PythonRunner
 
+/**
+ * Finds the Python library directory
+ *
+ * @param dir the starting directory
+ * @param item the item to look for
+ * @returns the Python library directory, or null if not found
+ */
 function findPythonLibDir(dir: string, item: string): string | null {
   // Co-located with this module (e.g., as built)
   if (fs.existsSync(path.resolve(path.join(dir, item)))) {
@@ -469,12 +504,24 @@ function findPythonLibDir(dir: string, item: string): string | null {
   }
 
   return null;
-}
+} // fn: findPythonLibDir
 
+/**
+ * Checks if the argument is a UUID string
+ *
+ * @param arg the argument definition
+ * @returns true if the argument is a UUID string, false otherwise
+ */
 function isUuidArg(arg: ArgDef): boolean {
   return arg.getTypeRef() === "UUID" && arg.getType() === ArgTag.STRING;
-}
+} // fn: isUuidArg
 
+/**
+ * Gets the base type hint for the argument
+ *
+ * @param arg the argument definition
+ * @returns the base type hint
+ */
 function getBaseTypeHint(arg: ArgDef): TypeHint {
   if (isUuidArg(arg)) {
     return "uuid";
@@ -534,8 +581,14 @@ function getBaseTypeHint(arg: ArgDef): TypeHint {
     default:
       return "default";
   }
-}
+} // fn: getBaseTypeHint
 
+/**
+ * Gets the type hint for the argument, including array dimensions
+ *
+ * @param arg the argument definition
+ * @returns the type hint
+ */
 function getTypeHint(arg: ArgDef): TypeHint {
   const dims = arg.getDim();
   let hint: TypeHint = getBaseTypeHint(arg);
@@ -543,7 +596,7 @@ function getTypeHint(arg: ArgDef): TypeHint {
     hint = { kind: "array", element: hint };
   }
   return hint;
-}
+} // fn: getTypeHint
 
 /**
  * Coverage for the entire program under test.

--- a/src/fuzzer/runners/python/PythonRunnerHost.py
+++ b/src/fuzzer/runners/python/PythonRunnerHost.py
@@ -20,9 +20,14 @@ except ModuleNotFoundError as e:
     exit(3)
 
 
+class CollectOptions(TypedDict):
+    coverageData: NotRequired[Literal[True]]
+
+
 class RunnerInput(TypedDict):
     args: List[Any]
     seq: int
+    collect: NotRequired[CollectOptions]
 
 
 class RunnerValueResult(TypedDict):
@@ -450,9 +455,17 @@ def json5_default(obj: Any) -> Any:
 def run_put(input: RunnerInput, filename: str, fnname: str, fn: Any, cov: coverage.Coverage, covInfo: dict[str, dict[str, List]]) -> RunnerResult:
     logging.debug(f"[{pid}] Running function '{fnname}' for {input}")
 
-    # cov.erase() is too expensive. Seems like only erasing the data works too
-    cov.get_data().erase()
-    cov.start()
+    collect_options = input.get("collect")
+    if collect_options is None:
+        coverage_enabled = True
+    else:
+        coverage_enabled = bool(collect_options.get("coverageData"))
+
+    if coverage_enabled:
+        # cov.erase() is too expensive. Seems like only erasing the data works too
+        cov.get_data().erase()
+        cov.start()
+
     error = None
     skip = None
     value = None
@@ -478,19 +491,21 @@ def run_put(input: RunnerInput, filename: str, fnname: str, fn: Any, cov: covera
         else:
             error = e
     finally:
-        cov.stop()
+        if coverage_enabled:
+            cov.stop()
 
     # Read coverage after stopping: a failing input still covers lines
     coverageData = {}
     coverageArcs = {}
-    for file in cov.get_data().measured_files():
-        lines = coverage_lines(cov, file)
-        if not lines:
-            continue
-        if file not in covInfo:
-            covInfo[file] = static_coverage(cov, file)
-        coverageData[file] = lines
-        coverageArcs[file] = coverage_arcs(cov, file)
+    if coverage_enabled:
+        for file in cov.get_data().measured_files():
+            lines = coverage_lines(cov, file)
+            if not lines:
+                continue
+            if file not in covInfo:
+                covInfo[file] = static_coverage(cov, file)
+            coverageData[file] = lines
+            coverageArcs[file] = coverage_arcs(cov, file)
 
     if skip is not None:
         return RunnerSkipResult(
@@ -499,7 +514,7 @@ def run_put(input: RunnerInput, filename: str, fnname: str, fn: Any, cov: covera
             seq=input["seq"],
             coverageData=coverageData,
             coverageArcs=coverageArcs,
-            staticCoverage=covInfo
+            staticCoverage=covInfo if coverage_enabled else {}
         )
 
     if error is not None:
@@ -512,7 +527,7 @@ def run_put(input: RunnerInput, filename: str, fnname: str, fn: Any, cov: covera
             seq=input["seq"],
             coverageData=coverageData,
             coverageArcs=coverageArcs,
-            staticCoverage=covInfo
+            staticCoverage=covInfo if coverage_enabled else {}
         )
 
     return RunnerValueResult(
@@ -521,7 +536,7 @@ def run_put(input: RunnerInput, filename: str, fnname: str, fn: Any, cov: covera
         seq=input["seq"],
         coverageData=coverageData,
         coverageArcs=coverageArcs,
-        staticCoverage=covInfo
+        staticCoverage=covInfo if coverage_enabled else {}
     )
 
 


### PR DESCRIPTION
Resolves #414. The logic to merge these execution code maps was missing on the Python side.