### PR TITLE
fix: cli test perf

### DIFF
--- a/src/fuzzer/runners/AbstractHost.ts
+++ b/src/fuzzer/runners/AbstractHost.ts
@@ -74,7 +74,6 @@ export abstract class AbstractHost {
    * @returns A promise that resolves with the response buffer.
    */
   public async getResponseBuffer(timeout: number = Infinity): Promise<Buffer> {
-    const MAX_HEARTBEATS = 240;
     let heartbeats = 0;
 
     return new Promise<Buffer>((resolve, reject) => {
@@ -269,6 +268,7 @@ export abstract class AbstractHost {
 } // class: AbstractHost
 
 export const PutTimeoutName = "PutTimeout";
+export const MAX_HEARTBEATS = 1000;
 
 export type HostMessageHandler = (payload: string) => void;
 

--- a/src/fuzzer/runners/javascript/JavascriptRunnerHost.ts
+++ b/src/fuzzer/runners/javascript/JavascriptRunnerHost.ts
@@ -5,6 +5,7 @@ import vm from "node:vm";
 import { Worker } from "node:worker_threads";
 import { serialize, deserialize } from "node:v8";
 import { RunnerInput, TypeHint } from "../AbstractRunner";
+import { MAX_HEARTBEATS } from "../AbstractHost";
 import { isError } from "../../Util";
 
 const realStdoutWrite = process.stdout.write.bind(process.stdout);
@@ -224,7 +225,6 @@ function setup() {
 } // fn: setup
 
 let heartbeatWorker: Worker | undefined;
-const MAX_HEARTBEATS = 240;
 
 /**
  * Start the heartbeat worker thread, sending heartbeat messages at the specified interval.

--- a/src/fuzzer/runners/python/PythonRunnerHost.py
+++ b/src/fuzzer/runners/python/PythonRunnerHost.py
@@ -7,10 +7,10 @@ import struct
 import logging
 import tempfile
 import traceback
-import re
 import uuid
 import ctypes
 import threading
+import sysconfig
 from contextlib import redirect_stdout
 from typing import Any, Literal, List, Tuple, Union, TypedDict, NotRequired
 
@@ -96,13 +96,16 @@ real_stdout = (
 )
 
 
+MAX_HEARTBEATS = 1000
+
+
 class HostHeartbeat:
     """Sends periodic startup heartbeat messages to the parent process.
-    Capped at max_heartbeats (default 240 = 1 minute total allowance).
+    Capped at max_heartbeats (default MAX_HEARTBEATS).
     Runs as a daemon thread and stops when stop() is called.
     """
 
-    def __init__(self, interval_sec: float = 0.25, max_heartbeats: int = 240):
+    def __init__(self, interval_sec: float = 0.25, max_heartbeats: int = MAX_HEARTBEATS):
         self.interval = interval_sec
         self.max_heartbeats = max_heartbeats
         self.heartbeat_count = 0
@@ -403,20 +406,31 @@ def is_under(root: str, path: str) -> bool:
 
 def program_files(filename: str) -> List[str]:
     """
-    Returns the files the program under test is made of: `filename`, plus every
-    module imported from `filename`'s own directory tree.
+    Returns the files the program under test is made of:
+    - `filename`, plus every local module imported from `filename`'s directory tree.
+    - 3rd-party packages imported by `filename`.
+    Excludes Python standard library (`stdlib`) modules.
 
     Must be called after the PUT is loaded, so that its imports have run.
     """
     root = os.path.dirname(filename)
+    stdlib_path = os.path.realpath(sysconfig.get_path("stdlib"))
+
     files = {filename}
     for module in list(sys.modules.values()):
         modfile = getattr(module, "__file__", None)
         if not modfile or os.path.splitext(modfile)[1] != ".py":
             continue
         modfile = os.path.realpath(modfile)
-        if is_under(root, modfile):
-            files.add(modfile)
+        parts = modfile.split(os.sep)
+
+        # Exclude Python Standard Library and virtualenv internals
+        if any(p in (".venv", "venv", "env", "__pycache__") for p in parts) or modfile.startswith(stdlib_path):
+            continue
+
+        # Include user project third-party packages
+        files.add(modfile)
+
     return sorted(files)
 
 
@@ -684,14 +698,10 @@ if __name__ == "__main__":
     filename = os.path.realpath(filename)
 
     # Start heartbeat thread during coverage initialization, module import, and static analysis
-    hb = HostHeartbeat(interval_sec=0.25, max_heartbeats=240)
+    hb = HostHeartbeat(interval_sec=0.25, max_heartbeats=MAX_HEARTBEATS)
     hb.start()
 
     try:
-        # One in-memory coverage instance for the whole run
-        cov = coverage.Coverage(
-            include=[os.path.join(os.path.dirname(filename), "**", "*.py")], branch=True, data_file=None)
-
         # Try to load the function: either results in a RunnerErrorResult
         # or a callable function
         logging.debug(f"[{pid}] Loading function '{fnname}' in {filename}")
@@ -701,10 +711,15 @@ if __name__ == "__main__":
         else:
             logging.debug(f"[{pid}]  - Loaded function")
 
+        pgm_files = program_files(filename)
+
+        # One in-memory coverage instance for the whole run
+        cov = coverage.Coverage(include=pgm_files, branch=True, data_file=None)
+
         # Static analysis of the program: the executable lines, functions, and
         # branches of every file it is made of.
         coverageInfo = {file: static_coverage(cov, file)
-                        for file in program_files(filename)}
+                        for file in pgm_files}
         logging.debug(
             f"[{pid}] Analyzed {len(coverageInfo)} file(s) of the program under test")
 

--- a/src/fuzzer/runners/python/PythonRunnerHost.py
+++ b/src/fuzzer/runners/python/PythonRunnerHost.py
@@ -428,8 +428,9 @@ def program_files(filename: str) -> List[str]:
         if any(p in (".venv", "venv", "env", "__pycache__") for p in parts) or modfile.startswith(stdlib_path):
             continue
 
-        # Include user project third-party packages
-        files.add(modfile)
+        # Include user project and third party packages
+        if is_under(root, modfile) or "site-packages" in parts or "dist-packages" in parts:
+            files.add(modfile)
 
     return sorted(files)
 


### PR DESCRIPTION
The CommandLine tests were inefficient and became the longest-running test. This PR fixes that by allowing the CommandLine to be called as a normal function to avoid expensive node startups and tear downs.