### PR TITLE
feat: cig fastpath for rnd=1

### DIFF
--- a/package.json
+++ b/package.json
@@ -304,23 +304,25 @@
             "description": "Composite generator lookback window size for history"
           },
           "nanofuzz.generators.compositeChunkSize": {
-            "title": "Re-evaluate the composite generator's subgens after _chunkSize inputs generated",
+            "title": "Re-evaluate which input generator to use after every `chunkSize` inputs generated",
             "type": "integer",
             "default": 20,
             "minimum": 1,
-            "description": "Re-evaluate the composite generator's subgens after _chunkSize inputs generated"
+            "description": "Re-evaluate which input generator to use after every `chunkSize` inputs generated"
           },
           "nanofuzz.generators.compositeExplorationChance": {
             "title": "Composite generator additional chance of subgen exploration",
             "type": "number",
             "default": 0.1,
             "minimum": 0,
+            "maximum": 1,
             "description": "Composite generator additional chance of subgen exploration"
           },
           "nanofuzz.generators.leaderboardMinScore": {
             "title": "Leaderboard initial minimum score",
             "type": "number",
             "default": 0.9999,
+            "minimum": 0,
             "description": "Leaderboard initial minimum score"
           },
           "nanofuzz.generators.leaderboardInitialFocus": {

--- a/src/fuzzer/generators/CompositeInputGenerator.test.ts
+++ b/src/fuzzer/generators/CompositeInputGenerator.test.ts
@@ -361,7 +361,7 @@ describe("src/fuzzer/generators/CompositeInputGenerator:", () => {
     }
   });
 
-  it("fastpath when compositeExplorationChance >= 1.0 and toggling between runs", async () => {
+  it("rnd-only fastpath: compositeExplorationChance >= 1.0 and toggling between runs", async () => {
     const program = ProgramFactory.fromSource(
       () => `export function dummyFn(x: number) {}`,
       "typescript"

--- a/src/fuzzer/generators/CompositeInputGenerator.test.ts
+++ b/src/fuzzer/generators/CompositeInputGenerator.test.ts
@@ -360,4 +360,71 @@ describe("src/fuzzer/generators/CompositeInputGenerator:", () => {
       Config.override("nanofuzz.generators.compositeTrackCheckpoints", false);
     }
   });
+
+  it("fastpath when compositeExplorationChance >= 1.0 and toggling between runs", async () => {
+    const program = ProgramFactory.fromSource(
+      () => `export function dummyFn(x: number) {}`,
+      "typescript"
+    );
+    const fnDef = program.functionsExported["dummyFn"];
+
+    const genStats: FuzzTestStats["generators"] = {
+      RandomInputGenerator: {
+        counters: { inputsGenerated: 0, dupesGenerated: 0 },
+        timers: { run: 0, val: 0, gen: 0, measure: 0, transform: 0 },
+      },
+      MutationInputGenerator: {
+        counters: { inputsGenerated: 0, dupesGenerated: 0 },
+        timers: { run: 0, val: 0, gen: 0, measure: 0, transform: 0 },
+      },
+      AiInputGenerator: {
+        counters: { inputsGenerated: 0, dupesGenerated: 0 },
+        timers: { run: 0, val: 0, gen: 0, measure: 0, transform: 0 },
+      },
+    };
+
+    const options = {
+      RandomInputGenerator: { enabled: true },
+      MutationInputGenerator: { enabled: true },
+      AiInputGenerator: { enabled: false },
+    };
+
+    const leaderboard = new Leaderboard<InputAndSource>();
+    const allInputs = new Map<string, unknown>();
+
+    const cig = new CompositeInputGenerator(
+      options,
+      fnDef,
+      "test-seed",
+      [],
+      leaderboard,
+      genStats,
+      allInputs
+    );
+
+    try {
+      // Run 1: compositeExplorationChance = 1.0 (fastpath active)
+      Config.override("nanofuzz.generators.compositeExplorationChance", 1.0);
+      cig.onRunStart(true);
+      expect(cig.nextable()).toBeTrue();
+      const inputRun1 = cig.next();
+      expect(inputRun1).toBeDefined();
+
+      // Run 2: compositeExplorationChance = 0.1 (productivity calculation active)
+      Config.override("nanofuzz.generators.compositeExplorationChance", 0.1);
+      cig.onRunStart(true);
+      expect(cig.nextable()).toBeTrue();
+      const inputRun2 = cig.next();
+      expect(inputRun2).toBeDefined();
+
+      // Run 3: compositeExplorationChance = 1.0 again (fastpath active again)
+      Config.override("nanofuzz.generators.compositeExplorationChance", 1.0);
+      cig.onRunStart(true);
+      expect(cig.nextable()).toBeTrue();
+      const inputRun3 = cig.next();
+      expect(inputRun3).toBeDefined();
+    } finally {
+      Config.override("nanofuzz.generators.compositeExplorationChance", 0.1);
+    }
+  });
 });

--- a/src/fuzzer/generators/CompositeInputGenerator.ts
+++ b/src/fuzzer/generators/CompositeInputGenerator.ts
@@ -327,6 +327,24 @@ export class CompositeInputGenerator extends AbstractInputGenerator {
       );
     }
 
+    // Fastpath: if compositeExplorationChance >= 1.0, randomly select from nextable subgens
+    // and skip calculations of cost, progress, and productivity.
+    if (this._P >= 1.0) {
+      const activeSubgenIndices = this._subgens
+        .map((_g, i) => i)
+        .filter((i) => this._activeSubgens[i] && this._subgens[i].nextable());
+      const candidateIndices =
+        activeSubgenIndices.length > 0
+          ? activeSubgenIndices
+          : this._subgens
+              .map((_g, i) => i)
+              .filter((i) => this._subgens[i].nextable());
+
+      return candidateIndices[
+        Math.floor(this._prng() * candidateIndices.length)
+      ];
+    }
+
     // Calculate cost and progress for each subgen's prior L generations
     const cost: number[] = []; // cost of subgen for L generations
     const progress: number[] = []; // progress of subgen for L generations


### PR DESCRIPTION
Implements a fastpath in `CompositeInputGenerator` to skip the algorithmic accounting when `--cig-randomness` is 1.