### PR TITLE
fix: runner startup heartbeats

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,13 @@
             "default": 200,
             "minimum": 0,
             "description": "Default maximum time (in ms) to allow a test function to run before making it as a timeout."
+          },
+          "nanofuzz.fuzzer.hostStartupTimeout": {
+            "title": "Timeout runner host startup after (ms)",
+            "type": "integer",
+            "default": 10000,
+            "minimum": 1000,
+            "description": "Maximum time (in ms) allowed for the runner host process to startup."
           }
         }
       },

--- a/spec/helpers/vscode.stub.js
+++ b/spec/helpers/vscode.stub.js
@@ -20,6 +20,7 @@ module.exports = {
     },
   },
   window: {
+    createTextEditorDecorationType: () => ({}),
     onDidChangeActiveTextEditor: {},
     onDidChangeTextEditorSelection: {},
     onDidChangeTextEditorVisibleRanges: {},
@@ -34,6 +35,18 @@ module.exports = {
   TextEditorSelectionChangeEvent: {},
   TextEditorVisibleRangesChangeEvent: {},
   Terminal: {},
+  Range: class Range {
+    constructor(start, end) {
+      this.start = start;
+      this.end = end;
+    }
+  },
+  Position: class Position {
+    constructor(line, character) {
+      this.line = line;
+      this.character = character;
+    }
+  },
   Uri: {
     file: (k) => {
       return {

--- a/src/fuzzer/runners/AbstractHost.ts
+++ b/src/fuzzer/runners/AbstractHost.ts
@@ -1,5 +1,8 @@
 import * as ChildProcess from "node:child_process";
 
+/**
+ * Abstract representation of a host process
+ */
 export abstract class AbstractHost {
   protected readonly _proc;
   protected _isActive: boolean = false;
@@ -41,10 +44,15 @@ export abstract class AbstractHost {
     this._proc.once("close", this._onClose);
 
     this._isActive = true;
-  }
+  } // constructor
 
   protected abstract _spawn(): ChildProcess.ChildProcessWithoutNullStreams;
 
+  /**
+   * Sends a message to the host process.
+   *
+   * @param payload The message payload, either a string or a Buffer.
+   */
   public sendMessage(payload: string | Buffer): void {
     if (!this._isActive) {
       throw new Error("Internal error: Cannot write to an inactive host");
@@ -57,48 +65,86 @@ export abstract class AbstractHost {
 
     this._proc.stdin.write(lengthBuffer);
     this._proc.stdin.write(payloadBuffer);
-  }
+  } // fn: sendMessage
 
+  /**
+   * Gets the response from the host as a buffer.
+   *
+   * @param timeout The maximum time to wait for a response, in milliseconds.
+   * @returns A promise that resolves with the response buffer.
+   */
   public async getResponseBuffer(timeout: number = Infinity): Promise<Buffer> {
+    const MAX_HEARTBEATS = 60;
+    let heartbeats = 0;
+
     return new Promise<Buffer>((resolve, reject) => {
-      let timedOut = false;
-      const timer =
-        timeout > 0 && timeout !== Infinity
-          ? setTimeout(() => {
-              timedOut = true;
+      let isDone = false;
+      let timer: NodeJS.Timeout | undefined;
+
+      const resetTimer = () => {
+        if (timer) clearTimeout(timer);
+        if (timeout > 0 && timeout !== Infinity) {
+          timer = setTimeout(() => {
+            if (isDone) return;
+            isDone = true;
+            const exception = new Error(
+              `Host did not respond within ${timeout} ms timeout`
+            );
+            exception.name = PutTimeoutName;
+            reject(exception);
+            this.kill();
+          }, timeout);
+        }
+      };
+
+      const cleanup = () => {
+        isDone = true;
+        if (timer) clearTimeout(timer);
+      };
+
+      resetTimer();
+
+      const readNext = async (): Promise<void> => {
+        try {
+          const header = await this._readStdout(PayloadSizeBytes);
+          if (isDone) return;
+          const length = header.readUInt32BE(0);
+          const payload = await this._readStdout(length);
+          if (isDone) return;
+
+          if (this._isHeartbeatPayload(payload)) {
+            heartbeats++;
+            if (heartbeats > MAX_HEARTBEATS) {
+              cleanup();
               const exception = new Error(
-                `Host did not respond within ${timeout} ms timeout`
+                `Host exceeded maximum allowed startup heartbeats limit (${MAX_HEARTBEATS} heartbeats / 1 minute)`
               );
               exception.name = PutTimeoutName;
               reject(exception);
               this.kill();
-            }, timeout)
-          : undefined;
-
-      this._readStdout(PayloadSizeBytes).then(
-        (buffer) => {
-          if (timedOut) return;
-          const length = buffer.readUInt32BE(0);
-          this._readStdout(length).then(
-            (payload) => {
-              if (timedOut) return;
-              if (timer) clearTimeout(timer);
-              resolve(payload);
-            },
-            (reason) => {
-              if (timedOut) return;
-              if (timer) clearTimeout(timer);
-              reject(reason);
+              return;
             }
-          );
-        },
-        (reason) => {
-          if (timedOut) return;
-          if (timer) clearTimeout(timer);
-          reject(reason);
+            resetTimer();
+            readNext();
+            return;
+          }
+
+          cleanup();
+          resolve(payload);
+        } catch (reason) {
+          if (!isDone) {
+            cleanup();
+            reject(reason);
+          }
         }
-      );
+      };
+
+      readNext();
     });
+  } // fn: getResponseBuffer
+
+  protected _isHeartbeatPayload(buf: Buffer): boolean {
+    return !!buf && buf.includes("HEART");
   }
 
   public async getResponse(timeout: number = Infinity): Promise<string> {
@@ -132,6 +178,10 @@ export abstract class AbstractHost {
     this.kill();
   };
 
+  /**
+   * Kills the host process and cleans up resources. If the
+   * host has already exited, this is a no-op.
+   */
   public kill(): void {
     this._isActive = false;
 
@@ -148,7 +198,7 @@ export abstract class AbstractHost {
         this._onExitSent = true;
       }
     }
-  }
+  } // fn: kill
 
   /**
    * Reads bytes from the stdout buffer. If the bytes have not arrived yet,

--- a/src/fuzzer/runners/javascript/JavascriptRunner.ts
+++ b/src/fuzzer/runners/javascript/JavascriptRunner.ts
@@ -249,11 +249,17 @@ export class JavascriptRunner extends AbstractRunner {
     const args = [runnerHost, this._filename, this._jsFn];
     const host = new NodeHost(args, path.dirname(this._filename));
 
-    const okcodeBuf = await host.getResponseBuffer(10000);
+    const hostStartupTimeout = Config.get<number>(
+      "nanofuzz.fuzzer.hostStartupTimeout",
+      10000
+    );
+    const okcodeBuf = await host.getResponseBuffer(hostStartupTimeout);
     const okcode = deserialize(okcodeBuf);
     if (okcode === "READY") {
       this._host = host;
-      const initialCoverage = deserialize(await host.getResponseBuffer(10000));
+      const initialCoverage = deserialize(
+        await host.getResponseBuffer(hostStartupTimeout)
+      );
       if (isCoverageMapData(initialCoverage)) {
         this._coverageInfo = initialCoverage;
       }

--- a/src/fuzzer/runners/javascript/JavascriptRunnerHost.ts
+++ b/src/fuzzer/runners/javascript/JavascriptRunnerHost.ts
@@ -54,12 +54,17 @@ async function main() {
     return (...args: unknown[]) => fn(...args);
   };
 
-  if (initialFilename && initialFnName) {
-    try {
-      getTargetFunction(initialFilename, initialFnName);
-    } catch {
-      // Ignore if initial load fails; loop will handle per-request errors
+  startHeartbeat(1000);
+  try {
+    if (initialFilename && initialFnName) {
+      try {
+        getTargetFunction(initialFilename, initialFnName);
+      } catch {
+        // Ignore if initial load fails; loop will handle per-request errors
+      }
     }
+  } finally {
+    stopHeartbeat();
   }
 
   // Send READY message
@@ -217,6 +222,50 @@ function setup() {
   });
 } // fn: setup
 
+let heartbeatTimer: NodeJS.Timeout | undefined;
+let heartbeatCount = 0;
+const MAX_HEARTBEATS = 60;
+
+/**
+ * Start the heartbeat timer, sending heartbeat messages at the specified interval.
+ *
+ * @param intervalMs The interval in milliseconds between heartbeat messages.
+ */
+function startHeartbeat(intervalMs = 1000): void {
+  heartbeatCount = 0;
+  heartbeatTimer = setInterval(() => {
+    heartbeatCount++;
+    if (heartbeatCount > MAX_HEARTBEATS) {
+      stopHeartbeat();
+      return;
+    }
+    try {
+      sendMsg("HEART");
+    } catch {
+      stopHeartbeat();
+    }
+  }, intervalMs);
+  if (heartbeatTimer.unref) {
+    heartbeatTimer.unref();
+  }
+} // fn: startHeartbeat
+
+/**
+ * Stops the heartbeat timer, if it is running.
+ */
+function stopHeartbeat(): void {
+  if (heartbeatTimer) {
+    clearInterval(heartbeatTimer);
+    heartbeatTimer = undefined;
+  }
+} // fn: stopHeartbeat
+
+/**
+ * Wraps a function with a timeout.
+ *
+ * @param fnToCall The function to wrap.
+ * @returns A new function that accepts a timeout and the original function's arguments.
+ */
 function functionTimeout(
   fnToCall: (...args: unknown[]) => unknown
 ): (timeout: number | undefined, ...args: unknown[]) => unknown {
@@ -231,7 +280,7 @@ function functionTimeout(
     script.runInNewContext(context, timeout ? { timeout } : {});
     return context.returnValue;
   };
-}
+} // fn: functionTimeout
 
 /**
  * Transforms an argument based on the provided type hint.

--- a/src/fuzzer/runners/python/PythonRunner.ts
+++ b/src/fuzzer/runners/python/PythonRunner.ts
@@ -457,15 +457,20 @@ export class PythonRunner extends AbstractRunner {
       this._pythonEnv
     );
 
+    const hostStartupTimeout = Config.get<number>(
+      "nanofuzz.fuzzer.hostStartupTimeout",
+      10000
+    );
+
     // a longer timeout tolerance for the host to pre-warm the coverage
-    const okcode = await host.getResponse(10000);
+    const okcode = await host.getResponse(hostStartupTimeout);
     if (okcode === `"READY"`) {
       this._host = host;
 
       // Get the static coverage structure, which the host sends once. The
       // dynamic `lines`/`arcs` are filled in by each `run`.
       this._coverageInfo = JSON5.parse<FullCoverage>(
-        await host.getResponse(10000)
+        await host.getResponse(hostStartupTimeout)
       );
       return host;
     } else {

--- a/src/fuzzer/runners/python/PythonRunnerHost.py
+++ b/src/fuzzer/runners/python/PythonRunnerHost.py
@@ -91,6 +91,39 @@ type RunnerResult = Union[RunnerValueResult,
 pid = os.getpid()
 
 
+class HostHeartbeat:
+    """Sends periodic startup heartbeat messages to the parent process.
+    Capped at max_heartbeats (default 60 = 1 minute total allowance).
+    Runs as a daemon thread and stops when stop() is called.
+    """
+
+    def __init__(self, interval_sec: float = 1.0, max_heartbeats: int = 60):
+        self.interval = interval_sec
+        self.max_heartbeats = max_heartbeats
+        self.heartbeat_count = 0
+        self.stop_event = threading.Event()
+        self.thread = None
+
+    def start(self):
+        def _worker():
+            while not self.stop_event.wait(timeout=self.interval):
+                if self.heartbeat_count >= self.max_heartbeats:
+                    logging.debug(
+                        f"[{pid}] Max heartbeats ({self.max_heartbeats}) reached during startup")
+                    break
+                self.heartbeat_count += 1
+                try:
+                    send_msg("HEART")
+                except (BrokenPipeError, OSError):
+                    break
+
+        self.thread = threading.Thread(target=_worker, daemon=True)
+        self.thread.start()
+
+    def stop(self):
+        self.stop_event.set()
+
+
 class PutTimeoutException(Exception):
     """Raised in the main thread when a test execution times out."""
     pass
@@ -544,7 +577,8 @@ def run_put(input: RunnerInput, filename: str, fnname: str, fn: Any, cov: covera
             # and call the original underlying function
             if hasattr(fn, 'hypothesis') and hasattr(fn.hypothesis, 'inner_test'):
                 # Unwrap Hypothesis test function
-                value = call_with_timeout(fn.hypothesis.inner_test, args, timeout_ms)
+                value = call_with_timeout(
+                    fn.hypothesis.inner_test, args, timeout_ms)
             else:
                 # Not Hypothesis; call directly
                 value = call_with_timeout(fn, args, timeout_ms)
@@ -644,44 +678,51 @@ if __name__ == "__main__":
     # and `include` patterns must match it.
     filename = os.path.realpath(filename)
 
-    # One in-memory coverage instance for the whole run
-    cov = coverage.Coverage(
-        include=[os.path.join(os.path.dirname(filename), "**", "*.py")], branch=True, data_file=None)
+    # Start heartbeat thread during coverage initialization, module import, and static analysis
+    hb = HostHeartbeat(interval_sec=1.0, max_heartbeats=60)
+    hb.start()
 
-    # Try to load the function: either results in a RunnerErrorResult
-    # or a callable function
-    logging.debug(f"[{pid}] Loading function '{fnname}' in {filename}")
-    [loadError, fn] = loadPythonFn(filename, modulename, fnname)
-    if (loadError is not None):
-        logging.debug(f"[{pid}]  - Unable to load")
-    else:
-        logging.debug(f"[{pid}]  - Loaded function")
+    try:
+        # One in-memory coverage instance for the whole run
+        cov = coverage.Coverage(
+            include=[os.path.join(os.path.dirname(filename), "**", "*.py")], branch=True, data_file=None)
 
-    # Static analysis of the program: the executable lines, functions, and
-    # branches of every file it is made of.
-    coverageInfo = {file: static_coverage(cov, file)
-                    for file in program_files(filename)}
-    logging.debug(
-        f"[{pid}] Analyzed {len(coverageInfo)} file(s) of the program under test")
+        # Try to load the function: either results in a RunnerErrorResult
+        # or a callable function
+        logging.debug(f"[{pid}] Loading function '{fnname}' in {filename}")
+        [loadError, fn] = loadPythonFn(filename, modulename, fnname)
+        if (loadError is not None):
+            logging.debug(f"[{pid}]  - Unable to load")
+        else:
+            logging.debug(f"[{pid}]  - Loaded function")
 
-    # Change cwd from the extension to that of the Python script
-    os.chdir(os.path.dirname(filename))
+        # Static analysis of the program: the executable lines, functions, and
+        # branches of every file it is made of.
+        coverageInfo = {file: static_coverage(cov, file)
+                        for file in program_files(filename)}
+        logging.debug(
+            f"[{pid}] Analyzed {len(coverageInfo)} file(s) of the program under test")
 
-    # Pre-warm the coverage machinery. The first `cov.start()` installs the
-    # tracer, which costs far more than a steady-state call and can push the
-    # first test over `fnTimeout` on its own -- and because a timeout kills
-    # the host, the respawned host pays it again, cascading into a run where
-    # every test times out.
-    #
-    # This must happen *before* the handshake below, so the cost is charged to
-    # the caller's startup budget (seconds) rather than its per-test budget
-    # (~100ms). Nothing runs between start and stop, so no coverage is
-    # recorded, and the final erase leaves the data empty for the first test.
-    cov.get_data().erase()
-    cov.start()
-    cov.stop()
-    cov.get_data().erase()
-    logging.debug(f"[{pid}] Pre-warmed coverage tracer")
+        # Change cwd from the extension to that of the Python script
+        os.chdir(os.path.dirname(filename))
+
+        # Pre-warm the coverage machinery. The first `cov.start()` installs the
+        # tracer, which costs far more than a steady-state call and can push the
+        # first test over `fnTimeout` on its own -- and because a timeout kills
+        # the host, the respawned host pays it again, cascading into a run where
+        # every test times out.
+        #
+        # This must happen *before* the handshake below, so the cost is charged to
+        # the caller's startup budget (seconds) rather than its per-test budget
+        # (~100ms). Nothing runs between start and stop, so no coverage is
+        # recorded, and the final erase leaves the data empty for the first test.
+        cov.get_data().erase()
+        cov.start()
+        cov.stop()
+        cov.get_data().erase()
+        logging.debug(f"[{pid}] Pre-warmed coverage tracer")
+    finally:
+        hb.stop()
 
     # Ready for inputs
     send_msg("READY")

--- a/src/ui/CommandLine.ts
+++ b/src/ui/CommandLine.ts
@@ -74,6 +74,12 @@ Commander.program
     parseIntArgGeZero,
     200
   )
+  .option(
+    `--host-startup-timeout <integer>`,
+    `Maximum time in ms allowed for test runner host startup`,
+    parseIntArgGeOne,
+    10000
+  )
   .option(`--seed <string>`, `Seed for pseudo-random number generator`, "")
 
   // ------------------------------- Transformers ------------------------------ //
@@ -239,6 +245,11 @@ const updateFn = (payload: FuzzBusyStatusMessage) => {
 for (const key in options) {
   const value = options[key];
   switch (key) {
+    // infrastructure options
+    case "hostStartupTimeout":
+      Config.override("nanofuzz.fuzzer.hostStartupTimeout", value);
+      break;
+
     // ai config options
     case "modelProvider":
       Config.override("nanofuzz.ai.provider", value);

--- a/src/ui/CoverageHeatmap.test.ts
+++ b/src/ui/CoverageHeatmap.test.ts
@@ -1,0 +1,279 @@
+import { createInstrumenter } from "istanbul-lib-instrument";
+import { createFileCoverage, FileCoverageData } from "istanbul-lib-coverage";
+import * as vscode from "vscode";
+import { _calculateDecorationRanges } from "./CoverageHeatmap";
+
+declare global {
+  var __coverage__: Record<string, FileCoverageData> | undefined;
+}
+
+function createDocMock(lines: string[]): vscode.TextDocument {
+  const lineAtFunc = (
+    lineOrPosition: number | vscode.Position
+  ): vscode.TextLine => {
+    const line =
+      typeof lineOrPosition === "number" ? lineOrPosition : lineOrPosition.line;
+    const text = lines[line] ?? "";
+    const range = new vscode.Range(
+      new vscode.Position(line, 0),
+      new vscode.Position(line, text.length)
+    );
+    const nonWs = text.search(/\S/);
+    return {
+      lineNumber: line,
+      text,
+      range,
+      rangeIncludingLineBreak: range,
+      firstNonWhitespaceCharacterIndex: nonWs >= 0 ? nonWs : text.length,
+      isEmptyOrWhitespace: text.trim().length === 0,
+    };
+  };
+
+  return {
+    uri: vscode.Uri.file("/test.ts"),
+    fileName: "/test.ts",
+    isUntitled: false,
+    languageId: "typescript",
+    encoding: "utf8",
+    version: 1,
+    isDirty: false,
+    isClosed: false,
+    save: () => Promise.resolve(true),
+    eol: vscode.EndOfLine ? vscode.EndOfLine.LF : 1,
+    lineCount: lines.length,
+    lineAt: lineAtFunc,
+    offsetAt: (_position: vscode.Position) => 0,
+    positionAt: (_offset: number) => new vscode.Position(0, 0),
+    getText: (_range?: vscode.Range) => lines.join("\n"),
+    getWordRangeAtPosition: (_position: vscode.Position, _regex?: RegExp) =>
+      undefined,
+    validateRange: (range: vscode.Range) => range,
+    validatePosition: (position: vscode.Position) => position,
+  };
+}
+
+describe("CoverageHeatmap decoration ranges", () => {
+  it("Line 3: const b = 2 inside while(false) should have 0 hits", () => {
+    const data: FileCoverageData = {
+      path: "/test.ts",
+      statementMap: {
+        "0": { start: { line: 1, column: 2 }, end: { line: 1, column: 13 } },
+        "1": { start: { line: 1, column: 15 }, end: { line: 1, column: 41 } },
+        "2": { start: { line: 1, column: 39 }, end: { line: 1, column: 40 } },
+      },
+      fnMap: {},
+      branchMap: {},
+      s: {
+        "0": 1,
+        "1": 1,
+        "2": 0,
+      },
+      f: {},
+      b: {},
+    };
+
+    const fileMap = createFileCoverage(data);
+    const docMock = createDocMock([
+      "  const a = 1; while(false) {const b = 2};",
+    ]);
+
+    const ranges = _calculateDecorationRanges(fileMap, docMock);
+
+    expect(ranges[0].length).toBe(1);
+    expect(ranges[0][0].start.character).toBe(29);
+    expect(ranges[0][0].end.character).toBe(40);
+  });
+
+  it("Line 6: optionB in multi-line object literal should be covered", () => {
+    const data: FileCoverageData = {
+      path: "/test.ts",
+      statementMap: {
+        "0": { start: { line: 1, column: 17 }, end: { line: 4, column: 4 } },
+        "1": { start: { line: 2, column: 32 }, end: { line: 2, column: 35 } },
+      },
+      fnMap: {},
+      branchMap: {},
+      s: {
+        "0": 1,
+        "1": 3,
+      },
+      f: {},
+      b: {},
+    };
+
+    const fileMap = createFileCoverage(data);
+    const docMock = createDocMock([
+      "  const config = {",
+      "    optionA: [1,2,3].map((x) => x*2),",
+      "    optionB: 2,",
+      "  };",
+    ]);
+
+    const ranges = _calculateDecorationRanges(fileMap, docMock);
+
+    const coversLine3 = ranges.some(
+      (bucket, level) =>
+        level > 0 && bucket.some((r) => r.start.line <= 2 && r.end.line >= 2)
+    );
+    expect(coversLine3).toBe(true);
+  });
+
+  it("Line 12: const b=g inside single-line while(true)", () => {
+    const data: FileCoverageData = {
+      path: "/test.ts",
+      statementMap: {
+        "0": { start: { line: 1, column: 12 }, end: { line: 1, column: 13 } },
+        "1": { start: { line: 1, column: 15 }, end: { line: 1, column: 39 } },
+        "2": { start: { line: 1, column: 36 }, end: { line: 1, column: 37 } },
+        "3": { start: { line: 1, column: 49 }, end: { line: 1, column: 50 } },
+      },
+      fnMap: {},
+      branchMap: {},
+      s: {
+        "0": 1,
+        "1": 1,
+        "2": 1000,
+        "3": 1,
+      },
+      f: {},
+      b: {},
+    };
+
+    const fileMap = createFileCoverage(data);
+    const docMock = createDocMock([
+      "  const g = 2; while(true) {const b=g;}; const v=g;",
+    ]);
+
+    const ranges = _calculateDecorationRanges(fileMap, docMock);
+
+    expect(ranges[20].length).toBe(1);
+    expect(ranges[20][0].start.character).toBe(28);
+    expect(ranges[20][0].end.character).toBe(38);
+  });
+
+  it("Real istanbul instrumentation for optionA map x*2", () => {
+    const code = [
+      "const config = {",
+      "  optionA: [1,2,3,4,5,6,7,8,9,10].map((x) => x*2),",
+      "};",
+    ].join("\n");
+
+    const inst = createInstrumenter({ compact: false });
+    const instrumented = inst.instrumentSync(code, "/realtest.js");
+
+    globalThis.__coverage__ = {};
+    eval(instrumented);
+
+    const covData = globalThis.__coverage__["/realtest.js"];
+    expect(covData).toBeDefined();
+
+    const cov = createFileCoverage(covData);
+    const docMock = createDocMock(code.split("\n"));
+
+    const ranges = _calculateDecorationRanges(cov, docMock);
+
+    const level20 = ranges[20];
+    const callbackRange = level20.find(
+      (r) => r.start.line === 1 && r.start.character === 45
+    );
+    expect(callbackRange).toBeDefined();
+    expect(callbackRange?.end.character).toBe(48); // Ends right after x*2, not extending into closing parenthesis ')'
+
+    const coversArrowHeader = level20.some(
+      (r) => r.start.line === 1 && r.start.character === 38
+    );
+    expect(coversArrowHeader).toBe(true);
+
+    const coversOuterLine = ranges.some(
+      (bucket, level) =>
+        level > 0 &&
+        level < 20 &&
+        bucket.some((r) => r.start.line === 0 && r.start.character === 0)
+    );
+    expect(coversOuterLine).toBe(true);
+  });
+
+  it("Winsorized square-root scaling handles extreme outlier infinite loop hit counts", () => {
+    const data: FileCoverageData = {
+      path: "/test.ts",
+      statementMap: {
+        "0": { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
+        "1": { start: { line: 2, column: 0 }, end: { line: 2, column: 10 } },
+        "2": { start: { line: 3, column: 0 }, end: { line: 3, column: 10 } },
+        "3": { start: { line: 4, column: 0 }, end: { line: 4, column: 10 } },
+        "4": { start: { line: 5, column: 0 }, end: { line: 5, column: 10 } },
+      },
+      fnMap: {},
+      branchMap: {},
+      s: {
+        "0": 10,
+        "1": 10,
+        "2": 100,
+        "3": 1000,
+        "4": 1000000,
+      },
+      f: {},
+      b: {},
+    };
+
+    const fileMap = createFileCoverage(data);
+    const docMock = createDocMock([
+      "line1;",
+      "line2;",
+      "line3;",
+      "line4;",
+      "line5;",
+    ]);
+
+    const ranges = _calculateDecorationRanges(fileMap, docMock);
+
+    const level7HasStmt2 = ranges[7].some((r) => r.start.line === 2);
+    expect(level7HasStmt2).toBe(true);
+
+    const level20HasStmt3 = ranges[20].some((r) => r.start.line === 3);
+    const level20HasStmt4 = ranges[20].some((r) => r.start.line === 4);
+    expect(level20HasStmt3).toBe(true);
+    expect(level20HasStmt4).toBe(true);
+  });
+
+  it("Line 12 with comment: const g = 2; /*while(true) {const b=g;}*/; const v=w;", () => {
+    const data: FileCoverageData = {
+      path: "/test.ts",
+      statementMap: {
+        "0": { start: { line: 1, column: 2 }, end: { line: 1, column: 13 } },
+        "1": { start: { line: 1, column: 49 }, end: { line: 1, column: 60 } },
+      },
+      fnMap: {},
+      branchMap: {},
+      s: {
+        "0": 1,
+        "1": 1,
+      },
+      f: {},
+      b: {},
+    };
+
+    const fileMap = createFileCoverage(data);
+    const docMock = createDocMock([
+      "  const g = 2; /*while(true) {const b=g;}*/; const v=w;",
+    ]);
+
+    const ranges = _calculateDecorationRanges(fileMap, docMock);
+
+    let commentCovered = false;
+    ranges.forEach((bucket) => {
+      bucket.forEach((r) => {
+        if (r.start.character < 41 && r.end.character > 15) {
+          commentCovered = true;
+        }
+      });
+    });
+    expect(commentCovered).toBe(false);
+
+    // Verify statement 1 (const v=w;) expanded leftward to 'const' (column 45) across the comment gap
+    const coversConstV = ranges.some((bucket) =>
+      bucket.some((r) => r.start.line === 0 && r.start.character === 45)
+    );
+    expect(coversConstV).toBe(true);
+  });
+});

--- a/src/ui/CoverageHeatmap.ts
+++ b/src/ui/CoverageHeatmap.ts
@@ -53,7 +53,7 @@ export function applyCoverageHeatmapToEditor(
     editor.document.fileName in rangeCache &&
     rangeCache[editor.document.fileName].fileMap === fileMap
       ? rangeCache[editor.document.fileName].ranges // cached ranges
-      : _calculateDecorationRanges(fileMap); // create new
+      : _calculateDecorationRanges(fileMap, editor.document); // create new
 
   // Apply the editor decorations to the hit elements
   // Note: skip coloring elements with no hits (i===0))
@@ -72,9 +72,13 @@ export function applyCoverageHeatmapToEditor(
  * Creates a set of bucketed ranges for the given file coverage map.
  *
  * @param `fileMap` file coverage map
+ * @param `doc` optional vscode text document for statement start column alignment
  * @returns `vscode.Range`s bucketed according to hit count
  */
-function _calculateDecorationRanges(fileMap: FileCoverage): vscode.Range[][] {
+function _calculateDecorationRanges(
+  fileMap: FileCoverage,
+  doc?: vscode.TextDocument
+): vscode.Range[][] {
   // We use a text span tree to represent the coverage map hierarchically,
   // which we may then flatten into a set of non-overlapping text editor
   // decorations where the hit count of child (e.g., leaf) nodes have
@@ -106,14 +110,14 @@ function _calculateDecorationRanges(fileMap: FileCoverage): vscode.Range[][] {
   // Function coverage
   for (const f of Object.keys(fileMap.f)) {
     const element = fileMap.fnMap[f]; // hit element
-    if (!element?.decl?.start || !element?.loc?.end) continue;
+    if (!element?.decl?.start || !element?.decl?.end) continue;
     spans.insert(
       {
         begin: {
           line: element.decl.start.line - 1,
           col: element.decl.start.column,
         },
-        end: { line: element.loc.end.line - 1, col: element.loc.end.column },
+        end: { line: element.decl.end.line - 1, col: element.decl.end.column },
       },
       fileMap.f[f]
     );
@@ -150,19 +154,98 @@ function _calculateDecorationRanges(fileMap: FileCoverage): vscode.Range[][] {
   }
 
   // Statement coverage
-  for (const s of Object.keys(fileMap.s)) {
+  const statementKeys = Object.keys(fileMap.s);
+  for (const s of statementKeys) {
     const element = fileMap.statementMap[s]; // hit element
     if (!element?.start || !element?.end) continue;
-    spans.insert(
-      {
-        begin: {
-          line: element.start.line - 1,
-          col: element.start.column,
-        },
-        end: { line: element.end.line - 1, col: element.end.column },
-      },
-      fileMap.s[s]
-    );
+
+    const begin = {
+      line: element.start.line - 1,
+      col: element.start.column,
+    };
+    let end = {
+      line: element.end.line - 1,
+      col: element.end.column,
+    };
+
+    // If source map points to an inner expression/rvalue on the line
+    // (e.g. initializers for const/let/var), expand begin.col leftwards
+    // to the start of the statement (line's first non-whitespace character)
+    if (doc && begin.line >= 0 && begin.line < doc.lineCount) {
+      const lineText = doc.lineAt(begin.line).text;
+      const firstNonWsCol = lineText.search(/\S/);
+      if (firstNonWsCol >= 0 && firstNonWsCol < begin.col) {
+        let minAllowedCol = firstNonWsCol;
+        for (const otherKey of statementKeys) {
+          if (otherKey === s) continue;
+          const other = fileMap.statementMap[otherKey];
+          if (
+            other?.end &&
+            other.end.line === element.start.line &&
+            other.end.column <= element.start.column
+          ) {
+            if (other.end.column > minAllowedCol) {
+              minAllowedCol = other.end.column;
+            }
+          }
+        }
+        if (minAllowedCol < begin.col) {
+          begin.col = minAllowedCol;
+        }
+      }
+
+      // If single-line statement ends near a trailing semicolon on lineText, include the semicolon
+      if (
+        begin.line === end.line &&
+        end.col < lineText.length &&
+        lineText[end.col] === ";"
+      ) {
+        end.col++;
+      }
+    }
+
+    // If this statement contains child statements, trim its end to the header line(s) before its earliest child
+    // so container headers (e.g. while/if/for/try) are highlighted without bleeding into children's line indentation
+    let earliestChildStart: { line: number; column: number } | undefined;
+    for (const childKey of statementKeys) {
+      if (childKey === s) continue;
+      const child = fileMap.statementMap[childKey];
+      if (!child?.start || !child?.end) continue;
+
+      if (
+        (child.start.line > element.start.line ||
+          (child.start.line === element.start.line &&
+            child.start.column > element.start.column)) &&
+        (child.end.line < element.end.line ||
+          (child.end.line === element.end.line &&
+            child.end.column <= element.end.column))
+      ) {
+        if (
+          !earliestChildStart ||
+          child.start.line < earliestChildStart.line ||
+          (child.start.line === earliestChildStart.line &&
+            child.start.column < earliestChildStart.column)
+        ) {
+          earliestChildStart = child.start;
+        }
+      }
+    }
+
+    if (earliestChildStart) {
+      if (earliestChildStart.line === element.start.line) {
+        end = {
+          line: earliestChildStart.line - 1,
+          col: earliestChildStart.column,
+        };
+      } else {
+        end = {
+          line: earliestChildStart.line - 2,
+          col: Number.MAX_SAFE_INTEGER,
+        };
+      }
+    }
+
+    spans.insert({ begin, end }, fileMap.s[s]);
   }
 
   // Flatten the spans & assign each to a decoration bucket

--- a/src/ui/CoverageHeatmap.ts
+++ b/src/ui/CoverageHeatmap.ts
@@ -75,7 +75,7 @@ export function applyCoverageHeatmapToEditor(
  * @param `doc` optional vscode text document for statement start column alignment
  * @returns `vscode.Range`s bucketed according to hit count
  */
-function _calculateDecorationRanges(
+export function _calculateDecorationRanges(
   fileMap: FileCoverage,
   doc?: vscode.TextDocument
 ): vscode.Range[][] {
@@ -88,21 +88,51 @@ function _calculateDecorationRanges(
   // of the (possibly numerous) hits of their containing `if` statement.
   const spans = new TextSpans<number>();
 
-  // Determine the maximum number of hits so that we appropriately
-  // assign hit counts to buckets.
-  const maxHits = Math.max(
-    0,
+  // Collect all non-zero hit counts to compute the Winsorized maximum
+  // threshold (95th percentile). Winsorization caps extreme hit count
+  // outliers (e.g., from infinite loop timeouts or tight loops) so that
+  // normal code statements executed 10x vs 100x retain distinct
+  // appropriate visual contrast.
+  const allHitCounts: number[] = [
     ...Object.values(fileMap.s),
-    ...Object.values(fileMap.b).map((b) =>
-      Math.max(0, ...b.filter((e) => !Number.isNaN(e)))
+    ...Object.values(fileMap.b).flatMap((b) =>
+      b.filter((e) => !Number.isNaN(e))
     ),
-    ...Object.values(fileMap.f)
-  );
+    ...Object.values(fileMap.f),
+  ]
+    .filter((h) => Number.isFinite(h) && h > 0)
+    .sort((a, b) => a - b);
 
-  // Helper function to assign a hit count to a decoration bucket
+  const maxHits =
+    allHitCounts.length > 0 ? allHitCounts[allHitCounts.length - 1] : 0;
+
+  // Winsorized maximum (95th percentile threshold). Hit counts above this cap
+  // are clamped to effectiveMaxHits so outlier loops do not compress the scale.
+  let effectiveMaxHits = maxHits;
+  if (allHitCounts.length >= 5) {
+    const p95Idx = Math.floor((allHitCounts.length - 1) * 0.95);
+    effectiveMaxHits = Math.max(1, allHitCounts[p95Idx]);
+  }
+
+  // Helper function to assign a hit count to a decoration bucket using
+  // Square-Root Scaling with Winsorization:
+  //
+  // 1. Winsorization (95th percentile capping): Clamps extreme outlier hit
+  //    counts, such as 1,000,000 iterations in an infinite loop timeout,
+  //    to effectiveMaxHits so they do not overwhelm the heat contrast for
+  //    other hits in the heatmap.
+  // 2. Square-root scaling (sqrt(hits) / sqrt(max)): Provides "better"
+  //    perceptual contrast for execution frequencies (e.g., 1x vs 10x vs
+  //    100x) without the severe compression of logarithmic scaling or the
+  //    distortion that can result from linear scaling.
   function _gradientLevelForRatio(hits: number): number {
-    const ratio = hits / maxHits;
-    if (hits === 0 || !Number.isFinite(ratio) || ratio <= 0) return 0;
+    if (hits === 0 || !Number.isFinite(hits) || hits <= 0) return 0;
+    if (effectiveMaxHits <= 1) return GRANULARITY;
+
+    const clampedHits = Math.min(hits, effectiveMaxHits);
+    const ratio = Math.sqrt(clampedHits) / Math.sqrt(effectiveMaxHits);
+
+    if (ratio <= 0) return 1;
     if (ratio >= 1) return GRANULARITY;
     return Math.max(1, Math.min(GRANULARITY, Math.ceil(ratio * GRANULARITY)));
   } // fn: _gradientLevelForRatio
@@ -111,13 +141,39 @@ function _calculateDecorationRanges(
   for (const f of Object.keys(fileMap.f)) {
     const element = fileMap.fnMap[f]; // hit element
     if (!element?.decl?.start || !element?.decl?.end) continue;
+
+    const startCol = element.decl.start.column;
+    let endCol = element.decl.end.column;
+    const startLine = element.decl.start.line - 1;
+
+    // If doc is available, expand arrow function declaration headers
+    // (e.g. `(x) => ` or `x => `) so the parameter header is covered
+    // as a complete unit instead of leaving isolated single-char
+    // `(` highlights.
+    if (doc && startLine >= 0 && startLine < doc.lineCount) {
+      const lineText = doc.lineAt(startLine).text;
+      const arrowIdx = lineText.indexOf("=>", startCol);
+      if (arrowIdx >= startCol) {
+        let afterArrow = arrowIdx + 2;
+        while (
+          afterArrow < lineText.length &&
+          /\s/.test(lineText[afterArrow])
+        ) {
+          afterArrow++;
+        }
+        if (afterArrow > endCol) {
+          endCol = afterArrow;
+        }
+      }
+    }
+
     spans.insert(
       {
         begin: {
-          line: element.decl.start.line - 1,
-          col: element.decl.start.column,
+          line: startLine,
+          col: startCol,
         },
-        end: { line: element.decl.end.line - 1, col: element.decl.end.column },
+        end: { line: element.decl.end.line - 1, col: endCol },
       },
       fileMap.f[f]
     );
@@ -133,14 +189,35 @@ function _calculateDecorationRanges(
     // See https://github.com/istanbuljs/istanbuljs/issues/130
     // Workaround here: ignore if branches.
     if (element.type !== "if") {
-      for (const i in hits) {
+      for (let i = 0; i < hits.length; i++) {
         const loc = element.locations[i];
         if (!loc?.start || !loc?.end) continue;
+
+        let startCol = loc.start.column;
+        const startLine = loc.start.line - 1;
+
+        // For conditional expressions (ternary `? :`), expand branch arm
+        // start leftward if preceded by `: ` or `? ` on the same line so
+        // the operator syntax is grouped with its arm
+        if (
+          element.type === "cond-expr" &&
+          doc &&
+          startLine >= 0 &&
+          startLine < doc.lineCount
+        ) {
+          const lineText = doc.lineAt(startLine).text;
+          const prefix = lineText.substring(0, startCol);
+          const operatorMatch = prefix.match(/([?:])\s*$/);
+          if (operatorMatch && operatorMatch.index !== undefined) {
+            startCol = operatorMatch.index;
+          }
+        }
+
         spans.insert(
           {
             begin: {
-              line: loc.start.line - 1,
-              col: loc.start.column,
+              line: startLine,
+              col: startCol,
             },
             end: {
               line: loc.end.line - 1,
@@ -155,32 +232,36 @@ function _calculateDecorationRanges(
 
   // Statement coverage
   const statementKeys = Object.keys(fileMap.s);
+
+  // First pass: compute expanded begin position for each statement.
+  // If source map points to an inner expression/rvalue on the line
+  // (e.g. initializers for const/let/var), expand begin.col leftwards
+  // to the start of the statement (line's first non-whitespace character).
+  const expandedBegins: Record<string, { line: number; col: number }> = {};
   for (const s of statementKeys) {
-    const element = fileMap.statementMap[s]; // hit element
+    const element = fileMap.statementMap[s];
     if (!element?.start || !element?.end) continue;
 
     const begin = {
       line: element.start.line - 1,
       col: element.start.column,
     };
-    let end = {
-      line: element.end.line - 1,
-      col: element.end.column,
-    };
 
-    // If source map points to an inner expression/rvalue on the line
-    // (e.g. initializers for const/let/var), expand begin.col leftwards
-    // to the start of the statement (line's first non-whitespace character)
     if (doc && begin.line >= 0 && begin.line < doc.lineCount) {
       const lineText = doc.lineAt(begin.line).text;
       const firstNonWsCol = lineText.search(/\S/);
       if (firstNonWsCol >= 0 && firstNonWsCol < begin.col) {
         let minAllowedCol = firstNonWsCol;
+        let isInsideOtherStmt = false;
+
         for (const otherKey of statementKeys) {
           if (otherKey === s) continue;
           const other = fileMap.statementMap[otherKey];
+          if (!other?.start || !other?.end) continue;
+
+          // If another statement on the same line ends before s, do not
+          // expand past its end
           if (
-            other?.end &&
             other.end.line === element.start.line &&
             other.end.column <= element.start.column
           ) {
@@ -188,60 +269,194 @@ function _calculateDecorationRanges(
               minAllowedCol = other.end.column;
             }
           }
+
+          // If another statement contains s (whether on the same line or
+          // starting on an earlier line)
+          if (
+            (other.start.line < element.start.line ||
+              (other.start.line === element.start.line &&
+                other.start.column <= element.start.column)) &&
+            (other.end.line > element.end.line ||
+              (other.end.line === element.end.line &&
+                other.end.column >= element.end.column))
+          ) {
+            isInsideOtherStmt = true;
+            const startColInLine =
+              other.start.line === element.start.line
+                ? other.start.column
+                : firstNonWsCol;
+            if (startColInLine > minAllowedCol) {
+              minAllowedCol = startColInLine;
+            }
+          }
         }
-        if (minAllowedCol < begin.col) {
-          begin.col = minAllowedCol;
+
+        // Search for declaration/return keyword in lineText starting
+        // between minAllowedCol and begin.col
+        const linePrefix = lineText.substring(
+          minAllowedCol,
+          element.end.column
+        );
+        const kwMatches = [
+          ...linePrefix.matchAll(
+            /\b(const|let|var|return|throw|await|yield|def|val)\b/g
+          ),
+        ].filter((m) => minAllowedCol + (m.index ?? 0) <= begin.col);
+
+        if (kwMatches.length > 0) {
+          const lastKw = kwMatches[kwMatches.length - 1];
+          const kwCol = minAllowedCol + (lastKw.index ?? 0);
+          const kwPrefix = lineText.substring(kwCol, begin.col);
+          if (!/[/*#;]/.test(kwPrefix)) {
+            begin.col = kwCol;
+          }
+        } else if (!isInsideOtherStmt) {
+          // If no keyword and not inside a container statement, expand
+          // to first non-whitespace character after the last comment
+          // delimiter or semicolon
+          const lastSepMatch = linePrefix.match(/.*[/*#;]/);
+          const safeStart = lastSepMatch ? lastSepMatch[0].length : 0;
+          const cleanSuffix = linePrefix.substring(safeStart);
+          const nonWsRel = cleanSuffix.search(/\S/);
+          if (nonWsRel >= 0) {
+            begin.col = minAllowedCol + safeStart + nonWsRel;
+          }
         }
       }
+    }
+    expandedBegins[s] = begin;
+  }
 
-      // If single-line statement ends near a trailing semicolon on lineText, include the semicolon
-      if (
-        begin.line === end.line &&
-        end.col < lineText.length &&
-        lineText[end.col] === ";"
-      ) {
-        end.col++;
+  // Second pass: insert statement ranges
+  for (const s of statementKeys) {
+    const element = fileMap.statementMap[s]; // hit element
+    if (!element?.start || !element?.end || !expandedBegins[s]) continue;
+
+    const begin = expandedBegins[s];
+    let end = {
+      line: element.end.line - 1,
+      col: element.end.column,
+    };
+
+    if (doc && begin.line >= 0 && begin.line < doc.lineCount) {
+      const lineText = doc.lineAt(begin.line).text;
+      // If single-line statement ends near a trailing semicolon on lineText, include trailing semicolon
+      if (begin.line === end.line) {
+        while (end.col < lineText.length && lineText[end.col] === ";") {
+          end.col++;
+        }
       }
     }
 
-    // If this statement contains child statements, trim its end to the header line(s) before its earliest child
-    // so container headers (e.g. while/if/for/try) are highlighted without bleeding into children's line indentation
-    let earliestChildStart: { line: number; column: number } | undefined;
-    for (const childKey of statementKeys) {
-      if (childKey === s) continue;
-      const child = fileMap.statementMap[childKey];
-      if (!child?.start || !child?.end) continue;
-
+    // Check if s is a block container statement (e.g. while, if, for,
+    // try, switch, do)
+    let isBlockContainer = false;
+    if (doc && begin.line >= 0 && begin.line < doc.lineCount) {
+      const lineText = doc.lineAt(begin.line).text;
+      const stmtStartText = lineText.substring(begin.col);
       if (
-        (child.start.line > element.start.line ||
-          (child.start.line === element.start.line &&
-            child.start.column > element.start.column)) &&
-        (child.end.line < element.end.line ||
-          (child.end.line === element.end.line &&
-            child.end.column <= element.end.column))
+        /^\s*\b(while|if|for|try|switch|do)\b/.test(stmtStartText) ||
+        /\b(while|if|for|try|switch|do)\s*\(/.test(stmtStartText)
       ) {
+        isBlockContainer = true;
+      }
+    }
+
+    // Only trim container statement headers if s is a block container
+    if (isBlockContainer) {
+      let earliestChildStart: { line: number; column: number } | undefined;
+      for (const childKey of statementKeys) {
+        if (childKey === s) continue;
+        const child = fileMap.statementMap[childKey];
+        const childBegin = expandedBegins[childKey];
+        if (!child?.start || !child?.end || !childBegin) continue;
+
         if (
-          !earliestChildStart ||
-          child.start.line < earliestChildStart.line ||
-          (child.start.line === earliestChildStart.line &&
-            child.start.column < earliestChildStart.column)
+          (childBegin.line > element.start.line ||
+            (childBegin.line === element.start.line &&
+              childBegin.col > begin.col)) &&
+          (child.end.line < element.end.line ||
+            (child.end.line === element.end.line &&
+              child.end.column <= element.end.column))
         ) {
-          earliestChildStart = child.start;
+          if (
+            !earliestChildStart ||
+            childBegin.line < earliestChildStart.line ||
+            (childBegin.line === earliestChildStart.line &&
+              childBegin.col < earliestChildStart.column)
+          ) {
+            earliestChildStart = {
+              line: childBegin.line + 1,
+              column: childBegin.col,
+            };
+          }
         }
       }
-    }
 
-    if (earliestChildStart) {
-      if (earliestChildStart.line === element.start.line) {
-        end = {
-          line: earliestChildStart.line - 1,
-          col: earliestChildStart.column,
-        };
-      } else {
-        end = {
-          line: earliestChildStart.line - 2,
-          col: Number.MAX_SAFE_INTEGER,
-        };
+      if (earliestChildStart) {
+        if (earliestChildStart.line === element.start.line) {
+          end = {
+            line: earliestChildStart.line - 1,
+            col: earliestChildStart.column,
+          };
+        } else {
+          // Multi-line container statement: trim end to the end of the
+          // container header line
+          end = {
+            line: element.start.line - 1,
+            col:
+              doc &&
+              element.start.line - 1 >= 0 &&
+              element.start.line - 1 < doc.lineCount
+                ? doc.lineAt(element.start.line - 1).text.length
+                : Number.MAX_SAFE_INTEGER,
+          };
+        }
+
+        // Insert a dedicated span for the container's closing brace '}' at
+        // element.end ONLY if a '}' is present
+        const closingLine = element.end.line - 1;
+        const closingCol = element.end.column;
+        if (
+          doc &&
+          closingLine >= 0 &&
+          closingLine < doc.lineCount &&
+          closingCol > 0
+        ) {
+          const closingLineText = doc.lineAt(closingLine).text;
+          let braceStartCol = -1;
+          let braceEndCol = closingCol;
+
+          if (
+            closingCol <= closingLineText.length &&
+            closingLineText[closingCol - 1] === "}"
+          ) {
+            braceStartCol = closingCol - 1;
+            if (
+              braceEndCol < closingLineText.length &&
+              closingLineText[braceEndCol] === ";"
+            ) {
+              braceEndCol++;
+            }
+          } else if (
+            closingCol <= closingLineText.length &&
+            closingLineText[closingCol - 1] === ";" &&
+            closingCol >= 2 &&
+            closingLineText[closingCol - 2] === "}"
+          ) {
+            braceStartCol = closingCol - 2;
+          }
+
+          if (braceStartCol >= 0) {
+            spans.insert(
+              {
+                begin: { line: closingLine, col: braceStartCol },
+                end: { line: closingLine, col: braceEndCol },
+              },
+              fileMap.s[s]
+            );
+          }
+        }
       }
     }
 


### PR DESCRIPTION
Apparently if we run a ton of docker images all starting NaNofuzz with runners that instrument tons of python code at the same time, they don't start super fast. This PR implements a heartbeat mechanism during runner startups so we can tell the difference between a dead runner and a busy one so we can wait longer when it's just busy.